### PR TITLE
Flag attribute syntax for lit-extended ("?" after attribute name).

### DIFF
--- a/src/lib/lit-extended.ts
+++ b/src/lib/lit-extended.ts
@@ -61,6 +61,11 @@ export const extendedPartCallback =
               return new AttributePart(
                   instance, node as Element, name, templatePart.strings!);
             }
+            if (templatePart.name!.endsWith('?')) {
+              const name = templatePart.name!.slice(0, -1);
+              return new FlagAttributePart(
+                  instance, node as Element, name, templatePart.strings!);
+            }
             return new PropertyPart(
                 instance,
                 node as Element,
@@ -112,5 +117,24 @@ export class EventPart implements Part {
     if (listener != null) {
       this.element.addEventListener(this.eventName, listener);
     }
+  }
+}
+
+export class FlagAttributePart extends AttributePart {
+  setValue(values: any[], startIndex: number): void {
+    const s = this.strings;
+    if (s.length !== 2 || s[0] !== '' || s[1] !== '') {
+      // Has to be single expression
+      throw new Error('Flag attributes may only contain a single expression.');
+    }
+
+    const value = values[startIndex];
+    if (typeof value !== 'boolean')
+      throw new Error('Value has to be boolean.');
+
+    if (value)
+      this.element.setAttribute(this.name, '');
+    else
+      this.element.removeAttribute(this.name);
   }
 }

--- a/src/test/lib/lit-extended_test.ts
+++ b/src/test/lib/lit-extended_test.ts
@@ -51,6 +51,15 @@ suite('lit-extended', () => {
       assert.equal(container.innerHTML, '<div foo="1bar2baz3"></div>');
     });
 
+    test('renders flag attribute', () => {
+      render(html`<div foo?="${true}"></div>`, container);
+      assert.equal(container.innerHTML, '<div foo=""></div>');
+    });
+    test('does not render flag attribute', () => {
+      render(html`<div foo?="${false}"></div>`, container);
+      assert.equal(container.innerHTML, '<div></div>');
+    });
+
     test('reuses an existing ExtendedTemplateInstance when available', () => {
       const t = (content: any) => html`<div>${content}</div>`;
 


### PR DESCRIPTION
I thought that this might be a nice syntax for the extended usage, though the use cases for when setting a content attribute is desired over just using a DOM property are probably limited.

```html
<input readonly?="${true}"/>  => <input readonly=""/>
<input readonly?="${false}"/> => <input />
```

Well, just a suggestion more than anything else.