### PR TITLE
feat: SpreadPart for multiple attributes/properties

### DIFF
--- a/src/lib/lit-extended.ts
+++ b/src/lib/lit-extended.ts
@@ -42,6 +42,23 @@ export {html} from '../lit-html.js';
  *
  *     html`<button on-click=${(e)=> this.onClickHandler(e)}>Buy Now</button>`
  *
+ * To set multiple values you can use the spread attribute with `...=${options}`:
+ *   Note: provided spread data will overwrite currently set values
+ *
+ * Example:
+ *
+ *     const options = {
+ *       'id$': 'buy',
+ *       'data-action': 'add-to-cart',
+ *       'active': true
+ *     };
+ *     html`<button class="fanzy" id="my-button" ...=${options}>Buy Now</button>`
+ *
+ * Result:
+ *
+ *     <button class="fanzy" id="buy" data-action="add-to-cart">Buy Now</button>
+ *     document.querySelector('button').active; // true
+ *
  */
 export function render(
     result: TemplateResult, container: Element|DocumentFragment) {

--- a/src/lib/lit-extended.ts
+++ b/src/lib/lit-extended.ts
@@ -61,6 +61,10 @@ export const extendedPartCallback =
               return new AttributePart(
                   instance, node as Element, name, templatePart.strings!);
             }
+            if (templatePart.name!.endsWith('...')) {
+              return new SpreadPart(
+                  instance, node as Element, templatePart.rawName as string, templatePart.strings!);
+            }
             return new PropertyPart(
                 instance,
                 node as Element,
@@ -69,6 +73,21 @@ export const extendedPartCallback =
           }
           return defaultPartCallback(instance, templatePart, node);
         };
+
+export class SpreadPart extends AttributePart {
+  setValue(values: any[], startIndex: number): void {
+    const properties = values[startIndex];
+    Object.keys(properties).forEach((property) => {
+      const value = properties[property];
+      if (property.endsWith('$')) {
+        const attribute = property!.slice(0, -1);
+        this.element.setAttribute(attribute, value);
+      } else {
+        (this.element as any)[property] = value;
+      }
+    });
+  }
+}
 
 export class PropertyPart extends AttributePart {
   setValue(values: any[], startIndex: number): void {

--- a/src/test/lib/lit-extended_test.ts
+++ b/src/test/lib/lit-extended_test.ts
@@ -191,6 +191,21 @@ suite('lit-extended', () => {
       assert.equal(target, undefined);
     });
 
+    test('spread part sets properties and attributes', () => {
+      const options = { foo: '123', 'bar$': '456' };
+      render(html`<div ...=${options}></div>`, container);
+      const div = container.firstChild!;
+      assert.equal((div as any).foo, 123);
+      assert.equal((div as any).getAttribute('bar'), 456);
+    });
+
+    test('spread part overrides current values', () => {
+      const options = { foo: '123', 'bar$': '456' };
+      render(html`<div foo="100" bar$="200" ...=${options}></div>`, container);
+      const div = container.firstChild!;
+      assert.equal((div as any).foo, 123);
+      assert.equal((div as any).getAttribute('bar'), 456);
+    });
 
   });
 });


### PR DESCRIPTION
Allows for the following syntax:

```js
let options = {
  'id$': 'my-id',
  'active': true
};

render(html`<my-element my-option="some" ...=${options}></my-element>`, target);
```

Result:
```html
<my-element my-option="some" id="my-id"></my-element>
```
```js
document.querySelector('my-element').active; // true
```

If there is an interest for it I can provide tests, demos and docu.