### PR TITLE
Keep fragment in the template's document during clone

### DIFF
--- a/src/lit-html.ts
+++ b/src/lit-html.ts
@@ -629,7 +629,7 @@ export class TemplateInstance {
     // Clone the node, rather than importing it, to keep the fragment in the
     // template's document. This leaves the fragment inert so custom elements
     // won't upgrade until after the main document adopts the node.
-    const fragment = this.template.element.content.cloneNode(true);
+    const fragment = this.template.element.content.cloneNode(true) as DocumentFragment;
     const parts = this.template.parts;
 
     if (parts.length > 0) {

--- a/src/lit-html.ts
+++ b/src/lit-html.ts
@@ -626,7 +626,10 @@ export class TemplateInstance {
   }
 
   _clone(): DocumentFragment {
-    const fragment = document.importNode(this.template.element.content, true);
+    // Clone the node, rather than importing it, to keep the fragment in the
+    // template's document. This leaves the fragment inert so custom elements
+    // won't upgrade until after the main document adopts the node.
+    const fragment = this.template.element.content.cloneNode(true);
     const parts = this.template.parts;
 
     if (parts.length > 0) {


### PR DESCRIPTION
The template's document doesn't have a browsing context, so custom elements aren't upgraded. This change defers upgrading any custom elements inside the template until after the treewalker that links the Parts to the DOM.
This is important because custom elements can modify their DOM at upgrade time (e.g. when using ShadyDOM).

Fixes #231 