### PR TITLE
handle boolean attributes

### DIFF
--- a/src/lit-html.ts
+++ b/src/lit-html.ts
@@ -417,7 +417,20 @@ export class AttributePart implements MultiPart {
     return text + strings[l];
   }
 
+  protected _setBooleanValue(value: boolean) {
+    if (value) {
+      this.element.setAttribute(this.name, this.name);
+    } else {
+      this.element.removeAttribute(this.name);
+    }
+  }
+
   setValue(values: any[], startIndex: number): void {
+    if (this.strings.length === 2 && typeof values[startIndex] === 'boolean') {
+      this._setBooleanValue(values[startIndex]);
+      return;
+    }
+
     const text = this._interpolate(values, startIndex);
     this.element.setAttribute(this.name, text);
   }

--- a/src/test/lit-html_test.ts
+++ b/src/test/lit-html_test.ts
@@ -343,6 +343,13 @@ suite('lit-html', () => {
         assert.equal(container.innerHTML, '<div foo="bar"></div>');
       });
 
+      test('renders boolean attributes', () => {
+        render(html`<div foo=${true}></div>`, container);
+        assert.equal(container.innerHTML, '<div foo="foo"></div>');
+        render(html`<div foo=${false}></div>`, container);
+        assert.equal(container.innerHTML, '<div></div>');
+      });
+
       test('renders to multiple attribute expressions', () => {
         render(
             html`<div foo="${'Foo'}" bar="${'Bar'}" baz=${'Baz'}></div>`,


### PR DESCRIPTION
Fixes #236 

---

Does this seem like a stable enough fix @justinfagnani?

Basically we're checking if the remaining values is of length `1` and that the value is a bool. Then toggling the attribute instead of setting it etc.

Is it ok to rely on that length check? or is there a better way?