### PR TITLE
Run travis tests with headless chrome

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ cache:
 before_script:
 - npm run build
 script:
-- xvfb-run wct --npm
+- xvfb-run wct --npm --configFile wct-travis.conf.json
 - if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then wct -s 'windows 10/microsoftedge@15' -s 'macos 10.12/safari@10' --npm; fi
 env:
   global:

--- a/wct-travis.conf.json
+++ b/wct-travis.conf.json
@@ -1,0 +1,14 @@
+{
+  "plugins": {
+    "local": {
+      "browserOptions": {
+        "chrome": [
+          "start-maximized",
+          "headless",
+          "disable-gpu",
+          "no-sandbox"
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
Chromedriver has issues with Travis when running a non-headless chrome, so run headless chrome instead.

This is probably a temporary workaround, but it _should_ get the build green again.