### PR TITLE
Update the repository location in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.8.0",
   "description": "HTML template literals in JavaScript",
   "license": "BSD-3-Clause",
-  "repository": "PolymerLabs/lit-html",
+  "repository": "Polymer/lit-html",
   "main": "lit-html.js",
   "module": "lit-html.js",
   "directories": {


### PR DESCRIPTION
The repository URL in https://www.npmjs.com/package/lit-html looks wrong.
This PR updates `package.json` to fix the URL.