### PR TITLE
IE11 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_script:
 - npm run build
 script:
 - xvfb-run wct --npm
-- if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then wct -s 'windows 10/microsoftedge@15' -s 'macos 10.12/safari@10' --npm; fi
+- if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then wct -s 'windows 10/microsoftedge@15' -s 'macos 10.12/safari@10' -s 'windows 8.1/internet explorer@11' --npm; fi
 env:
   global:
   - secure: mNT4DpaOzcY+Z8JmXhVdbYBRt1gJG7kVMfe0Kd3HSRwQwAltW1JWhnRWQgW526xi/EFuYkIy1Ec4Hhc0pZ+t+ngXrHgtVPV6te7nQzBhBUNFZv72nDagk8YxQBTcSHMEVRa7c4NXlCW66hM0WWDVy7PACs7NuGj25qegFUulbjNEmYfwF8VMsfyB8/X6NJff8ZQTWEACwODJIBY2l0ogxI2jbUjTnrVNvtjd4IV1gnmi2AvY0RwRs/grigP4oMPcD/5tleUBjlojqq3U/DjMCoaoCge7fPnRZ2O1GHVHPOlAlFWa6DGvsXBiPNqlzchAQtkCKCnNJ1xM8UNlR0EYQCWBSsXO+wmAFoB1UexumHObsaCzLTL2yYXByCzKVNlGkCMppZUp+b+T3Vu039TEF1dCXf4XpQOouNb9pdlR0tkWUOF08hENzeAkHBFO1nw3kt+smm/b/6QXHe0H+X2GN3uKRX/TMYYgR3cckD4cQ9DeaXlJ/6tJtoVkOyNLL1LOHVtS7MTL2oUBJnj29cjOaUoCg/aVEt+g7brysj8Eb7itZctc/GwL/cWqIIKCuUUAuRJYgrBx3AQH9GjMtNAsrMtoVEmcOIK1lBLLmeduZXDogTevTMbGtyToATAQbLX/a2TxUBM5AZLE/dMiUnmZMVEMZ4anp2VhrmzflrbRcBI=

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 sudo: required
 dist: trusty
-node_js: stable
+node_js: '9'
 addons:
   firefox: latest
   chrome: stable

--- a/src/lib/lit-extended.ts
+++ b/src/lib/lit-extended.ts
@@ -57,17 +57,17 @@ export const extendedPartCallback =
     (instance: TemplateInstance, templatePart: TemplatePart, node: Node):
         Part => {
           if (templatePart.type === 'attribute') {
-            if (templatePart.rawName!.substr(0, 3) == 'on-') {
+            if (templatePart.rawName!.substr(0, 3) === 'on-') {
               const eventName = templatePart.rawName!.slice(3);
               return new EventPart(instance, node as Element, eventName);
             }
-            const lastChar = templatePart.name!.substr(templatePart.name!.length-1);
-            if (lastChar == '$') {
+            const lastChar = templatePart.name!.substr(templatePart.name!.length - 1);
+            if (lastChar === '$') {
               const name = templatePart.name!.slice(0, -1);
               return new AttributePart(
                   instance, node as Element, name, templatePart.strings!);
             }
-            if (lastChar == '?') {
+            if (lastChar === '?') {
               const name = templatePart.name!.slice(0, -1);
               return new BooleanAttributePart(
                   instance, node as Element, name, templatePart.strings!);

--- a/src/lib/lit-extended.ts
+++ b/src/lib/lit-extended.ts
@@ -57,16 +57,17 @@ export const extendedPartCallback =
     (instance: TemplateInstance, templatePart: TemplatePart, node: Node):
         Part => {
           if (templatePart.type === 'attribute') {
-            if (templatePart.rawName!.startsWith('on-')) {
+            if (templatePart.rawName!.substr(0, 3) == 'on-') {
               const eventName = templatePart.rawName!.slice(3);
               return new EventPart(instance, node as Element, eventName);
             }
-            if (templatePart.name!.endsWith('$')) {
+            const lastChar = templatePart.name!.substr(templatePart.name!.length-1);
+            if (lastChar == '$') {
               const name = templatePart.name!.slice(0, -1);
               return new AttributePart(
                   instance, node as Element, name, templatePart.strings!);
             }
-            if (templatePart.name!.endsWith('?')) {
+            if (lastChar == '?') {
               const name = templatePart.name!.slice(0, -1);
               return new BooleanAttributePart(
                   instance, node as Element, name, templatePart.strings!);

--- a/src/lit-html.ts
+++ b/src/lit-html.ts
@@ -744,17 +744,6 @@ export class TemplateInstance {
           walker.nextNode();
         }
         let node = walker.currentNode;
-        // Swap the comment placeholders for empty text nodes
-        // The nextSibling of the part placeholder is the part endNode
-        if (node.nextSibling !== null && node.nextSibling!.nodeType === 8) {
-          node.parentNode!.replaceChild(document.createTextNode(''), node.nextSibling!);
-        }
-        // The part placeholder is the part startNode
-        if (node.nodeType === 8) {
-          node = document.createTextNode('');
-          walker.currentNode.parentNode!.replaceChild(node, walker.currentNode);
-          walker.currentNode = node;
-        }
         this._parts.push(this._partCallback(this, part, node));
       }
     }

--- a/src/lit-html.ts
+++ b/src/lit-html.ts
@@ -743,8 +743,7 @@ export class TemplateInstance {
           index++;
           walker.nextNode();
         }
-        let node = walker.currentNode;
-        this._parts.push(this._partCallback(this, part, node));
+        this._parts.push(this._partCallback(this, part, walker.currentNode));
       }
     }
     return fragment;

--- a/src/lit-html.ts
+++ b/src/lit-html.ts
@@ -340,7 +340,6 @@ export class Template {
         // Generate a new text node for each literal section
         // These nodes are also used as the markers for node parts
         for (let i = 0; i < lastIndex; i++) {
-          console.log(parent.nodeName);
           parent.insertBefore(
               (strings[i] === '')
                   ? document.createComment('')

--- a/src/test/lib/async-append_test.ts
+++ b/src/test/lib/async-append_test.ts
@@ -20,6 +20,8 @@ import {html, render} from '../../lit-html.js';
 
 import {TestAsyncIterable} from './test-async-iterable.js';
 
+import {stripExpressionDelimeters} from '../test-helpers.js';
+
 const assert = chai.assert;
 
 // Set Symbol.asyncIterator on browsers without it
@@ -39,59 +41,59 @@ suite('asyncAppend', () => {
 
   test('appends content as the async iterable yields new values', async () => {
     render(html`<div>${asyncAppend(iterable)}</div>`, container);
-    assert.equal(container.innerHTML, '<div></div>');
+    assert.equal(stripExpressionDelimeters(container.innerHTML), '<div></div>');
 
     await iterable.push('foo');
-    assert.equal(container.innerHTML, '<div>foo</div>');
+    assert.equal(stripExpressionDelimeters(container.innerHTML), '<div>foo</div>');
 
     await iterable.push('bar');
-    assert.equal(container.innerHTML, '<div>foobar</div>');
+    assert.equal(stripExpressionDelimeters(container.innerHTML), '<div>foobar</div>');
   });
 
   test('appends nothing with a value is undefined', async () => {
     render(html`<div>${asyncAppend(iterable)}</div>`, container);
-    assert.equal(container.innerHTML, '<div></div>');
+    assert.equal(stripExpressionDelimeters(container.innerHTML), '<div></div>');
 
     await iterable.push('foo');
-    assert.equal(container.innerHTML, '<div>foo</div>');
+    assert.equal(stripExpressionDelimeters(container.innerHTML), '<div>foo</div>');
 
     await iterable.push(undefined);
-    assert.equal(container.innerHTML, '<div>foo</div>');
+    assert.equal(stripExpressionDelimeters(container.innerHTML), '<div>foo</div>');
   });
 
   test('uses a mapper function', async () => {
     render(
         html`<div>${asyncAppend(iterable, (v, i) => html`${i}: ${v} `)}</div>`,
         container);
-    assert.equal(container.innerHTML, '<div></div>');
+    assert.equal(stripExpressionDelimeters(container.innerHTML), '<div></div>');
 
     await iterable.push('foo');
-    assert.equal(container.innerHTML, '<div>0: foo </div>');
+    assert.equal(stripExpressionDelimeters(container.innerHTML), '<div>0: foo </div>');
 
     await iterable.push('bar');
-    assert.equal(container.innerHTML, '<div>0: foo 1: bar </div>');
+    assert.equal(stripExpressionDelimeters(container.innerHTML), '<div>0: foo 1: bar </div>');
   });
 
   test('renders new iterable over a pending iterable', async () => {
     const t = (iterable: any) => html`<div>${asyncAppend(iterable)}</div>`;
     render(t(iterable), container);
-    assert.equal(container.innerHTML, '<div></div>');
+    assert.equal(stripExpressionDelimeters(container.innerHTML), '<div></div>');
 
     await iterable.push('foo');
-    assert.equal(container.innerHTML, '<div>foo</div>');
+    assert.equal(stripExpressionDelimeters(container.innerHTML), '<div>foo</div>');
 
     const iterable2 = new TestAsyncIterable<string>();
     render(t(iterable2), container);
 
     // The last value is preserved until we receive the first
     // value from the new iterable
-    assert.equal(container.innerHTML, '<div>foo</div>');
+    assert.equal(stripExpressionDelimeters(container.innerHTML), '<div>foo</div>');
 
     await iterable2.push('hello');
-    assert.equal(container.innerHTML, '<div>hello</div>');
+    assert.equal(stripExpressionDelimeters(container.innerHTML), '<div>hello</div>');
 
     await iterable.push('bar');
-    assert.equal(container.innerHTML, '<div>hello</div>');
+    assert.equal(stripExpressionDelimeters(container.innerHTML), '<div>hello</div>');
   });
 
   test('renders new value over a pending iterable', async () => {
@@ -99,16 +101,16 @@ suite('asyncAppend', () => {
     // This is a little bit of an odd usage of directives as values, but it
     // is possible, and we check here that asyncAppend plays nice in this case
     render(t(asyncAppend(iterable)), container);
-    assert.equal(container.innerHTML, '<div></div>');
+    assert.equal(stripExpressionDelimeters(container.innerHTML), '<div></div>');
 
     await iterable.push('foo');
-    assert.equal(container.innerHTML, '<div>foo</div>');
+    assert.equal(stripExpressionDelimeters(container.innerHTML), '<div>foo</div>');
 
     render(t('hello'), container);
-    assert.equal(container.innerHTML, '<div>hello</div>');
+    assert.equal(stripExpressionDelimeters(container.innerHTML), '<div>hello</div>');
 
     await iterable.push('bar');
-    assert.equal(container.innerHTML, '<div>hello</div>');
+    assert.equal(stripExpressionDelimeters(container.innerHTML), '<div>hello</div>');
   });
 
 });

--- a/src/test/lib/async-replace_test.ts
+++ b/src/test/lib/async-replace_test.ts
@@ -20,6 +20,8 @@ import {html, render} from '../../lit-html.js';
 
 import {TestAsyncIterable} from './test-async-iterable.js';
 
+import {stripExpressionDelimeters} from '../test-helpers.js';
+
 const assert = chai.assert;
 
 // Set Symbol.asyncIterator on browsers without it
@@ -39,59 +41,59 @@ suite('asyncReplace', () => {
 
   test('replaces content as the async iterable yields new values', async () => {
     render(html`<div>${asyncReplace(iterable)}</div>`, container);
-    assert.equal(container.innerHTML, '<div></div>');
+    assert.equal(stripExpressionDelimeters(container.innerHTML), '<div></div>');
 
     await iterable.push('foo');
-    assert.equal(container.innerHTML, '<div>foo</div>');
+    assert.equal(stripExpressionDelimeters(container.innerHTML), '<div>foo</div>');
 
     await iterable.push('bar');
-    assert.equal(container.innerHTML, '<div>bar</div>');
+    assert.equal(stripExpressionDelimeters(container.innerHTML), '<div>bar</div>');
   });
 
   test('clears the Part when a value is undefined', async () => {
     render(html`<div>${asyncReplace(iterable)}</div>`, container);
-    assert.equal(container.innerHTML, '<div></div>');
+    assert.equal(stripExpressionDelimeters(container.innerHTML), '<div></div>');
 
     await iterable.push('foo');
-    assert.equal(container.innerHTML, '<div>foo</div>');
+    assert.equal(stripExpressionDelimeters(container.innerHTML), '<div>foo</div>');
 
     await iterable.push(undefined);
-    assert.equal(container.innerHTML, '<div></div>');
+    assert.equal(stripExpressionDelimeters(container.innerHTML), '<div></div>');
   });
 
   test('uses the mapper function', async () => {
     render(
         html`<div>${asyncReplace(iterable, (v, i) => html`${i}: ${v} `)}</div>`,
         container);
-    assert.equal(container.innerHTML, '<div></div>');
+    assert.equal(stripExpressionDelimeters(container.innerHTML), '<div></div>');
 
     await iterable.push('foo');
-    assert.equal(container.innerHTML, '<div>0: foo </div>');
+    assert.equal(stripExpressionDelimeters(container.innerHTML), '<div>0: foo </div>');
 
     await iterable.push('bar');
-    assert.equal(container.innerHTML, '<div>1: bar </div>');
+    assert.equal(stripExpressionDelimeters(container.innerHTML), '<div>1: bar </div>');
   });
 
   test('renders new iterable over a pending iterable', async () => {
     const t = (iterable: any) => html`<div>${asyncReplace(iterable)}</div>`;
     render(t(iterable), container);
-    assert.equal(container.innerHTML, '<div></div>');
+    assert.equal(stripExpressionDelimeters(container.innerHTML), '<div></div>');
 
     await iterable.push('foo');
-    assert.equal(container.innerHTML, '<div>foo</div>');
+    assert.equal(stripExpressionDelimeters(container.innerHTML), '<div>foo</div>');
 
     const iterable2 = new TestAsyncIterable<string>();
     render(t(iterable2), container);
 
     // The last value is preserved until we receive the first
     // value from the new iterable
-    assert.equal(container.innerHTML, '<div>foo</div>');
+    assert.equal(stripExpressionDelimeters(container.innerHTML), '<div>foo</div>');
 
     await iterable2.push('hello');
-    assert.equal(container.innerHTML, '<div>hello</div>');
+    assert.equal(stripExpressionDelimeters(container.innerHTML), '<div>hello</div>');
 
     await iterable.push('bar');
-    assert.equal(container.innerHTML, '<div>hello</div>');
+    assert.equal(stripExpressionDelimeters(container.innerHTML), '<div>hello</div>');
   });
 
   test('renders new value over a pending iterable', async () => {
@@ -99,16 +101,16 @@ suite('asyncReplace', () => {
     // This is a little bit of an odd usage of directives as values, but it
     // is possible, and we check here that asyncReplace plays nice in this case
     render(t(asyncReplace(iterable)), container);
-    assert.equal(container.innerHTML, '<div></div>');
+    assert.equal(stripExpressionDelimeters(container.innerHTML), '<div></div>');
 
     await iterable.push('foo');
-    assert.equal(container.innerHTML, '<div>foo</div>');
+    assert.equal(stripExpressionDelimeters(container.innerHTML), '<div>foo</div>');
 
     render(t('hello'), container);
-    assert.equal(container.innerHTML, '<div>hello</div>');
+    assert.equal(stripExpressionDelimeters(container.innerHTML), '<div>hello</div>');
 
     await iterable.push('bar');
-    assert.equal(container.innerHTML, '<div>hello</div>');
+    assert.equal(stripExpressionDelimeters(container.innerHTML), '<div>hello</div>');
   });
 
 });

--- a/src/test/lib/lit-extended_test.ts
+++ b/src/test/lib/lit-extended_test.ts
@@ -18,6 +18,8 @@
 import {html, PropertyPart, render} from '../../lib/lit-extended.js';
 import {directive, html as htmlPlain} from '../../lit-html.js';
 
+import {stripExpressionDelimeters} from '../test-helpers.js';
+
 const assert = chai.assert;
 
 suite('lit-extended', () => {
@@ -38,46 +40,46 @@ suite('lit-extended', () => {
 
     test('renders to an attribute', () => {
       render(html`<div foo$="${'bar'}"></div>`, container);
-      assert.equal(container.innerHTML, '<div foo="bar"></div>');
+      assert.equal(stripExpressionDelimeters(container.innerHTML), '<div foo="bar"></div>');
     });
 
     test('renders to an attribute without quotes', () => {
       render(html`<div foo$=${'bar'}></div>`, container);
-      assert.equal(container.innerHTML, '<div foo="bar"></div>');
+      assert.equal(stripExpressionDelimeters(container.innerHTML), '<div foo="bar"></div>');
     });
 
     test('renders interpolation to an attribute', () => {
       render(html`<div foo$="1${'bar'}2${'baz'}3"></div>`, container);
-      assert.equal(container.innerHTML, '<div foo="1bar2baz3"></div>');
+      assert.equal(stripExpressionDelimeters(container.innerHTML), '<div foo="1bar2baz3"></div>');
     });
 
     test('renders a boolean attribute as an empty string when truthy', () => {
       let t = (value: any) => html`<div foo?="${value}"></div>`;
 
       render(t(true), container);
-      assert.equal(container.innerHTML, '<div foo=""></div>');
+      assert.equal(stripExpressionDelimeters(container.innerHTML), '<div foo=""></div>');
 
       render(t('a'), container);
-      assert.equal(container.innerHTML, '<div foo=""></div>');
+      assert.equal(stripExpressionDelimeters(container.innerHTML), '<div foo=""></div>');
 
       render(t(1), container);
-      assert.equal(container.innerHTML, '<div foo=""></div>');
+      assert.equal(stripExpressionDelimeters(container.innerHTML), '<div foo=""></div>');
     });
 
     test('removes a boolean attribute when falsey', () => {
       let t = (value: any) => html`<div foo?="${value}"></div>`;
 
       render(t(false), container);
-      assert.equal(container.innerHTML, '<div></div>');
+      assert.equal(stripExpressionDelimeters(container.innerHTML), '<div></div>');
 
       render(t(0), container);
-      assert.equal(container.innerHTML, '<div></div>');
+      assert.equal(stripExpressionDelimeters(container.innerHTML), '<div></div>');
 
       render(t(null), container);
-      assert.equal(container.innerHTML, '<div></div>');
+      assert.equal(stripExpressionDelimeters(container.innerHTML), '<div></div>');
 
       render(t(undefined), container);
-      assert.equal(container.innerHTML, '<div></div>');
+      assert.equal(stripExpressionDelimeters(container.innerHTML), '<div></div>');
     });
 
     test('reuses an existing ExtendedTemplateInstance when available', () => {
@@ -225,7 +227,7 @@ suite('lit-extended', () => {
       });
 
       render(html`<div foo="${fooDirective}"></div>`, container);
-      assert.equal(container.innerHTML, '<div></div>');
+      assert.equal(stripExpressionDelimeters(container.innerHTML), '<div></div>');
       assert.equal((container.firstElementChild as any).foo, 1234);
     });
 

--- a/src/test/lib/lit-extended_test.ts
+++ b/src/test/lib/lit-extended_test.ts
@@ -54,7 +54,7 @@ suite('lit-extended', () => {
     });
 
     test('renders a boolean attribute as an empty string when truthy', () => {
-      let t = (value: any) => html`<div foo?="${value}"></div>`;
+      const t = (value: any) => html`<div foo?="${value}"></div>`;
 
       render(t(true), container);
       assert.equal(stripExpressionDelimeters(container.innerHTML), '<div foo=""></div>');
@@ -67,7 +67,7 @@ suite('lit-extended', () => {
     });
 
     test('removes a boolean attribute when falsey', () => {
-      let t = (value: any) => html`<div foo?="${value}"></div>`;
+      const t = (value: any) => html`<div foo?="${value}"></div>`;
 
       render(t(false), container);
       assert.equal(stripExpressionDelimeters(container.innerHTML), '<div></div>');

--- a/src/test/lib/repeat_test.ts
+++ b/src/test/lib/repeat_test.ts
@@ -18,6 +18,8 @@
 import {repeat} from '../../lib/repeat.js';
 import {html, render} from '../../lit-html.js';
 
+import {stripExpressionDelimeters} from '../test-helpers.js';
+
 const assert = chai.assert;
 
 suite('repeat', () => {
@@ -35,7 +37,7 @@ suite('repeat', () => {
           html`${repeat([1, 2, 3], (i) => i, (i: number) => html`
             <li>item: ${i}</li>`)}`;
       render(r, container);
-      assert.equal(container.innerHTML, `
+      assert.equal(stripExpressionDelimeters(container.innerHTML), `
             <li>item: 1</li>
             <li>item: 2</li>
             <li>item: 3</li>`);
@@ -47,13 +49,13 @@ suite('repeat', () => {
             <li>item: ${i}</li>`)}`;
 
       render(t([1, 2, 3]), container);
-      assert.equal(container.innerHTML, `
+      assert.equal(stripExpressionDelimeters(container.innerHTML), `
             <li>item: 1</li>
             <li>item: 2</li>
             <li>item: 3</li>`);
 
       render(t([1, 2, 3]), container);
-      assert.equal(container.innerHTML, `
+      assert.equal(stripExpressionDelimeters(container.innerHTML), `
             <li>item: 1</li>
             <li>item: 2</li>
             <li>item: 3</li>`);
@@ -65,7 +67,7 @@ suite('repeat', () => {
           html`${repeat(items, (i) => i, (i: number) => html`
             <li>item: ${i}</li>`)}`;
       render(t(), container);
-      assert.equal(container.innerHTML, `
+      assert.equal(stripExpressionDelimeters(container.innerHTML), `
             <li>item: 1</li>
             <li>item: 2</li>
             <li>item: 3</li>`);
@@ -73,7 +75,7 @@ suite('repeat', () => {
 
       items = [3, 2, 1];
       render(t(), container);
-      assert.equal(container.innerHTML, `
+      assert.equal(stripExpressionDelimeters(container.innerHTML), `
             <li>item: 3</li>
             <li>item: 2</li>
             <li>item: 1</li>`);
@@ -90,7 +92,7 @@ suite('repeat', () => {
 
       render(t([1, 2, 3, 4, 5]), container);
 
-      assert.equal(container.innerHTML, `
+      assert.equal(stripExpressionDelimeters(container.innerHTML), `
             <li>item: 1</li>
             <li>item: 2</li>
             <li>item: 3</li>
@@ -99,7 +101,7 @@ suite('repeat', () => {
 
       render(t([1, 5, 3, 4, 2]), container);
 
-      assert.equal(container.innerHTML, `
+      assert.equal(stripExpressionDelimeters(container.innerHTML), `
             <li>item: 1</li>
             <li>item: 5</li>
             <li>item: 3</li>
@@ -114,14 +116,14 @@ suite('repeat', () => {
 
       render(t([1, 2, 3]), container);
 
-      assert.equal(container.innerHTML, `
+      assert.equal(stripExpressionDelimeters(container.innerHTML), `
             <li>item: 1</li>
             <li>item: 2</li>
             <li>item: 3</li>`);
 
       render(t([3, 2, 1]), container);
 
-      assert.equal(container.innerHTML, `
+      assert.equal(stripExpressionDelimeters(container.innerHTML), `
             <li>item: 3</li>
             <li>item: 2</li>
             <li>item: 1</li>`);
@@ -135,7 +137,7 @@ suite('repeat', () => {
             <li>item: ${i}</li>`)}`;
 
       render(t([666, 666]), container);
-      assert.equal(container.innerHTML, `
+      assert.equal(stripExpressionDelimeters(container.innerHTML), `
             <li>item: 666</li>`);
     });
 
@@ -145,7 +147,7 @@ suite('repeat', () => {
             <li>item: ${i}</li>`)}`;
 
       render(t([666, 777, 666]), container);
-      assert.equal(container.innerHTML, `
+      assert.equal(stripExpressionDelimeters(container.innerHTML), `
             <li>item: 777</li>
             <li>item: 666</li>`);
     });
@@ -158,7 +160,7 @@ suite('repeat', () => {
 
       render(t([666, 666]), container);
       assert.equal(updates, 2);
-      assert.equal(container.innerHTML, `
+      assert.equal(stripExpressionDelimeters(container.innerHTML), `
             <li>item: 2</li>`);
     });
 
@@ -171,7 +173,7 @@ suite('repeat', () => {
       render(t(), container);
       items = [0, 1, 2, 3];
       render(t(), container);
-      assert.equal(container.innerHTML, `
+      assert.equal(stripExpressionDelimeters(container.innerHTML), `
             <li>item: 0</li>
             <li>item: 1</li>
             <li>item: 2</li>
@@ -187,7 +189,7 @@ suite('repeat', () => {
       render(t(), container);
       items = [1, 2, 3, 4];
       render(t(), container);
-      assert.equal(container.innerHTML, `
+      assert.equal(stripExpressionDelimeters(container.innerHTML), `
             <li>item: 1</li>
             <li>item: 2</li>
             <li>item: 3</li>
@@ -203,7 +205,7 @@ suite('repeat', () => {
       render(t(), container);
       items = [];
       render(t(), container);
-      assert.equal(container.innerHTML, ``);
+      assert.equal(stripExpressionDelimeters(container.innerHTML), ``);
     });
 
     test('can remove the first item', () => {
@@ -217,7 +219,7 @@ suite('repeat', () => {
 
       items = [2, 3];
       render(t(), container);
-      assert.equal(container.innerHTML, `
+      assert.equal(stripExpressionDelimeters(container.innerHTML), `
             <li>item: 2</li>
             <li>item: 3</li>`);
       const children2 = Array.from(container.querySelectorAll('li'));
@@ -236,7 +238,7 @@ suite('repeat', () => {
 
       items = [1, 2];
       render(t(), container);
-      assert.equal(container.innerHTML, `
+      assert.equal(stripExpressionDelimeters(container.innerHTML), `
             <li>item: 1</li>
             <li>item: 2</li>`);
       const children2 = Array.from(container.querySelectorAll('li'));
@@ -255,7 +257,7 @@ suite('repeat', () => {
 
       items = [1, 3];
       render(t(), container);
-      assert.equal(container.innerHTML, `
+      assert.equal(stripExpressionDelimeters(container.innerHTML), `
             <li>item: 1</li>
             <li>item: 3</li>`);
       const children2 = Array.from(container.querySelectorAll('li'));
@@ -271,7 +273,7 @@ suite('repeat', () => {
       const r = html`${repeat([1, 2, 3], (i: number) => html`
             <li>item: ${i}</li>`)}`;
       render(r, container);
-      assert.equal(container.innerHTML, `
+      assert.equal(stripExpressionDelimeters(container.innerHTML), `
             <li>item: 1</li>
             <li>item: 2</li>
             <li>item: 3</li>`);
@@ -282,14 +284,14 @@ suite('repeat', () => {
       const t = () => html`${repeat(items, (i: number) => html`
             <li>item: ${i}</li>`)}`;
       render(t(), container);
-      assert.equal(container.innerHTML, `
+      assert.equal(stripExpressionDelimeters(container.innerHTML), `
             <li>item: 1</li>
             <li>item: 2</li>
             <li>item: 3</li>`);
 
       items = [3, 2, 1];
       render(t(), container);
-      assert.equal(container.innerHTML, `
+      assert.equal(stripExpressionDelimeters(container.innerHTML), `
             <li>item: 3</li>
             <li>item: 2</li>
             <li>item: 1</li>`);
@@ -303,7 +305,7 @@ suite('repeat', () => {
 
       items = [];
       render(t(), container);
-      assert.equal(container.innerHTML, ``);
+      assert.equal(stripExpressionDelimeters(container.innerHTML), ``);
     });
 
     test('re-renders a list', () => {
@@ -313,7 +315,7 @@ suite('repeat', () => {
 
       render(t(), container);
       render(t(), container);
-      assert.equal(container.innerHTML, `
+      assert.equal(stripExpressionDelimeters(container.innerHTML), `
             <li>item: 1</li>
             <li>item: 2</li>
             <li>item: 3</li>

--- a/src/test/lib/unsafe-html_test.ts
+++ b/src/test/lib/unsafe-html_test.ts
@@ -18,6 +18,8 @@
 import {unsafeHTML} from '../../lib/unsafe-html.js';
 import {html, render} from '../../lit-html.js';
 
+import {stripExpressionDelimeters} from '../test-helpers.js';
+
 const assert = chai.assert;
 
 suite('unsafeHTML', () => {
@@ -28,7 +30,7 @@ suite('unsafeHTML', () => {
         html`<div>before${unsafeHTML('<span>inner</span>after</div>')}`,
         container);
     assert.equal(
-        container.innerHTML, '<div>before<span>inner</span>after</div>');
+        stripExpressionDelimeters(container.innerHTML), '<div>before<span>inner</span>after</div>');
   });
 
 });

--- a/src/test/lib/until_test.ts
+++ b/src/test/lib/until_test.ts
@@ -19,6 +19,8 @@ import {until} from '../../lib/until.js';
 import {html, render} from '../../lit-html.js';
 import {Deferred} from './deferred.js';
 
+import {stripExpressionDelimeters} from '../test-helpers.js';
+
 const assert = chai.assert;
 
 suite('until', () => {
@@ -36,12 +38,12 @@ suite('until', () => {
         html
         `<div>${until(deferred.promise, html`<span>loading...</span>`)}</div>`,
         container);
-        assert.equal(container.innerHTML, '<div><span>loading...</span></div>');
+        assert.equal(stripExpressionDelimeters(container.innerHTML), '<div><span>loading...</span></div>');
         deferred.resolve('foo');
         return deferred.promise
             .then(() => new Promise((r) => setTimeout(() => r())))
             .then(() => {
-              assert.equal(container.innerHTML, '<div>foo</div>');
+              assert.equal(stripExpressionDelimeters(container.innerHTML), '<div>foo</div>');
             });
   });
 
@@ -49,19 +51,19 @@ suite('until', () => {
     const t = (v: any) =>
         html`<div>${until(v, html`<span>loading...</span>`)}</div>`;
     render(t(deferred.promise), container);
-    assert.equal(container.innerHTML, '<div><span>loading...</span></div>');
+    assert.equal(stripExpressionDelimeters(container.innerHTML), '<div><span>loading...</span></div>');
 
     const deferred2 = new Deferred<string>();
     render(t(deferred2.promise), container);
-    assert.equal(container.innerHTML, '<div><span>loading...</span></div>');
+    assert.equal(stripExpressionDelimeters(container.innerHTML), '<div><span>loading...</span></div>');
 
     deferred2.resolve('bar');
     return deferred2.promise.then(() => {
-      assert.equal(container.innerHTML, '<div>bar</div>');
+      assert.equal(stripExpressionDelimeters(container.innerHTML), '<div>bar</div>');
 
       deferred.resolve('foo');
       return deferred.promise.then(() => {
-        assert.equal(container.innerHTML, '<div>bar</div>');
+        assert.equal(stripExpressionDelimeters(container.innerHTML), '<div>bar</div>');
       });
     });
   });

--- a/src/test/lit-html_test.ts
+++ b/src/test/lit-html_test.ts
@@ -17,6 +17,8 @@
 
 import {AttributePart, defaultPartCallback, defaultTemplateFactory, directive, html, NodePart, Part, render, svg, TemplateInstance, TemplatePart, TemplateResult} from '../lit-html.js';
 
+import {stripExpressionDelimeters} from './test-helpers.js';
+
 const assert = chai.assert;
 
 suite('lit-html', () => {
@@ -68,7 +70,7 @@ suite('lit-html', () => {
       const result = html`{{}}`;
       assert.equal(defaultTemplateFactory(result).parts.length, 0);
       render(result, container);
-      assert.equal(container.innerHTML, '{{}}');
+      assert.equal(stripExpressionDelimeters(container.innerHTML), '{{}}');
     });
 
     test('parses parts for multiple expressions', () => {
@@ -126,21 +128,21 @@ suite('lit-html', () => {
       const container = document.createElement('div');
       const result = html`<div>${1} ${2}</div>`;
       render(result, container);
-      assert.equal(container.innerHTML, '<div>1 2</div>');
+      assert.equal(stripExpressionDelimeters(container.innerHTML), '<div>1 2</div>');
     });
 
     test('parses expressions for two child nodes of one element', () => {
       const container = document.createElement('div');
       const result = html`test`;
       render(result, container);
-      assert.equal(container.innerHTML, 'test');
+      assert.equal(stripExpressionDelimeters(container.innerHTML), 'test');
     });
 
     test('parses expressions for two attributes of one element', () => {
       const container = document.createElement('div');
       const result = html`<div a="${1}" b="${2}"></div>`;
       render(result, container);
-      assert.equal(container.innerHTML, '<div a="1" b="2"></div>');
+      assert.equal(stripExpressionDelimeters(container.innerHTML), '<div a="1" b="2"></div>');
     });
 
     test('updates when called multiple times with arrays', () => {
@@ -151,9 +153,9 @@ suite('lit-html', () => {
       };
       render(ul(['a', 'b', 'c']), container);
       assert.equal(
-          container.innerHTML, '<ul><li>a</li><li>b</li><li>c</li></ul>');
+          stripExpressionDelimeters(container.innerHTML), '<ul><li>a</li><li>b</li><li>c</li></ul>');
       render(ul(['x', 'y']), container);
-      assert.equal(container.innerHTML, '<ul><li>x</li><li>y</li></ul>');
+      assert.equal(stripExpressionDelimeters(container.innerHTML), '<ul><li>x</li><li>y</li></ul>');
     });
 
     test('resists XSS attempt in node values', () => {
@@ -181,22 +183,22 @@ suite('lit-html', () => {
 
       test('renders a string', () => {
         render(html`<div>${'foo'}</div>`, container);
-        assert.equal(container.innerHTML, '<div>foo</div>');
+        assert.equal(stripExpressionDelimeters(container.innerHTML), '<div>foo</div>');
       });
 
       test('renders a number', () => {
         render(html`<div>${123}</div>`, container);
-        assert.equal(container.innerHTML, '<div>123</div>');
+        assert.equal(stripExpressionDelimeters(container.innerHTML), '<div>123</div>');
       });
 
       test('renders undefined', () => {
         render(html`<div>${undefined}</div>`, container);
-        assert.equal(container.innerHTML, '<div></div>');
+        assert.equal(stripExpressionDelimeters(container.innerHTML), '<div></div>');
       });
 
       test('renders null', () => {
         render(html`<div>${null}</div>`, container);
-        assert.equal(container.innerHTML, '<div></div>');
+        assert.equal(stripExpressionDelimeters(container.innerHTML), '<div></div>');
       });
 
       test('does not call a function bound to text', () => {
@@ -208,23 +210,23 @@ suite('lit-html', () => {
 
       test('renders arrays', () => {
         render(html`<div>${[1, 2, 3]}</div>`, container);
-        assert.equal(container.innerHTML, '<div>123</div>');
+        assert.equal(stripExpressionDelimeters(container.innerHTML), '<div>123</div>');
       });
 
       test('renders nested templates', () => {
         const partial = html`<h1>${'foo'}</h1>`;
         render(html`${partial}${'bar'}`, container);
-        assert.equal(container.innerHTML, '<h1>foo</h1>bar');
+        assert.equal(stripExpressionDelimeters(container.innerHTML), '<h1>foo</h1>bar');
       });
 
       test('renders parts with whitespace after them', () => {
         render(html`<div>${'foo'} </div>`, container);
-        assert.equal(container.innerHTML, '<div>foo </div>');
+        assert.equal(stripExpressionDelimeters(container.innerHTML), '<div>foo </div>');
       });
 
       test('preserves whitespace between parts', () => {
         render(html`<div>${'foo'} ${'bar'}</div>`, container);
-        assert.equal(container.innerHTML, '<div>foo bar</div>');
+        assert.equal(stripExpressionDelimeters(container.innerHTML), '<div>foo bar</div>');
       });
 
       const testSkipForTemplatePolyfill =
@@ -239,22 +241,22 @@ suite('lit-html', () => {
                 html`<table>${html`<tr>${html`<td></td>`}</tr>`}</table>`;
             render(table, container);
             assert.equal(
-                container.innerHTML, '<table><tr><td></td></tr></table>');
+                stripExpressionDelimeters(container.innerHTML), '<table><tr><td></td></tr></table>');
 
             table = html`<tbody>${html`<tr></tr>`}</tbody>`;
             render(table, container);
-            assert.equal(container.innerHTML, '<tbody><tr></tr></tbody>');
+            assert.equal(stripExpressionDelimeters(container.innerHTML), '<tbody><tr></tr></tbody>');
 
             table = html`<table><tr></tr>${html`<tr></tr>`}</table>`;
             render(table, container);
             assert.equal(
-                container.innerHTML,
+                stripExpressionDelimeters(container.innerHTML),
                 '<table><tbody><tr></tr><tr></tr></tbody></table>');
 
             table = html`<table><tr><td></td>${html`<td></td>`}</tr></table>`;
             render(table, container);
             assert.equal(
-                container.innerHTML,
+                stripExpressionDelimeters(container.innerHTML),
                 '<table><tbody><tr><td></td><td></td></tr></tbody></table>');
 
             table = html`<table><tr><td></td>${html`<td></td>`}${
@@ -262,7 +264,7 @@ suite('lit-html', () => {
                                                                }</tr></table>`;
             render(table, container);
             assert.equal(
-                container.innerHTML,
+                stripExpressionDelimeters(container.innerHTML),
                 '<table><tbody><tr><td></td><td></td><td></td></tr></tbody></table>');
           });
 
@@ -279,31 +281,31 @@ suite('lit-html', () => {
           () => {
             const template = html`<div a="<table>${'foo'}"></div>`;
             render(template, container);
-            assert.equal(container.innerHTML, `<div a="<table>foo"></div>`);
+            assert.equal(stripExpressionDelimeters(container.innerHTML), `<div a="<table>foo"></div>`);
           });
 
       test('values contain interpolated values', () => {
         const t = html`${'a'},${'b'},${'c'}`;
         render(t, container);
-        assert.equal(container.innerHTML, 'a,b,c');
+        assert.equal(stripExpressionDelimeters(container.innerHTML), 'a,b,c');
       });
 
       // test('renders multiple nested templates', () => {
       //   const partial = html`<h1>${'foo'}</h1>`;
       //   html`${partial}${'bar'}${partial}${'baz'}qux`, container);
-      //   assert.equal(container.innerHTML,
+      //   assert.equal(stripExpressionDelimeters(container.innerHTML),
       //   '<h1>foo</h1>bar<h1>foo</h1>bazqux');
       // });
 
       test('renders arrays of nested templates', () => {
         render(html`<div>${[1, 2, 3].map((i) => html`${i}`)}</div>`, container);
-        assert.equal(container.innerHTML, '<div>123</div>');
+        assert.equal(stripExpressionDelimeters(container.innerHTML), '<div>123</div>');
       });
 
       test('renders an element', () => {
         const child = document.createElement('p');
         render(html`<div>${child}</div>`, container);
-        assert.equal(container.innerHTML, '<div><p></p></div>');
+        assert.equal(stripExpressionDelimeters(container.innerHTML), '<div><p></p></div>');
       });
 
       test('renders an array of elements', () => {
@@ -314,26 +316,26 @@ suite('lit-html', () => {
         ];
         render(html`<div>${children}</div>`, container);
         assert.equal(
-            container.innerHTML, '<div><p></p><a></a><span></span></div>');
+            stripExpressionDelimeters(container.innerHTML), '<div><p></p><a></a><span></span></div>');
       });
 
       test('renders to an attribute', () => {
         render(html`<div foo="${'bar'}"></div>`, container);
-        assert.equal(container.innerHTML, '<div foo="bar"></div>');
+        assert.equal(stripExpressionDelimeters(container.innerHTML), '<div foo="bar"></div>');
       });
 
       test(
           'renders to an attribute expression after an attribute literal',
           () => {
             render(html`<div a="b" foo="${'bar'}"></div>`, container);
-            assert.equal(container.innerHTML, '<div a="b" foo="bar"></div>');
+            assert.equal(stripExpressionDelimeters(container.innerHTML), '<div a="b" foo="bar"></div>');
           });
 
       test(
           'renders to an attribute expression before an attribute literal',
           () => {
             render(html`<div foo="${'bar'}" a="b"></div>`, container);
-            assert.equal(container.innerHTML, '<div a="b" foo="bar"></div>');
+            assert.equal(stripExpressionDelimeters(container.innerHTML), '<div a="b" foo="bar"></div>');
           });
 
       // Regression test for exception in template parsing caused by attributes
@@ -345,20 +347,20 @@ suite('lit-html', () => {
                 html`<a href="${'foo'}" class="bar"><div id=${'a'}></div></a>`,
                 container);
             assert.equal(
-                container.innerHTML,
+                stripExpressionDelimeters(container.innerHTML),
                 `<a class="bar" href="foo"><div id="a"></div></a>`);
           });
 
       test('renders to an attribute without quotes', () => {
         render(html`<div foo=${'bar'}></div>`, container);
-        assert.equal(container.innerHTML, '<div foo="bar"></div>');
+        assert.equal(stripExpressionDelimeters(container.innerHTML), '<div foo="bar"></div>');
       });
 
       test('renders to multiple attribute expressions', () => {
         render(
             html`<div foo="${'Foo'}" bar="${'Bar'}" baz=${'Baz'}></div>`,
             container);
-        assert.oneOf(container.innerHTML, [
+        assert.oneOf(stripExpressionDelimeters(container.innerHTML), [
           '<div foo="Foo" bar="Bar" baz="Baz"></div>',
           '<div foo="Foo" baz="Baz" bar="Bar"></div>'
         ]);
@@ -369,7 +371,7 @@ suite('lit-html', () => {
           <div>${''}</div>
           <div foo=${'bar'}></div>
         `, container);
-        assert.equal(container.innerHTML, `
+        assert.equal(stripExpressionDelimeters(container.innerHTML), `
           <div></div>
           <div foo="bar"></div>
         `);
@@ -377,12 +379,12 @@ suite('lit-html', () => {
 
       test('renders to attributes with attribute-like values', () => {
         render(html`<div foo="bar=${'foo'}"></div>`, container);
-        assert.equal(container.innerHTML, '<div foo="bar=foo"></div>');
+        assert.equal(stripExpressionDelimeters(container.innerHTML), '<div foo="bar=foo"></div>');
       });
 
       test('renders interpolation to an attribute', () => {
         render(html`<div foo="1${'bar'}2${'baz'}3"></div>`, container);
-        assert.equal(container.innerHTML, '<div foo="1bar2baz3"></div>');
+        assert.equal(stripExpressionDelimeters(container.innerHTML), '<div foo="1bar2baz3"></div>');
       });
 
       test('does not call a function bound to an attribute', () => {
@@ -396,18 +398,18 @@ suite('lit-html', () => {
 
       test('renders an array to an attribute', () => {
         render(html`<div foo=${[1, 2, 3]}></div>`, container);
-        assert.equal(container.innerHTML, '<div foo="123"></div>');
+        assert.equal(stripExpressionDelimeters(container.innerHTML), '<div foo="123"></div>');
       });
 
       test('renders to an attribute before a node', () => {
         render(html`<div foo="${'bar'}">${'baz'}</div>`, container);
-        assert.equal(container.innerHTML, '<div foo="bar">baz</div>');
+        assert.equal(stripExpressionDelimeters(container.innerHTML), '<div foo="bar">baz</div>');
       });
 
       test('renders to an attribute after a node', () => {
         render(html`<div>${'baz'}</div><div foo="${'bar'}"></div>`, container);
         assert.equal(
-            container.innerHTML, '<div>baz</div><div foo="bar"></div>');
+            stripExpressionDelimeters(container.innerHTML), '<div>baz</div><div foo="bar"></div>');
       });
 
       test('renders a Promise', () => {
@@ -416,10 +418,10 @@ suite('lit-html', () => {
           resolve = res;
         });
         render(html`<div>${promise}</div>`, container);
-        assert.equal(container.innerHTML, '<div></div>');
+        assert.equal(stripExpressionDelimeters(container.innerHTML), '<div></div>');
         resolve!('foo');
         return promise.then(() => {
-          assert.equal(container.innerHTML, '<div>foo</div>');
+          assert.equal(stripExpressionDelimeters(container.innerHTML), '<div>foo</div>');
         });
       });
 
@@ -430,7 +432,7 @@ suite('lit-html', () => {
           }
         };
         render(html`<div>${promise}</div>`, container);
-        assert.equal(container.innerHTML, '<div>foo</div>');
+        assert.equal(stripExpressionDelimeters(container.innerHTML), '<div>foo</div>');
       });
 
       test('renders racing Promises correctly', () => {
@@ -449,21 +451,21 @@ suite('lit-html', () => {
 
         // First render, first Promise, no value
         render(t(), container);
-        assert.equal(container.innerHTML, '<div></div>');
+        assert.equal(stripExpressionDelimeters(container.innerHTML), '<div></div>');
 
         promise = promise2;
         // Second render, second Promise, still no value
         render(t(), container);
-        assert.equal(container.innerHTML, '<div></div>');
+        assert.equal(stripExpressionDelimeters(container.innerHTML), '<div></div>');
 
         // Resolve the first Promise, should not update the container
         resolve1!('foo');
         return promise1.then(() => {
-          assert.equal(container.innerHTML, '<div></div>');
+          assert.equal(stripExpressionDelimeters(container.innerHTML), '<div></div>');
           // Resolve the second Promise, should update the container
           resolve2!('bar');
           return promise2.then(() => {
-            assert.equal(container.innerHTML, '<div>bar</div>');
+            assert.equal(stripExpressionDelimeters(container.innerHTML), '<div>bar</div>');
           });
         });
       });
@@ -477,7 +479,7 @@ suite('lit-html', () => {
             </style>
             <a href="/buy/${'foo'}"></a>
           `, container);
-        assert.equal(container.innerHTML, `
+        assert.equal(stripExpressionDelimeters(container.innerHTML), `
             <style>
               .foo {
                 background: black;
@@ -493,7 +495,7 @@ suite('lit-html', () => {
               ${'baz'}
               <p>${'qux'}</p>
             </div>`, container);
-        assert.equal(container.innerHTML, `
+        assert.equal(stripExpressionDelimeters(container.innerHTML), `
             <div foo="bar">
               baz
               <p>qux</p>
@@ -517,7 +519,7 @@ suite('lit-html', () => {
             <p>${'foo'}</p>
           </div>`;
         render(t, container);
-        assert.equal(container.innerHTML, `
+        assert.equal(stripExpressionDelimeters(container.innerHTML), `
           <div>
             <!-- this is a comment -->
             <h1 class="foo">title</h1>
@@ -534,7 +536,7 @@ suite('lit-html', () => {
             }
           </style>`;
         render(t, container);
-        assert.equal(container.innerHTML, `
+        assert.equal(stripExpressionDelimeters(container.innerHTML), `
           <style>
             h1: {
               color: red;
@@ -550,7 +552,7 @@ suite('lit-html', () => {
             <style>${'bar'}</style>
             <a href="/buy/${'foo'}"></a>
           `, container);
-          assert.equal(container.innerHTML, `
+          assert.equal(stripExpressionDelimeters(container.innerHTML), `
             <style>bar</style>
             <a href="/buy/foo"></a>
           `);
@@ -558,12 +560,12 @@ suite('lit-html', () => {
 
       test('renders expressions with preceding elements', () => {
         render(html`<a>${'foo'}</a>${html`<h1>${'bar'}</h1>`}`, container);
-        assert.equal(container.innerHTML, '<a>foo</a><h1>bar</h1>');
+        assert.equal(stripExpressionDelimeters(container.innerHTML), '<a>foo</a><h1>bar</h1>');
 
         // This is nearly the same test case as above, but was causing a
         // different stack trace
         render(html`<a>${'foo'}</a>${'bar'}`, container);
-        assert.equal(container.innerHTML, '<a>foo</a>bar');
+        assert.equal(stripExpressionDelimeters(container.innerHTML), '<a>foo</a>bar');
       });
 
       test('renders directives on NodeParts', () => {
@@ -572,7 +574,7 @@ suite('lit-html', () => {
         });
 
         render(html`<div>${fooDirective}</div>`, container);
-        assert.equal(container.innerHTML, '<div>foo</div>');
+        assert.equal(stripExpressionDelimeters(container.innerHTML), '<div>foo</div>');
       });
 
       test('renders directives on AttributeParts', () => {
@@ -581,7 +583,7 @@ suite('lit-html', () => {
         });
 
         render(html`<div foo="${fooDirective}"></div>`, container);
-        assert.equal(container.innerHTML, '<div foo="foo"></div>');
+        assert.equal(stripExpressionDelimeters(container.innerHTML), '<div foo="foo"></div>');
       });
 
     });
@@ -601,11 +603,11 @@ suite('lit-html', () => {
         const t = () => html`<div>${foo}</div>`;
 
         render(t(), container);
-        assert.equal(container.innerHTML, '<div>aaa</div>');
+        assert.equal(stripExpressionDelimeters(container.innerHTML), '<div>aaa</div>');
         const text = container.firstChild!.childNodes[1] as Text;
         text.textContent = 'bbb';
         render(t(), container);
-        assert.equal(container.innerHTML, '<div>bbb</div>');
+        assert.equal(stripExpressionDelimeters(container.innerHTML), '<div>bbb</div>');
       });
 
       test('dirty checks simple values', () => {
@@ -614,7 +616,7 @@ suite('lit-html', () => {
         const t = () => html`<div>${foo}</div>`;
 
         render(t(), container);
-        assert.equal(container.innerHTML, '<div>aaa</div>');
+        assert.equal(stripExpressionDelimeters(container.innerHTML), '<div>aaa</div>');
         const text = container.firstChild!.childNodes[1] as Text;
         assert.equal(text.textContent, 'aaa');
 
@@ -623,11 +625,11 @@ suite('lit-html', () => {
         // persist through the next render with the same value.
         text.textContent = 'bbb';
         assert.equal(text.textContent, 'bbb');
-        assert.equal(container.innerHTML, '<div>bbb</div>');
+        assert.equal(stripExpressionDelimeters(container.innerHTML), '<div>bbb</div>');
 
         // Re-render with the same content, should be a no-op
         render(t(), container);
-        assert.equal(container.innerHTML, '<div>bbb</div>');
+        assert.equal(stripExpressionDelimeters(container.innerHTML), '<div>bbb</div>');
         const text2 = container.firstChild!.childNodes[1] as Text;
 
         // The next node should be the same too
@@ -640,13 +642,13 @@ suite('lit-html', () => {
         const t = () => html`<div>${foo}</div>`;
 
         render(t(), container);
-        assert.equal(container.innerHTML, '<div>aaa</div>');
+        assert.equal(stripExpressionDelimeters(container.innerHTML), '<div>aaa</div>');
         const div = container.firstChild as HTMLDivElement;
         assert.equal(div.tagName, 'DIV');
 
         foo = 'bbb';
         render(t(), container);
-        assert.equal(container.innerHTML, '<div>bbb</div>');
+        assert.equal(stripExpressionDelimeters(container.innerHTML), '<div>bbb</div>');
         const div2 = container.firstChild as HTMLDivElement;
         // check that only the part changed
         assert.equal(div, div2);
@@ -659,11 +661,11 @@ suite('lit-html', () => {
         const t = () => html`<div>${foo}${bar}</div>`;
 
         render(t(), container);
-        assert.equal(container.innerHTML, '<div>foobar</div>');
+        assert.equal(stripExpressionDelimeters(container.innerHTML), '<div>foobar</div>');
 
         foo = 'bbb';
         render(t(), container);
-        assert.equal(container.innerHTML, '<div>bbbbar</div>');
+        assert.equal(stripExpressionDelimeters(container.innerHTML), '<div>bbbbar</div>');
       });
 
       test('renders and updates attributes', () => {
@@ -673,11 +675,11 @@ suite('lit-html', () => {
         const t = () => html`<div a="${foo}:${bar}"></div>`;
 
         render(t(), container);
-        assert.equal(container.innerHTML, '<div a="foo:bar"></div>');
+        assert.equal(stripExpressionDelimeters(container.innerHTML), '<div a="foo:bar"></div>');
 
         foo = 'bbb';
         render(t(), container);
-        assert.equal(container.innerHTML, '<div a="bbb:bar"></div>');
+        assert.equal(stripExpressionDelimeters(container.innerHTML), '<div a="bbb:bar"></div>');
       });
 
       test('updates nested templates', () => {
@@ -697,25 +699,25 @@ suite('lit-html', () => {
         };
 
         render(t(true), container);
-        assert.equal(container.innerHTML, '<h1>foo</h1>baz');
+        assert.equal(stripExpressionDelimeters(container.innerHTML), '<h1>foo</h1>baz');
 
         foo = 'bbb';
         render(t(true), container);
-        assert.equal(container.innerHTML, '<h1>bbb</h1>baz');
+        assert.equal(stripExpressionDelimeters(container.innerHTML), '<h1>bbb</h1>baz');
 
         render(t(false), container);
-        assert.equal(container.innerHTML, '<h2>bar</h2>baz');
+        assert.equal(stripExpressionDelimeters(container.innerHTML), '<h2>bar</h2>baz');
       });
 
       test('updates arrays', () => {
         let items = [1, 2, 3];
         const t = () => html`<div>${items}</div>`;
         render(t(), container);
-        assert.equal(container.innerHTML, '<div>123</div>');
+        assert.equal(stripExpressionDelimeters(container.innerHTML), '<div>123</div>');
 
         items = [3, 2, 1];
         render(t(), container);
-        assert.equal(container.innerHTML, '<div>321</div>');
+        assert.equal(stripExpressionDelimeters(container.innerHTML), '<div>321</div>');
       });
 
       test('updates arrays that shrink then grow', () => {
@@ -724,30 +726,30 @@ suite('lit-html', () => {
 
         items = [1, 2, 3];
         render(t(), container);
-        assert.equal(container.innerHTML, '<div>123</div>');
+        assert.equal(stripExpressionDelimeters(container.innerHTML), '<div>123</div>');
 
         items = [4];
         render(t(), container);
-        assert.equal(container.innerHTML, '<div>4</div>');
+        assert.equal(stripExpressionDelimeters(container.innerHTML), '<div>4</div>');
 
         items = [5, 6, 7];
         render(t(), container);
-        assert.equal(container.innerHTML, '<div>567</div>');
+        assert.equal(stripExpressionDelimeters(container.innerHTML), '<div>567</div>');
       });
 
       test('updates an element', () => {
         let child: any = document.createElement('p');
         const t = () => html`<div>${child}<div></div></div>`;
         render(t(), container);
-        assert.equal(container.innerHTML, '<div><p></p><div></div></div>');
+        assert.equal(stripExpressionDelimeters(container.innerHTML), '<div><p></p><div></div></div>');
 
         child = undefined;
         render(t(), container);
-        assert.equal(container.innerHTML, '<div><div></div></div>');
+        assert.equal(stripExpressionDelimeters(container.innerHTML), '<div><div></div></div>');
 
         child = document.createTextNode('foo');
         render(t(), container);
-        assert.equal(container.innerHTML, '<div>foo<div></div></div>');
+        assert.equal(stripExpressionDelimeters(container.innerHTML), '<div>foo<div></div></div>');
       });
 
       test('updates an array of elements', () => {
@@ -759,15 +761,15 @@ suite('lit-html', () => {
         const t = () => html`<div>${children}</div>`;
         render(t(), container);
         assert.equal(
-            container.innerHTML, '<div><p></p><a></a><span></span></div>');
+            stripExpressionDelimeters(container.innerHTML), '<div><p></p><a></a><span></span></div>');
 
         children = null;
         render(t(), container);
-        assert.equal(container.innerHTML, '<div></div>');
+        assert.equal(stripExpressionDelimeters(container.innerHTML), '<div></div>');
 
         children = document.createTextNode('foo');
         render(t(), container);
-        assert.equal(container.innerHTML, '<div>foo</div>');
+        assert.equal(stripExpressionDelimeters(container.innerHTML), '<div>foo</div>');
       });
 
       test(
@@ -843,7 +845,7 @@ suite('lit-html', () => {
         const container = document.createElement('div');
         const t = testHtml`<div someProp="${123}"></div>`;
         render(t, container);
-        assert.equal(container.innerHTML, '<div></div>');
+        assert.equal(stripExpressionDelimeters(container.innerHTML), '<div></div>');
         assert.strictEqual((container.firstElementChild as any).someProp, 123);
       });
 
@@ -851,7 +853,7 @@ suite('lit-html', () => {
         const container = document.createElement('div');
         const t = testHtml`${html`<div someProp="${123}"></div>`}`;
         render(t, container);
-        assert.equal(container.innerHTML, '<div></div>');
+        assert.equal(stripExpressionDelimeters(container.innerHTML), '<div></div>');
         assert.strictEqual((container.firstElementChild as any).someProp, 123);
       });
 
@@ -883,22 +885,22 @@ suite('lit-html', () => {
 
       test('accepts a string', () => {
         part.setValue('foo');
-        assert.equal(container.innerHTML, 'foo');
+        assert.equal(stripExpressionDelimeters(container.innerHTML), 'foo');
       });
 
       test('accepts a number', () => {
         part.setValue(123);
-        assert.equal(container.innerHTML, '123');
+        assert.equal(stripExpressionDelimeters(container.innerHTML), '123');
       });
 
       test('accepts undefined', () => {
         part.setValue(undefined);
-        assert.equal(container.innerHTML, '');
+        assert.equal(stripExpressionDelimeters(container.innerHTML), '');
       });
 
       test('accepts null', () => {
         part.setValue(null);
-        assert.equal(container.innerHTML, '');
+        assert.equal(stripExpressionDelimeters(container.innerHTML), '');
       });
 
       test('accepts a function', () => {
@@ -910,26 +912,26 @@ suite('lit-html', () => {
 
       test('accepts an element', () => {
         part.setValue(document.createElement('p'));
-        assert.equal(container.innerHTML, '<p></p>');
+        assert.equal(stripExpressionDelimeters(container.innerHTML), '<p></p>');
       });
 
       test('accepts arrays', () => {
         part.setValue([1, 2, 3]);
-        assert.equal(container.innerHTML, '123');
+        assert.equal(stripExpressionDelimeters(container.innerHTML), '123');
         assert.strictEqual(container.firstChild, startNode);
         assert.strictEqual(container.lastChild, endNode);
       });
 
       test('accepts an empty array', () => {
         part.setValue([]);
-        assert.equal(container.innerHTML, '');
+        assert.equal(stripExpressionDelimeters(container.innerHTML), '');
         assert.strictEqual(container.firstChild, startNode);
         assert.strictEqual(container.lastChild, endNode);
       });
 
       test('accepts nested arrays', () => {
         part.setValue([1, [2], 3]);
-        assert.equal(container.innerHTML, '123');
+        assert.equal(stripExpressionDelimeters(container.innerHTML), '123');
         assert.deepEqual(
             ['', '1', '', '2', '', '3', ''],
             Array.from(container.childNodes).map((n) => n.nodeValue));
@@ -939,12 +941,12 @@ suite('lit-html', () => {
 
       test('accepts nested templates', () => {
         part.setValue(html`<h1>${'foo'}</h1>`);
-        assert.equal(container.innerHTML, '<h1>foo</h1>');
+        assert.equal(stripExpressionDelimeters(container.innerHTML), '<h1>foo</h1>');
       });
 
       test('accepts arrays of nested templates', () => {
         part.setValue([1, 2, 3].map((i) => html`${i}`));
-        assert.equal(container.innerHTML, '123');
+        assert.equal(stripExpressionDelimeters(container.innerHTML), '123');
       });
 
       test('accepts an array of elements', () => {
@@ -954,41 +956,41 @@ suite('lit-html', () => {
           document.createElement('span')
         ];
         part.setValue(children);
-        assert.equal(container.innerHTML, '<p></p><a></a><span></span>');
+        assert.equal(stripExpressionDelimeters(container.innerHTML), '<p></p><a></a><span></span>');
       });
 
       test('updates a simple value to a complex one', () => {
         let value: string|TemplateResult = 'foo';
         const t = () => html`<div>${value}</div>`;
         render(t(), container);
-        assert.equal(container.innerHTML, '<div>foo</div>');
+        assert.equal(stripExpressionDelimeters(container.innerHTML), '<div>foo</div>');
 
         value = html`<span>bar</span>`;
         render(t(), container);
-        assert.equal(container.innerHTML, '<div><span>bar</span></div>');
+        assert.equal(stripExpressionDelimeters(container.innerHTML), '<div><span>bar</span></div>');
       });
 
       test('updates a complex value to a simple one', () => {
         let value: string|TemplateResult = html`<span>bar</span>`;
         const t = () => html`<div>${value}</div>`;
         render(t(), container);
-        assert.equal(container.innerHTML, '<div><span>bar</span></div>');
+        assert.equal(stripExpressionDelimeters(container.innerHTML), '<div><span>bar</span></div>');
 
         value = 'foo';
         render(t(), container);
-        assert.equal(container.innerHTML, '<div>foo</div>');
+        assert.equal(stripExpressionDelimeters(container.innerHTML), '<div>foo</div>');
       });
 
       test('updates when called multiple times with simple values', () => {
         part.setValue('abc');
-        assert.equal(container.innerHTML, 'abc');
+        assert.equal(stripExpressionDelimeters(container.innerHTML), 'abc');
         part.setValue('def');
-        assert.equal(container.innerHTML, 'def');
+        assert.equal(stripExpressionDelimeters(container.innerHTML), 'def');
       });
 
       test('updates when called multiple times with arrays', () => {
         part.setValue([1, 2, 3]);
-        assert.equal(container.innerHTML, '123');
+        assert.equal(stripExpressionDelimeters(container.innerHTML), '123');
         assert.deepEqual(
             ['', '1', '', '2', '', '3', ''],
             Array.from(container.childNodes).map((n) => n.nodeValue));
@@ -996,7 +998,7 @@ suite('lit-html', () => {
         assert.strictEqual(container.lastChild, endNode);
 
         part.setValue([]);
-        assert.equal(container.innerHTML, '');
+        assert.equal(stripExpressionDelimeters(container.innerHTML), '');
         assert.deepEqual(
             ['', ''], Array.from(container.childNodes).map((n) => n.nodeValue));
         assert.strictEqual(container.firstChild, startNode);
@@ -1005,7 +1007,7 @@ suite('lit-html', () => {
 
       test('updates when called multiple times with arrays 2', () => {
         part.setValue([1, 2, 3]);
-        assert.equal(container.innerHTML, '123');
+        assert.equal(stripExpressionDelimeters(container.innerHTML), '123');
         assert.deepEqual(
             ['', '1', '', '2', '', '3', ''],
             Array.from(container.childNodes).map((n) => n.nodeValue));
@@ -1013,7 +1015,7 @@ suite('lit-html', () => {
         assert.strictEqual(container.lastChild, endNode);
 
         part.setValue([4, 5]);
-        assert.equal(container.innerHTML, '45');
+        assert.equal(stripExpressionDelimeters(container.innerHTML), '45');
         assert.deepEqual(
             ['', '4', '', '5', ''],
             Array.from(container.childNodes).map((n) => n.nodeValue));
@@ -1021,14 +1023,14 @@ suite('lit-html', () => {
         assert.strictEqual(container.lastChild, endNode);
 
         part.setValue([]);
-        assert.equal(container.innerHTML, '');
+        assert.equal(stripExpressionDelimeters(container.innerHTML), '');
         assert.deepEqual(
             ['', ''], Array.from(container.childNodes).map((n) => n.nodeValue));
         assert.strictEqual(container.firstChild, startNode);
         assert.strictEqual(container.lastChild, endNode);
 
         part.setValue([4, 5]);
-        assert.equal(container.innerHTML, '45');
+        assert.equal(stripExpressionDelimeters(container.innerHTML), '45');
         assert.deepEqual(
             ['', '4', '', '5', ''],
             Array.from(container.childNodes).map((n) => n.nodeValue));
@@ -1038,7 +1040,7 @@ suite('lit-html', () => {
 
       test('updates nested arrays', () => {
         part.setValue([1, [2], 3]);
-        assert.equal(container.innerHTML, '123');
+        assert.equal(stripExpressionDelimeters(container.innerHTML), '123');
         assert.deepEqual(
             ['', '1', '', '2', '', '3', ''],
             Array.from(container.childNodes).map((n) => n.nodeValue));
@@ -1046,7 +1048,7 @@ suite('lit-html', () => {
         assert.strictEqual(container.lastChild, endNode);
 
         part.setValue([[1], 2, 3]);
-        assert.equal(container.innerHTML, '123');
+        assert.equal(stripExpressionDelimeters(container.innerHTML), '123');
         assert.deepEqual(
             ['', '1', '', '2', '', '3', ''],
             Array.from(container.childNodes).map((n) => n.nodeValue));
@@ -1059,11 +1061,11 @@ suite('lit-html', () => {
         const t = () => html`<p></p>${items}<a></a>`;
 
         render(t(), container);
-        assert.equal(container.innerHTML, '<p></p>123<a></a>');
+        assert.equal(stripExpressionDelimeters(container.innerHTML), '<p></p>123<a></a>');
 
         items = [1, 2, 3, 4];
         render(t(), container);
-        assert.equal(container.innerHTML, '<p></p>1234<a></a>');
+        assert.equal(stripExpressionDelimeters(container.innerHTML), '<p></p>1234<a></a>');
       });
 
       test(
@@ -1072,12 +1074,12 @@ suite('lit-html', () => {
             let value = 'foo';
             const r = () => html`<h1>${value}</h1>`;
             part.setValue(r());
-            assert.equal(container.innerHTML, '<h1>foo</h1>');
+            assert.equal(stripExpressionDelimeters(container.innerHTML), '<h1>foo</h1>');
             const originalH1 = container.querySelector('h1');
 
             value = 'bar';
             part.setValue(r());
-            assert.equal(container.innerHTML, '<h1>bar</h1>');
+            assert.equal(stripExpressionDelimeters(container.innerHTML), '<h1>bar</h1>');
             const newH1 = container.querySelector('h1');
             assert.strictEqual(newH1, originalH1);
           });
@@ -1088,12 +1090,12 @@ suite('lit-html', () => {
             let items = [1, 2, 3];
             const r = () => items.map((i) => html`<li>${i}</li>`);
             part.setValue(r());
-            assert.equal(container.innerHTML, '<li>1</li><li>2</li><li>3</li>');
+            assert.equal(stripExpressionDelimeters(container.innerHTML), '<li>1</li><li>2</li><li>3</li>');
             const originalLIs = Array.from(container.querySelectorAll('li'));
 
             items = [3, 2, 1];
             part.setValue(r());
-            assert.equal(container.innerHTML, '<li>3</li><li>2</li><li>1</li>');
+            assert.equal(stripExpressionDelimeters(container.innerHTML), '<li>3</li><li>2</li><li>1</li>');
             const newLIs = Array.from(container.querySelectorAll('li'));
             assert.deepEqual(newLIs, originalLIs);
           });

--- a/src/test/lit-html_test.ts
+++ b/src/test/lit-html_test.ts
@@ -525,6 +525,37 @@ suite('lit-html', () => {
           </div>`);
       });
 
+      test('render style tags with expressions correctly', () => {
+        const color = 'red';
+        const t = html`
+          <style>
+            h1: {
+              color: ${color};
+            }
+          </style>`;
+        render(t, container);
+        assert.equal(container.innerHTML, `
+          <style>
+            h1: {
+              color: red;
+            }
+          </style>`);
+      });
+
+      test('renders an attribute after empty style node binding', () => {
+        // This test is sensitive to the exact binding in the style tag.
+        // Make sure the binding takes up the whole element with no text
+        // on either side of it
+        render(html`
+            <style>${'bar'}</style>
+            <a href="/buy/${'foo'}"></a>
+          `, container);
+          assert.equal(container.innerHTML, `
+            <style>bar</style>
+            <a href="/buy/foo"></a>
+          `);
+      });
+
       test('renders expressions with preceding elements', () => {
         render(html`<a>${'foo'}</a>${html`<h1>${'bar'}</h1>`}`, container);
         assert.equal(container.innerHTML, '<a>foo</a><h1>bar</h1>');
@@ -563,6 +594,20 @@ suite('lit-html', () => {
         container = document.createElement('div');
       });
 
+      test('sanity check one', () => {
+        // bump line numbers
+        const foo = 'aaa';
+
+        const t = () => html`<div>${foo}</div>`;
+
+        render(t(), container);
+        assert.equal(container.innerHTML, '<div>aaa</div>');
+        const text = container.firstChild!.childNodes[1] as Text;
+        text.textContent = 'bbb';
+        render(t(), container);
+        assert.equal(container.innerHTML, '<div>bbb</div>');
+      });
+
       test('dirty checks simple values', () => {
         const foo = 'aaa';
 
@@ -573,7 +618,7 @@ suite('lit-html', () => {
         const text = container.firstChild!.childNodes[1] as Text;
         assert.equal(text.textContent, 'aaa');
 
-        // Set textContent manually. Since lit-html doesn't dirty checks against
+        // Set textContent manually. Since lit-html doesn't dirty check against
         // actual DOM, but again previous part values, this modification should
         // persist through the next render with the same value.
         text.textContent = 'bbb';

--- a/src/test/test-helpers.ts
+++ b/src/test/test-helpers.ts
@@ -1,0 +1,16 @@
+/**
+ * @license
+ * Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+export const stripExpressionDelimeters = (html: string) =>
+    html.replace(/<!---->/g, '');

--- a/test/shady.html
+++ b/test/shady.html
@@ -4,11 +4,11 @@
     <script>
       window.ShadyDOM = {force: true};
     </script>
-    <script src="../node_modules/babel-polyfill/dist/polyfill.min.js"></script>
     <script src="../node_modules/wct-browser-legacy/browser.js"></script>
+    <script src="../node_modules/@webcomponents/template/template.js"></script>
+    <script src="../node_modules/babel-polyfill/dist/polyfill.min.js"></script>
     <script src="../node_modules/@webcomponents/shadydom/shadydom.min.js"></script>
     <script src="../node_modules/@webcomponents/shadycss/scoping-shim.min.js"></script>
-    <script src="../node_modules/@webcomponents/template/template.js"></script>
   </head>
   <body>
     <script type="module" src="./lib/shady-render_test.js"></script>

--- a/test/shady.html
+++ b/test/shady.html
@@ -4,11 +4,11 @@
     <script>
       window.ShadyDOM = {force: true};
     </script>
+    <script src="../node_modules/babel-polyfill/dist/polyfill.min.js"></script>
     <script src="../node_modules/wct-browser-legacy/browser.js"></script>
     <script src="../node_modules/@webcomponents/shadydom/shadydom.min.js"></script>
     <script src="../node_modules/@webcomponents/shadycss/scoping-shim.min.js"></script>
     <script src="../node_modules/@webcomponents/template/template.js"></script>
-    <script src="../node_modules/babel-polyfill/dist/polyfill.min.js"></script>
   </head>
   <body>
     <script type="module" src="./lib/shady-render_test.js"></script>


### PR DESCRIPTION
This PR uses comment nodes in templates, but replaces them with text nodes during initial cloning to continue to support all the previous binding positions. That's why tests don't have to change much compared to #202.

I added a test of a binding that requires new placeholder node generation in style tags to ensure that style bindings still work.