### PR TITLE
fixes invalidCharacter error in Edge

### DIFF
--- a/src/lit-html.ts
+++ b/src/lit-html.ts
@@ -312,8 +312,20 @@ export class Template {
           // Find the attribute name
           const attributeNameInPart =
               lastAttributeNameRegex.exec(stringForPart)![1];
-          // Find the corresponding attribute
-          const attribute = attributes.getNamedItem(attributeNameInPart);
+
+          let attribute: { name: string, value: any };
+
+          try {
+            // Find the corresponding attribute
+            attribute = attributes.getNamedItem(attributeNameInPart);
+          } catch(e) {
+            // mimic namedNodeMap item when not supported
+            attribute = {
+              name: attributeNameInPart,
+              value: node.getAttribute(attributeNameInPart)
+            };
+          }
+
           const stringsForAttributeValue = attribute.value.split(markerRegex);
           this.parts.push(new TemplatePart(
               'attribute',

--- a/src/lit-html.ts
+++ b/src/lit-html.ts
@@ -318,7 +318,7 @@ export class Template {
           try {
             // Find the corresponding attribute
             attribute = attributes.getNamedItem(attributeNameInPart);
-          } catch(e) {
+          } catch (e) {
             // mimic namedNodeMap item when not supported
             attribute = {
               name: attributeNameInPart,

--- a/src/test/lib/lit-extended_test.ts
+++ b/src/test/lib/lit-extended_test.ts
@@ -52,7 +52,7 @@ suite('lit-extended', () => {
     });
 
     test('renders a boolean attribute as an empty string when truthy', () => {
-      let t = (value: any) => html`<div foo?="${value}"></div>`;
+      const t = (value: any) => html`<div foo?="${value}"></div>`;
 
       render(t(true), container);
       assert.equal(container.innerHTML, '<div foo=""></div>');
@@ -65,7 +65,7 @@ suite('lit-extended', () => {
     });
 
     test('removes a boolean attribute when falsey', () => {
-      let t = (value: any) => html`<div foo?="${value}"></div>`;
+      const t = (value: any) => html`<div foo?="${value}"></div>`;
 
       render(t(false), container);
       assert.equal(container.innerHTML, '<div></div>');


### PR DESCRIPTION
Background: 

attributes created with special attribute character will not be processed in Edge. This commit will allow attempt to `attributes.getNamedItem` and if that fails fall back to `node.getAttribute` instead.

fixes issue #295 