### PR TITLE
Makes EventPart more efficiently update

### DIFF
--- a/src/lib/lit-extended.ts
+++ b/src/lib/lit-extended.ts
@@ -144,17 +144,22 @@ export class EventPart implements Part {
 
   setValue(value: any): void {
     const listener = getValue(this, value);
-    const previous = this._listener;
-    if (listener === previous) {
+    if (listener === this._listener) {
       return;
     }
-
-    this._listener = listener;
-    if (previous != null) {
-      this.element.removeEventListener(this.eventName, previous);
+    if (listener == null) {
+      this.element.removeEventListener(this.eventName, this);
+    } else if (this._listener == null) {
+      this.element.addEventListener(this.eventName, this);
     }
-    if (listener != null) {
-      this.element.addEventListener(this.eventName, listener);
+    this._listener = listener;
+  }
+
+  handleEvent(event: Event) {
+    if (typeof this._listener === 'function') {
+      this._listener.call(this.element, event);
+    } else if (typeof this._listener.handleEvent === 'function') {
+      this._listener.handleEvent(event);
     }
   }
 }

--- a/src/test/lib/lit-extended_test.ts
+++ b/src/test/lib/lit-extended_test.ts
@@ -203,6 +203,36 @@ suite('lit-extended', () => {
       assert.equal(count2, 1);
     });
 
+    test('allows updating event listener without extra calls to remove/addEventListener', () => {
+      let listener: Function|null;
+      const t = () => html`<div on-click=${listener}></div>`;
+      render(t(), container);
+      const div = container.firstChild as HTMLElement;
+      let addCount = 0;
+      let removeCount = 0;
+      div.addEventListener = () => addCount++;
+      div.removeEventListener = () => removeCount++;
+      listener = () => {};
+      render(t(), container);
+      assert.equal(addCount, 1);
+      assert.equal(removeCount, 0);
+      listener = () => {};
+      assert.equal(addCount, 1);
+      assert.equal(removeCount, 0);
+      listener = null;
+      render(t(), container);
+      assert.equal(addCount, 1);
+      assert.equal(removeCount, 1);
+      listener = () => {};
+      render(t(), container);
+      assert.equal(addCount, 2);
+      assert.equal(removeCount, 1);
+      listener = () => {};
+      render(t(), container);
+      assert.equal(addCount, 2);
+      assert.equal(removeCount, 1);
+    });
+
     test('removes event listeners', () => {
       let target;
       let listener: any = (e: any) => target = e.target;


### PR DESCRIPTION
Fixes #306. Instead of calling add/removeEventListener whenever an EventPart's listener changes, installs the listener 1x and stores/calls the user's method, updating it via a simple property set when needed.

Note, this uses a previously committed method of updating the EventPart event listener.