### PR TITLE
IE11 does not import empty text nodes. This adds text node markers an…

### DIFF
--- a/src/test/lib/lit-extended_test.ts
+++ b/src/test/lib/lit-extended_test.ts
@@ -52,7 +52,7 @@ suite('lit-extended', () => {
     });
 
     test('renders a boolean attribute as an empty string when truthy', () => {
-      let t = (value: any) => html`<div foo?="${value}"></div>`;
+      const t = (value: any) => html`<div foo?="${value}"></div>`;
 
       render(t(true), container);
       assert.equal(container.innerHTML, '<div foo=""></div>');
@@ -65,7 +65,7 @@ suite('lit-extended', () => {
     });
 
     test('removes a boolean attribute when falsey', () => {
-      let t = (value: any) => html`<div foo?="${value}"></div>`;
+      const t = (value: any) => html`<div foo?="${value}"></div>`;
 
       render(t(false), container);
       assert.equal(container.innerHTML, '<div></div>');


### PR DESCRIPTION
…d then removes them as part of the content cloning and importing. #201