### PR TITLE
IE11 Support

### DIFF
--- a/src/test/lib/lit-extended_test.ts
+++ b/src/test/lib/lit-extended_test.ts
@@ -52,7 +52,7 @@ suite('lit-extended', () => {
     });
 
     test('renders a boolean attribute as an empty string when truthy', () => {
-      let t = (value: any) => html`<div foo?="${value}"></div>`;
+      const t = (value: any) => html`<div foo?="${value}"></div>`;
 
       render(t(true), container);
       assert.equal(container.innerHTML, '<div foo=""></div>');
@@ -65,7 +65,7 @@ suite('lit-extended', () => {
     });
 
     test('removes a boolean attribute when falsey', () => {
-      let t = (value: any) => html`<div foo?="${value}"></div>`;
+      const t = (value: any) => html`<div foo?="${value}"></div>`;
 
       render(t(false), container);
       assert.equal(container.innerHTML, '<div></div>');

--- a/test/shady.html
+++ b/test/shady.html
@@ -5,10 +5,10 @@
       window.ShadyDOM = {force: true};
     </script>
     <script src="../node_modules/wct-browser-legacy/browser.js"></script>
-    <script src="../node_modules/@webcomponents/shadydom/shadydom.min.js"></script>
-    <script src="../node_modules/@webcomponents/shadycss/scoping-shim.min.js"></script>
     <script src="../node_modules/@webcomponents/template/template.js"></script>
     <script src="../node_modules/babel-polyfill/dist/polyfill.min.js"></script>
+    <script src="../node_modules/@webcomponents/shadydom/shadydom.min.js"></script>
+    <script src="../node_modules/@webcomponents/shadycss/scoping-shim.min.js"></script>
   </head>
   <body>
     <script type="module" src="./lib/shady-render_test.js"></script>


### PR DESCRIPTION
IE11 does not import empty text nodes. This adds text node markers and then removes them as part of the content cloning and importing. #201 


I understand there is already an IE11 Support #267 PR opened, however this one uses the already existing marker system in lit-html does not have the side effect of removing comments.