### PR TITLE
Add test that expressions in <style> don’t corrupt textContent

### DIFF
--- a/src/test/lit-html_test.ts
+++ b/src/test/lit-html_test.ts
@@ -489,6 +489,11 @@ suite('lit-html', () => {
           `);
       });
 
+      test('renders no comments inside textContent', () => {
+        render(html`<style>${''}</style>`, container);
+        assert.equal(container.firstElementChild!.textContent, '');
+      });
+
       test('renders a combination of stuff', () => {
         render(html`
             <div foo="${'bar'}">


### PR DESCRIPTION
Similar to https://github.com/Polymer/lit-html/pull/313 but checks `.textContent`. instead of `.innerHTML`. This passes on all supported browsers.

cc @jridgewell 