### PR TITLE
Shady render fix

### DIFF
--- a/src/lib/modify-template.ts
+++ b/src/lib/modify-template.ts
@@ -85,7 +85,7 @@ const countNodes = (node: Node) => {
     count++;
   }
   return count;
-}
+};
 
 const nextActiveIndexInTemplateParts = (parts: TemplatePart[], startIndex: number = -1) => {
   for (let i = startIndex + 1; i < parts.length; i++) {
@@ -95,7 +95,7 @@ const nextActiveIndexInTemplateParts = (parts: TemplatePart[], startIndex: numbe
     }
   }
   return -1;
-}
+};
 
 /**
  * Inserts the given node into the Template, optionally before the given
@@ -110,8 +110,6 @@ export function insertNodeIntoTemplate(
   if (refNode === null || refNode === undefined) {
     content.appendChild(node);
     return;
-  } else if (!content.contains(refNode)) {
-    throw 'Reference node must be inside template.';
   }
   const walker = document.createTreeWalker(
       content,

--- a/src/lib/modify-template.ts
+++ b/src/lib/modify-template.ts
@@ -1,0 +1,82 @@
+/**
+ * @license
+ * Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+import {Template, TemplatePart} from '../lit-html.js';
+
+export function removeNodesFromTemplate(template: Template, nodes: Node[]) {
+  const {element: {content}, parts} = template;
+  const walker = document.createTreeWalker(
+    content,
+    NodeFilter.SHOW_ELEMENT | NodeFilter.SHOW_COMMENT |
+        NodeFilter.SHOW_TEXT,
+    null as any,
+    false);
+  let nodesIndex = 0;
+  let nodeToFind = nodes[nodesIndex];
+  let partIndex = 0;
+  let part = parts[partIndex];
+  let partDelta = 0;
+  let disableUntil = 0;
+  const nodesToRemove: Node[] = [];
+  let index = -1;
+  while (walker.nextNode()) {
+    index++;
+    const node = walker.currentNode as Element;
+    if (node === nodeToFind) {
+      nodeToFind = nodes[++nodesIndex];
+      const removeCount = node.childNodes.length + 1;
+      disableUntil = index + removeCount;
+      partDelta -= removeCount;
+      nodesToRemove.push(node);
+    }
+    // adjust part indices or disable parts.
+    while (part && part.index === index) {
+      if (index < disableUntil) {
+        part.index = -1;
+      } else {
+        part.index += partDelta;
+      }
+      part = parts[++partIndex];
+    }
+  }
+  nodesToRemove.forEach((n) => n.parentNode!.removeChild(n));
+}
+
+export function insertNodeIntoTemplate(template: Template, node: Node, refNode: Node|null = null) {
+  const {element: {content}, parts} = template;
+  const walker = document.createTreeWalker(
+    content,
+    NodeFilter.SHOW_ELEMENT | NodeFilter.SHOW_COMMENT |
+        NodeFilter.SHOW_TEXT,
+    null as any,
+    false);
+  let partIndex = 0;
+  let part = parts[partIndex];
+  let partDelta = 0;
+  let index = -1;
+  while (walker.nextNode()) {
+    index++;
+    const currentNode = walker.currentNode as Element;
+    if (currentNode === refNode) {
+      content.insertBefore(node, refNode);
+      partDelta = 1 + node.childNodes.length;
+    }
+    while (part && (part.index === index || part.index < 0)) {
+      if (part.index >= 0) {
+        part.index += partDelta;
+      }
+      part = parts[++partIndex];
+    }
+  }
+}

--- a/src/lib/modify-template.ts
+++ b/src/lib/modify-template.ts
@@ -12,7 +12,7 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {Template, TemplatePart} from '../lit-html.js';
+import {Template} from '../lit-html.js';
 
 export function removeNodesFromTemplate(template: Template, nodes: Node[]) {
   const {element: {content}, parts} = template;

--- a/src/lib/shady-render.ts
+++ b/src/lib/shady-render.ts
@@ -12,7 +12,8 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {render as baseRender, Template, templateCaches, TemplateResult} from '../lit-html.js';
+import {render as baseRender, Template, templateCaches, TemplateResult, renderToDom} from '../lit-html.js';
+import {removeNodesFromTemplate, insertNodeIntoTemplate} from './modify-template.js';
 
 export {html, svg, TemplateResult} from '../lit-html.js';
 
@@ -22,31 +23,86 @@ declare global {
   }
 }
 
+/**
+ * Template factory which scopes template DOM using ShadyCSS.
+ * @param scopeName {string}
+ */
 const shadyTemplateFactory = (scopeName: string) =>
     (result: TemplateResult) => {
-      const cacheKey = `${result.type}--${scopeName}`;
-      let templateCache = templateCaches.get(cacheKey);
-      if (templateCache === undefined) {
-        templateCache = new Map<TemplateStringsArray, Template>();
-        templateCaches.set(cacheKey, templateCache);
-      }
-      let template = templateCache.get(result.strings);
-      if (template === undefined) {
-        const element = result.getTemplateElement();
+  const cacheKey = `${result.type}--${scopeName}`;
+  let templateCache = templateCaches.get(cacheKey);
+  if (templateCache === undefined) {
+    templateCache = new Map<TemplateStringsArray, Template>();
+    templateCaches.set(cacheKey, templateCache);
+  }
+  let template = templateCache.get(result.strings);
+  if (template === undefined) {
+    const element = result.getTemplateElement();
+    window.ShadyCSS.prepareTemplateDom(element, scopeName);
+    template = new Template(result, element);
+    templateCache.set(result.strings, template);
+  }
+  return template;
+};
 
-        if (typeof window.ShadyCSS === 'object') {
-          window.ShadyCSS.prepareTemplate(element, scopeName);
-        }
+const TEMPLATE_TYPES = ['html', 'svg'];
+function removeStylesFromLitTemplates(scopeName: string) {
+  TEMPLATE_TYPES.forEach((type) => {
+    const templates = templateCaches.get(`${type}--${scopeName}`);
+    if (templates) {
+      templates.forEach((template) => {
+        const {element: {content}} = template;
+        const styles = content.querySelectorAll('style');
+        removeNodesFromTemplate(template, Array.from(styles));
+      });
+    }
+  });
+}
 
-        template = new Template(result, element);
-        templateCache.set(result.strings, template);
-      }
-      return template;
-    };
+const needsShadyStyling = window.ShadyCSS && (!window.ShadyCSS.nativeShadow ||
+  window.ShadyCSS.ApplyShim);
+
+const shadyRenderSet = new Set<string>();
+
+function hostForNode(node: Node) {
+  return node.nodeType === Node.DOCUMENT_FRAGMENT_NODE && (node as ShadowRoot).host
+}
 
 export function render(
     result: TemplateResult,
     container: Element|DocumentFragment,
     scopeName: string) {
-  return baseRender(result, container, shadyTemplateFactory(scopeName));
+  const host = hostForNode(container);
+  if (needsShadyStyling && host) {
+    const templateFactory = shadyTemplateFactory(scopeName);
+    const renderer = (container: Element|DocumentFragment, fragment: DocumentFragment) => {
+      if (!shadyRenderSet.has(scopeName)) {
+        shadyRenderSet.add(scopeName);
+        const styleTemplate = document.createElement('template');
+        Array.from(fragment.querySelectorAll('style')).forEach((s: Element) => {
+          styleTemplate.content.appendChild(s);
+        });
+        window.ShadyCSS.prepareTemplateStyles(styleTemplate, scopeName);
+        // fix templates.
+        removeStylesFromLitTemplates(scopeName);
+        // ApplyShim case.
+        if (window.ShadyCSS.nativeShadow) {
+          const style = styleTemplate.content.querySelector('style');
+          if (style) {
+            // insert style into rendered fragment
+            fragment.insertBefore(style, fragment.firstChild);
+            // insert into lit-template (for subsequent renders)
+            const template = templateFactory(result);
+            insertNodeIntoTemplate(template, style.cloneNode(true),
+                template.element.content.firstChild);
+          }
+        }
+      }
+      window.ShadyCSS.styleElement(host);
+      renderToDom(container, fragment);
+    }
+    return baseRender(result, container, templateFactory, renderer);
+  } else {
+    return baseRender(result, container);
+  }
 }

--- a/src/lib/shady-render.ts
+++ b/src/lib/shady-render.ts
@@ -59,9 +59,6 @@ function removeStylesFromLitTemplates(scopeName: string) {
   });
 }
 
-const needsShadyStyling = window.ShadyCSS && (!window.ShadyCSS.nativeShadow ||
-  window.ShadyCSS.ApplyShim);
-
 const shadyRenderSet = new Set<string>();
 
 function hostForNode(node: Node) {
@@ -73,7 +70,7 @@ export function render(
     container: Element|DocumentFragment,
     scopeName: string) {
   const host = hostForNode(container);
-  if (needsShadyStyling && host) {
+  if (host && typeof window.ShadyCSS === 'object') {
     const templateFactory = shadyTemplateFactory(scopeName);
     const renderer = (container: Element|DocumentFragment, fragment: DocumentFragment) => {
       if (!shadyRenderSet.has(scopeName)) {

--- a/src/lit-html.ts
+++ b/src/lit-html.ts
@@ -263,7 +263,7 @@ export class TemplatePart {
   }
 }
 
-const isTemplatePartActive = (part: TemplatePart) => part.index !== -1;
+export const isTemplatePartActive = (part: TemplatePart) => part.index !== -1;
 
 /**
  * An updateable Template that tracks the location of dynamic parts.

--- a/src/lit-html.ts
+++ b/src/lit-html.ts
@@ -140,11 +140,7 @@ export function defaultTemplateFactory(result: TemplateResult) {
   return template;
 }
 
-export function renderToDom(container: Element|DocumentFragment, fragment: DocumentFragment) {
-  removeNodes(container, container.firstChild);
-  container.appendChild(fragment);
-}
-type TemplateContainer = (Element|DocumentFragment)&{
+export type TemplateContainer = (Element|DocumentFragment)&{
   __templateInstance?: TemplateInstance;
 };
 
@@ -165,8 +161,7 @@ type TemplateContainer = (Element|DocumentFragment)&{
 export function render(
     result: TemplateResult,
     container: Element|DocumentFragment,
-    templateFactory: TemplateFactory = defaultTemplateFactory,
-    renderDom: Function = renderToDom
+    templateFactory: TemplateFactory = defaultTemplateFactory
   ) {
   const template = templateFactory(result);
   let instance = (container as TemplateContainer).__templateInstance;
@@ -186,7 +181,8 @@ export function render(
   const fragment = instance._clone();
   instance.update(result.values);
 
-  renderDom(container, fragment);
+  removeNodes(container, container.firstChild);
+  container.appendChild(fragment);
 }
 
 /**
@@ -266,6 +262,8 @@ export class TemplatePart {
       public rawName?: string, public strings?: string[]) {
   }
 }
+
+const isTemplatePartActive = (part: TemplatePart) => part.index !== -1;
 
 /**
  * An updateable Template that tracks the location of dynamic parts.
@@ -757,7 +755,8 @@ export class TemplateInstance {
       let index = -1;
       for (let i = 0; i < parts.length; i++) {
         const part = parts[i];
-        const partActive = (part.index >= 0);
+        const partActive = isTemplatePartActive(part);
+        // An inactive part has no coresponding Template node.
         if (partActive) {
           while (index < part.index) {
             index++;

--- a/src/test/lib/modify-template_test.ts
+++ b/src/test/lib/modify-template_test.ts
@@ -1,0 +1,114 @@
+/**
+ * @license
+ * Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+/// <reference path="../../../node_modules/@types/mocha/index.d.ts" />
+/// <reference path="../../../node_modules/@types/chai/index.d.ts" />
+
+import {removeNodesFromTemplate, insertNodeIntoTemplate} from '../../lib/modify-template.js';
+
+import {html, render, defaultTemplateFactory as templateFactory} from '../../lit-html.js';
+
+import {stripExpressionDelimeters} from '../test-helpers.js';
+
+const assert = chai.assert;
+
+suite('add/remove nodes from template', () => {
+
+  let container: HTMLElement;
+
+  setup(() => {
+    container = document.createElement('div');
+  });
+
+  test('inserting nodes into template between parts renders/updates result', () => {
+    const getResult = (a: any, b: any, c: any) => html`
+        <div foo="${a}">
+          ${b}
+          <p>${c}</p>
+        </div>`;
+    const result = getResult('bar', 'baz', 'qux');
+    const template = templateFactory(result);
+    const div1 = document.createElement('div');
+    div1.innerHTML = '<span>1</span>';
+    insertNodeIntoTemplate(template, div1, template.element.content.firstChild);
+    const div2 = document.createElement('div');
+    div2.innerHTML = '<span>2</span>';
+    insertNodeIntoTemplate(template, div2, template.element.content.querySelector('p'));
+    const div3 = document.createElement('div');
+    div3.innerHTML = '<span>3</span>';
+    insertNodeIntoTemplate(template, div3);
+    render(result, container);
+    assert.equal(stripExpressionDelimeters(container.innerHTML), `<div><span>1</span></div>
+        <div foo="bar">
+          baz
+          <div><span>2</span></div><p>qux</p>
+        </div><div><span>3</span></div>`);
+    render(getResult('a', 'b', 'c'), container);
+    assert.equal(stripExpressionDelimeters(container.innerHTML), `<div><span>1</span></div>
+        <div foo="a">
+          b
+          <div><span>2</span></div><p>c</p>
+        </div><div><span>3</span></div>`);
+  });
+
+  test('removing nodes in template between parts renders/updates result', () => {
+    const getResult = (a: any, b: any, c: any) => html`<div name="remove"><span>remove</span></div>
+        <div foo="${a}"><div name="remove"><span>remove</span></div>
+          ${b}
+          <div name="remove"><span name="remove">remove</span></div><p>${c}</p>
+        </div><div name="remove"><span name="remove"><span name="remove">remove</span></span></div>`;
+    const result = getResult('bar', 'baz', 'qux');
+    const template = templateFactory(result);
+    const nodeSet = new Set(Array.from(template.element.content.querySelectorAll('[name="remove"]')));
+    removeNodesFromTemplate(template, nodeSet);
+    render(result, container);
+    assert.equal(stripExpressionDelimeters(container.innerHTML), `
+        <div foo="bar">
+          baz
+          <p>qux</p>
+        </div>`);
+    render(getResult('a', 'b', 'c'), container);
+    assert.equal(stripExpressionDelimeters(container.innerHTML), `
+        <div foo="a">
+          b
+          <p>c</p>
+        </div>`);
+  });
+
+  test('removing nodes in template containing parts renders/updates result', () => {
+    const getResult = (a: any, b: any, c: any, r1: any, r2: any, r3: any) =>
+        html`<div name="remove"><span>${r1}</span></div>
+        <div foo="${a}"><div name="remove"><span>${r2}</span></div>
+          ${b}
+          <div name="remove"><span name="remove">${r3}</span></div><p>${c}</p>
+        </div><div name="remove"><span name="remove"><span name="remove">remove</span></span></div>`;
+    const result = getResult('bar', 'baz', 'qux', 'r1', 'r2', 'r3');
+    const template = templateFactory(result);
+    const nodeSet = new Set(Array.from(template.element.content.querySelectorAll('[name="remove"]')));
+    removeNodesFromTemplate(template, nodeSet);
+    render(result, container);
+    assert.equal(stripExpressionDelimeters(container.innerHTML), `
+        <div foo="bar">
+          baz
+          <p>qux</p>
+        </div>`);
+    render(getResult('a', 'b', 'c', 'rr1', 'rr2', 'rr3'), container);
+    assert.equal(stripExpressionDelimeters(container.innerHTML), `
+        <div foo="a">
+          b
+          <p>c</p>
+        </div>`);
+  });
+
+});

--- a/src/test/lib/shady-render_test.ts
+++ b/src/test/lib/shady-render_test.ts
@@ -13,7 +13,6 @@
  */
 
 import {html, render} from '../../lib/shady-render.js';
-import {stripExpressionDelimeters} from '../test-helpers.js';
 
 
 /// <reference path="../../node_modules/@types/mocha/index.d.ts" />

--- a/src/test/lib/shady-render_test.ts
+++ b/src/test/lib/shady-render_test.ts
@@ -13,6 +13,7 @@
  */
 
 import {html, render} from '../../lib/shady-render.js';
+import {stripExpressionDelimeters} from '../test-helpers.js';
 
 
 /// <reference path="../../node_modules/@types/mocha/index.d.ts" />
@@ -84,6 +85,35 @@ suite('shady-render', () => {
     const div = (container.shadowRoot  as DocumentFragment).querySelector('div');
     assert.equal(getComputedStyle(div as HTMLElement).getPropertyValue('border-top-width').trim(), '1px');
     renderTemplate('2px solid black');
+    assert.equal(getComputedStyle(div as HTMLElement).getPropertyValue('border-top-width').trim(), '1px');
+    document.body.removeChild(container);
+  });
+
+  test('parts around styles with parts render/update', () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    container.attachShadow({mode: 'open'});
+    const renderTemplate = (border: string, a: string, b: string, c: string) => {
+      render(html`<div id="a">${a}</div>
+        <style>
+          div {
+            border: ${border};
+          }
+        </style><div id="b">${b}</div>
+        <div id="c">${c}</div>
+      `, container.shadowRoot as DocumentFragment, 'scope-3a');
+    }
+    renderTemplate('1px solid black', 'a', 'b', 'c');
+    const shadowRoot = container.shadowRoot as DocumentFragment;
+    assert.equal(shadowRoot.querySelector('#a')!.textContent, `a`);
+    assert.equal(shadowRoot.querySelector('#b')!.textContent, `b`);
+    assert.equal(shadowRoot.querySelector('#c')!.textContent, `c`);
+    const div = shadowRoot.querySelector('div');
+    assert.equal(getComputedStyle(div as HTMLElement).getPropertyValue('border-top-width').trim(), '1px');
+    renderTemplate('2px solid black', 'a1', 'b1', 'c1');
+    assert.equal(shadowRoot.querySelector('#a')!.textContent, `a1`);
+    assert.equal(shadowRoot.querySelector('#b')!.textContent, `b1`);
+    assert.equal(shadowRoot.querySelector('#c')!.textContent, `c1`);
     assert.equal(getComputedStyle(div as HTMLElement).getPropertyValue('border-top-width').trim(), '1px');
     document.body.removeChild(container);
   });

--- a/src/test/lib/shady-render_test.ts
+++ b/src/test/lib/shady-render_test.ts
@@ -33,9 +33,9 @@ suite('shady-render', () => {
         }
       </style>
       <div>Testing...</div>
-    `, container.shadowRoot as DocumentFragment, 'scope-1');
-    const div = (container.shadowRoot  as DocumentFragment).querySelector('div');
-    assert.equal(getComputedStyle(div as HTMLElement).getPropertyValue('border-top-width').trim(), '2px');
+    `, container.shadowRoot!, 'scope-1');
+    const div = (container.shadowRoot!).querySelector('div');
+    assert.equal(getComputedStyle(div!).getPropertyValue('border-top-width').trim(), '2px');
     document.body.removeChild(container);
   });
 
@@ -58,11 +58,11 @@ suite('shady-render', () => {
         </style>
         <span>Testing...</span>
       `}
-    `, container.shadowRoot as DocumentFragment, 'scope-2');
-    const div = (container.shadowRoot  as DocumentFragment).querySelector('div');
-    assert.equal(getComputedStyle(div as HTMLElement).getPropertyValue('border-top-width').trim(), '4px');
-    const span = (container.shadowRoot  as DocumentFragment).querySelector('span');
-    assert.equal(getComputedStyle(span as HTMLElement).getPropertyValue('border-top-width').trim(), '5px');
+    `, container.shadowRoot!, 'scope-2');
+    const div = (container.shadowRoot!).querySelector('div');
+    assert.equal(getComputedStyle(div!).getPropertyValue('border-top-width').trim(), '4px');
+    const span = (container.shadowRoot!).querySelector('span');
+    assert.equal(getComputedStyle(span!).getPropertyValue('border-top-width').trim(), '5px');
     document.body.removeChild(container);
   });
 
@@ -81,10 +81,10 @@ suite('shady-render', () => {
       `, container.shadowRoot as DocumentFragment, 'scope-3');
     }
     renderTemplate('1px solid black');
-    const div = (container.shadowRoot  as DocumentFragment).querySelector('div');
-    assert.equal(getComputedStyle(div as HTMLElement).getPropertyValue('border-top-width').trim(), '1px');
+    const div = (container.shadowRoot!).querySelector('div');
+    assert.equal(getComputedStyle(div!).getPropertyValue('border-top-width').trim(), '1px');
     renderTemplate('2px solid black');
-    assert.equal(getComputedStyle(div as HTMLElement).getPropertyValue('border-top-width').trim(), '1px');
+    assert.equal(getComputedStyle(div!).getPropertyValue('border-top-width').trim(), '1px');
     document.body.removeChild(container);
   });
 
@@ -100,20 +100,20 @@ suite('shady-render', () => {
           }
         </style><div id="b">${b}</div>
         <div id="c">${c}</div>
-      `, container.shadowRoot as DocumentFragment, 'scope-3a');
+      `, container.shadowRoot!, 'scope-3a');
     }
     renderTemplate('1px solid black', 'a', 'b', 'c');
-    const shadowRoot = container.shadowRoot as DocumentFragment;
+    const shadowRoot = container.shadowRoot!;
     assert.equal(shadowRoot.querySelector('#a')!.textContent, `a`);
     assert.equal(shadowRoot.querySelector('#b')!.textContent, `b`);
     assert.equal(shadowRoot.querySelector('#c')!.textContent, `c`);
     const div = shadowRoot.querySelector('div');
-    assert.equal(getComputedStyle(div as HTMLElement).getPropertyValue('border-top-width').trim(), '1px');
+    assert.equal(getComputedStyle(div!).getPropertyValue('border-top-width').trim(), '1px');
     renderTemplate('2px solid black', 'a1', 'b1', 'c1');
     assert.equal(shadowRoot.querySelector('#a')!.textContent, `a1`);
     assert.equal(shadowRoot.querySelector('#b')!.textContent, `b1`);
     assert.equal(shadowRoot.querySelector('#c')!.textContent, `c1`);
-    assert.equal(getComputedStyle(div as HTMLElement).getPropertyValue('border-top-width').trim(), '1px');
+    assert.equal(getComputedStyle(div!).getPropertyValue('border-top-width').trim(), '1px');
     document.body.removeChild(container);
   });
 
@@ -131,9 +131,9 @@ suite('shady-render', () => {
         }
       </style>
       <div>Testing...</div>
-    `, container.shadowRoot as DocumentFragment, 'scope-4');
-    const div = (container.shadowRoot  as DocumentFragment).querySelector('div');
-    assert.equal(getComputedStyle(div as HTMLElement).getPropertyValue('border-top-width').trim(), '2px');
+    `, container.shadowRoot!, 'scope-4');
+    const div = (container.shadowRoot!).querySelector('div');
+    assert.equal(getComputedStyle(div!).getPropertyValue('border-top-width').trim(), '2px');
     document.body.removeChild(container);
   });
 
@@ -154,9 +154,9 @@ suite('shady-render', () => {
         }
       </style>
       <div>Testing...</div>
-    `, container.shadowRoot as DocumentFragment, 'scope-5');
-    const div = (container.shadowRoot  as DocumentFragment).querySelector('div');
-    const computedStyle = getComputedStyle(div as HTMLElement);
+    `, container.shadowRoot!, 'scope-5');
+    const div = (container.shadowRoot!).querySelector('div');
+    const computedStyle = getComputedStyle(div!);
     assert.equal(computedStyle.getPropertyValue('border-top-width').trim(), '3px');
     assert.equal(computedStyle.getPropertyValue('padding-top').trim(), '4px');
     document.body.removeChild(container);

--- a/test/index.html
+++ b/test/index.html
@@ -13,6 +13,7 @@
     <script type="module" src="./lib/unsafe-html_test.js"></script>
     <script type="module" src="./lib/async-append_test.js"></script>
     <script type="module" src="./lib/async-replace_test.js"></script>
+    <script type="module" src="./lib/modify-template_test.js"></script>
     <script>
       WCT.loadSuites([
         'shady.html',

--- a/test/index.html
+++ b/test/index.html
@@ -16,6 +16,8 @@
     <script>
       WCT.loadSuites([
         'shady.html',
+        'shady.html?shadydom=true',
+        'shady.html?shadydom=true&shimscssproperties=true',
       ]);
     </script>
   </body>

--- a/test/shady.html
+++ b/test/shady.html
@@ -2,13 +2,19 @@
 <html>
   <head>
     <script>
-      window.ShadyDOM = {force: true};
+      if (location.search.match('shadydom')) {
+        window.ShadyDOM = {force: true};
+      }
+      if (location.search.match('shimcssproperties')) {
+        window.ShadyCSS = {shimcssproperties: true};
+      }
     </script>
     <script src="../node_modules/wct-browser-legacy/browser.js"></script>
     <script src="../node_modules/@webcomponents/template/template.js"></script>
     <script src="../node_modules/babel-polyfill/dist/polyfill.min.js"></script>
     <script src="../node_modules/@webcomponents/shadydom/shadydom.min.js"></script>
     <script src="../node_modules/@webcomponents/shadycss/scoping-shim.min.js"></script>
+    <script src="../node_modules/@webcomponents/shadycss/apply-shim.min.js"></script>
   </head>
   <body>
     <script type="module" src="./lib/shady-render_test.js"></script>


### PR DESCRIPTION
Fixes #326 by imposing a limitation that styles for a scope name can only be supplied in the initial render of that shadowRoot. This is required because `ShadyCSS` can only prepare styles for a scope once to properly track styles in that scope and process custom properties when polyfilled and @apply.

Styles are processed based on initial scope rendering, but templated DOM within a scope will always be correctly given a scoping class. 

Note that styles in the first render of a scope can contain lit parts. This is useful for one-time bindings.

**Warning:** merge only after [this ShadyCSS PR](https://github.com/webcomponents/shadycss/pull/183) is merged and released.