### PR TITLE
Render initial undefined values

### DIFF
--- a/src/lit-html.ts
+++ b/src/lit-html.ts
@@ -501,6 +501,11 @@ export class AttributePart implements MultiPart {
   }
 
   protected _equalToPreviousValues(values: any[], startIndex: number) {
+    if (this._previousValues.length === 0) {
+      // Always return false for the initial render, otherwise parts with an
+      // undefined value won't get rendered.
+      return false;
+    }
     for (let i = startIndex; i < startIndex + this.size; i++) {
       if (this._previousValues[i] !== values[i] ||
           !isPrimitiveValue(values[i])) {

--- a/src/test/lit-html_test.ts
+++ b/src/test/lit-html_test.ts
@@ -196,6 +196,11 @@ suite('lit-html', () => {
         assert.equal(stripExpressionDelimeters(container.innerHTML), '<div></div>');
       });
 
+      test('renders undefined in attributes', () => {
+        render(html`<div attribute="it's ${undefined}"></div>`, container);
+        assert.equal(stripExpressionDelimeters(container.innerHTML), '<div attribute="it\'s undefined"></div>');
+      });
+
       test('renders null', () => {
         render(html`<div>${null}</div>`, container);
         assert.equal(stripExpressionDelimeters(container.innerHTML), '<div></div>');


### PR DESCRIPTION
As mentioned in #375, if all values for an AttributePart or PropertyPart are `undefined`, the initial render will not set the attribute/property. See [this comment](https://github.com/Polymer/lit-html/issues/375#issuecomment-399745122) for an explanation as to why that's wrong.

Instead of adding an extra property to check for the initial render and introducing logic to update the property on the first render I simply added a check on the length of `this._previousValue`, as that array can only be empty for the initial render (the property is set to an empty array in the constructor; `setValue` always sets the property to a non-empty array).