### PR TITLE
Refactor AttributePart to only have a single value

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1357,16 +1357,10 @@
       "integrity": "sha512-U/j4nODWIq0U9v0ll48dj4U4YgTqsVeRt0LKei0GA10JUpnZnORoIByY5+7m9G6KWIAj2mT9KtuUOnn7u93VXg==",
       "dev": true
     },
-    "@webcomponents/template": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@webcomponents/template/-/template-1.3.1.tgz",
-      "integrity": "sha512-BYnF+2bPzWyiuAetU3XHjXNjIiMLzbw3YPBBb8/OEM/ZekdFJURiw/50vjd4j8OBzFemIHfpHgdIi2kwInyCww==",
-      "dev": true
-    },
     "@webcomponents/webcomponentsjs": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@webcomponents/webcomponentsjs/-/webcomponentsjs-2.0.2.tgz",
-      "integrity": "sha512-+3515t7jnWsx+mNRECwXbjXBM0DLCNB4uH4DSIbu7akIJn0tO2GZuLvZeBhXbRFQLfohN+2ZTWT44A6EtPhVqA==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@webcomponents/webcomponentsjs/-/webcomponentsjs-2.0.4.tgz",
+      "integrity": "sha512-wzPSTmwjAd/0oKW36Yi+cB/BmDrHhcHqGlbqqMjrbPIFkt5Mw7wtvEZQouCrQyBNnRquUhRnSWIBrRijHNBBKg==",
       "dev": true
     },
     "accepts": {
@@ -2048,17 +2042,6 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-undefined-to-void/-/babel-plugin-transform-undefined-to-void-6.10.0-alpha.f95869d4.tgz",
       "integrity": "sha1-F1oaMJDmFkA/jIGc3Ooa7LZlI7I=",
       "dev": true
-    },
-    "babel-polyfill": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
-      "integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "^6.26.0",
-        "core-js": "^2.5.0",
-        "regenerator-runtime": "^0.10.5"
-      }
     },
     "babel-preset-minify": {
       "version": "0.4.0-alpha.caaefb4c",
@@ -7387,12 +7370,6 @@
       "requires": {
         "regenerate": "^1.4.0"
       }
-    },
-    "regenerator-runtime": {
-      "version": "0.10.5",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
-      "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg=",
-      "dev": true
     },
     "regenerator-transform": {
       "version": "0.12.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,32 +5,31 @@
   "requires": true,
   "dependencies": {
     "@babel/code-frame": {
-      "version": "7.0.0-beta.51",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.51.tgz",
-      "integrity": "sha1-vXHZsZKvl435FYKdOdQJRFZDmgw=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-rc.1.tgz",
+      "integrity": "sha512-qhQo3GqwqMUv03SxxjcEkWtlkEDvFYrBKbJUn4Dtd9amC2cLkJ3me4iYUVSBbVXWbfbVRalEeVBHzX4aQYKnBg==",
       "dev": true,
       "requires": {
-        "@babel/highlight": "7.0.0-beta.51"
+        "@babel/highlight": "7.0.0-rc.1"
       }
     },
     "@babel/core": {
-      "version": "7.0.0-beta.51",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.0.0-beta.51.tgz",
-      "integrity": "sha1-DlS9a2OHNrKuWTwxpH8JaeKyuW0=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.0.0-rc.1.tgz",
+      "integrity": "sha512-CvuSsq+LFs9N4SJG8MnNPI0hnl913HK1OqG3NEfejOKo+JqtVuxpmAFyXIDogX2x668xqFKAW6EQiCIcUHklMg==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "7.0.0-beta.51",
-        "@babel/generator": "7.0.0-beta.51",
-        "@babel/helpers": "7.0.0-beta.51",
-        "@babel/parser": "7.0.0-beta.51",
-        "@babel/template": "7.0.0-beta.51",
-        "@babel/traverse": "7.0.0-beta.51",
-        "@babel/types": "7.0.0-beta.51",
+        "@babel/code-frame": "7.0.0-rc.1",
+        "@babel/generator": "7.0.0-rc.1",
+        "@babel/helpers": "7.0.0-rc.1",
+        "@babel/parser": "7.0.0-rc.1",
+        "@babel/template": "7.0.0-rc.1",
+        "@babel/traverse": "7.0.0-rc.1",
+        "@babel/types": "7.0.0-rc.1",
         "convert-source-map": "^1.1.0",
         "debug": "^3.1.0",
         "json5": "^0.5.0",
-        "lodash": "^4.17.5",
-        "micromatch": "^3.1.10",
+        "lodash": "^4.17.10",
         "resolve": "^1.3.2",
         "semver": "^5.4.1",
         "source-map": "^0.5.0"
@@ -45,14 +44,14 @@
       }
     },
     "@babel/generator": {
-      "version": "7.0.0-beta.51",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.51.tgz",
-      "integrity": "sha1-bHV1/952HQdIXgS67cA5LG2eMPY=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-rc.1.tgz",
+      "integrity": "sha512-Ak4n780/coo+L9GZUS7V/IGJilP11t4UoWl0J9cG3jso4KkDGQcqdx4Y6gJAiXng+sDfvzUmvWfM1hZwH82J0A==",
       "dev": true,
       "requires": {
-        "@babel/types": "7.0.0-beta.51",
+        "@babel/types": "7.0.0-rc.1",
         "jsesc": "^2.5.1",
-        "lodash": "^4.17.5",
+        "lodash": "^4.17.10",
         "source-map": "^0.5.0",
         "trim-right": "^1.0.1"
       },
@@ -66,33 +65,33 @@
       }
     },
     "@babel/helper-annotate-as-pure": {
-      "version": "7.0.0-beta.51",
-      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.0.0-beta.51.tgz",
-      "integrity": "sha1-OM95IL9fM4oif3VOKGtvut7gS1g=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.0.0-rc.1.tgz",
+      "integrity": "sha512-GOV2UExs9gAvSrZF4rcgocXXeLJplq2kL2AsCrn6DmGwMUEfo/KB7FhedN3X6cVh0gOqqKkVKXrz3Li1wQ84xQ==",
       "dev": true,
       "requires": {
-        "@babel/types": "7.0.0-beta.51"
+        "@babel/types": "7.0.0-rc.1"
       }
     },
     "@babel/helper-builder-binary-assignment-operator-visitor": {
-      "version": "7.0.0-beta.51",
-      "resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.0.0-beta.51.tgz",
-      "integrity": "sha1-ITP//j4vcVkeQhR7lHKRyirTkjc=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.0.0-rc.1.tgz",
+      "integrity": "sha512-O6/szesBinGoExLl01Qg2vb5FaOfifSilgL5GnCZLz5z3Pg9jRolN6rGzQAOa/K9Y01TAmDf1dC06AKQUv3x8g==",
       "dev": true,
       "requires": {
-        "@babel/helper-explode-assignable-expression": "7.0.0-beta.51",
-        "@babel/types": "7.0.0-beta.51"
+        "@babel/helper-explode-assignable-expression": "7.0.0-rc.1",
+        "@babel/types": "7.0.0-rc.1"
       }
     },
     "@babel/helper-call-delegate": {
-      "version": "7.0.0-beta.51",
-      "resolved": "https://registry.npmjs.org/@babel/helper-call-delegate/-/helper-call-delegate-7.0.0-beta.51.tgz",
-      "integrity": "sha1-BO1yfJfPBbyy/WRINzMasV1jyBk=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-call-delegate/-/helper-call-delegate-7.0.0-rc.1.tgz",
+      "integrity": "sha512-3Z+shHGJTQnc61RCFVrQ3OJRmyL8uk4dWCsP8kT7G4inxv/bs6/zLOipK21VMePGpjUA4tnKxJCevMtp9ko4pw==",
       "dev": true,
       "requires": {
-        "@babel/helper-hoist-variables": "7.0.0-beta.51",
-        "@babel/traverse": "7.0.0-beta.51",
-        "@babel/types": "7.0.0-beta.51"
+        "@babel/helper-hoist-variables": "7.0.0-rc.1",
+        "@babel/traverse": "7.0.0-rc.1",
+        "@babel/types": "7.0.0-rc.1"
       }
     },
     "@babel/helper-define-map": {
@@ -169,75 +168,75 @@
       }
     },
     "@babel/helper-explode-assignable-expression": {
-      "version": "7.0.0-beta.51",
-      "resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.0.0-beta.51.tgz",
-      "integrity": "sha1-mHUzKti11cmC+kgcuCtzFwPyzS0=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.0.0-rc.1.tgz",
+      "integrity": "sha512-hSa+oxKn9bfbc3Ob1U7QJsO++do2Xe8Ft640alRJpEQ3VWy7tL8ZB+2xqo0pgHKo7rITuSxERz72uZji8dTiWg==",
       "dev": true,
       "requires": {
-        "@babel/traverse": "7.0.0-beta.51",
-        "@babel/types": "7.0.0-beta.51"
+        "@babel/traverse": "7.0.0-rc.1",
+        "@babel/types": "7.0.0-rc.1"
       }
     },
     "@babel/helper-function-name": {
-      "version": "7.0.0-beta.51",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.51.tgz",
-      "integrity": "sha1-IbSHSiJ8+Z7K/MMKkDAtpaJkBWE=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-rc.1.tgz",
+      "integrity": "sha512-fDbWxdYYbFNzcI5jn3qsPxHI1UCXwvFk0kGytGce/FEBYEPXBqycKknC8Oqiub8DzGtmTcvnqcm/cl/qxzeuiQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-get-function-arity": "7.0.0-beta.51",
-        "@babel/template": "7.0.0-beta.51",
-        "@babel/types": "7.0.0-beta.51"
+        "@babel/helper-get-function-arity": "7.0.0-rc.1",
+        "@babel/template": "7.0.0-rc.1",
+        "@babel/types": "7.0.0-rc.1"
       }
     },
     "@babel/helper-get-function-arity": {
-      "version": "7.0.0-beta.51",
-      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.51.tgz",
-      "integrity": "sha1-MoGy0EWvlcFyzpGyCCXYXqRnZBE=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-rc.1.tgz",
+      "integrity": "sha512-5+ydaIRxT42FSDqvoXIDksCGlW1903xC73HQnQCFF1YuV7VcIf+9M4+tRZulLlYlshw7ILA+4SiYsKoDlC0Irg==",
       "dev": true,
       "requires": {
-        "@babel/types": "7.0.0-beta.51"
+        "@babel/types": "7.0.0-rc.1"
       }
     },
     "@babel/helper-hoist-variables": {
-      "version": "7.0.0-beta.51",
-      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.0.0-beta.51.tgz",
-      "integrity": "sha1-XX68hZZWe2RPyYmRLDo++YvgWPw=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.0.0-rc.1.tgz",
+      "integrity": "sha512-ttcilOh9SM9eqVlzwz2Lv7B5Dwyaa8TIhi1DDEPnC3CarpNPXFdeCOoxoV5qjHRD1klAT86gczeU4lJnSDKmgA==",
       "dev": true,
       "requires": {
-        "@babel/types": "7.0.0-beta.51"
+        "@babel/types": "7.0.0-rc.1"
       }
     },
     "@babel/helper-member-expression-to-functions": {
-      "version": "7.0.0-beta.51",
-      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.0.0-beta.51.tgz",
-      "integrity": "sha1-KkJTZXQXZYiAbmAusXpS0yP4KHA=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.0.0-rc.1.tgz",
+      "integrity": "sha512-o263plHxPo1TxDDUx7gHuQ96Y8QyLs2n4968KZvo2l/9rkwn2L9kcIsRVjlhpPPKTz4tWe/7ZV50zkeDorrK9g==",
       "dev": true,
       "requires": {
-        "@babel/types": "7.0.0-beta.51"
+        "@babel/types": "7.0.0-rc.1"
       }
     },
     "@babel/helper-module-imports": {
-      "version": "7.0.0-beta.51",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.0.0-beta.51.tgz",
-      "integrity": "sha1-zgBCgEX7t9XrwOp7+DV4nxU2arI=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.0.0-rc.1.tgz",
+      "integrity": "sha512-eA8RzanjsZw4X2Cqh3WgVG7zwf1wdSUfXvZOH8Azx1rpwE0hzJ276jDZ3gSOJShsxPVvopHa4h+c2WfEUjW4+Q==",
       "dev": true,
       "requires": {
-        "@babel/types": "7.0.0-beta.51",
-        "lodash": "^4.17.5"
+        "@babel/types": "7.0.0-rc.1",
+        "lodash": "^4.17.10"
       }
     },
     "@babel/helper-module-transforms": {
-      "version": "7.0.0-beta.51",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.0.0-beta.51.tgz",
-      "integrity": "sha1-E68MjuQfJ3dDyPxD1EQxXbIyb3M=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.0.0-rc.1.tgz",
+      "integrity": "sha512-nz7FTFXlQ9UYp/dBjad4ZOu3Q4/1n86ysw9z9pjunqeKFNm+JHq7j5BeocFKIQAwul7QbIkSXiYm5EiteCHjiQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-module-imports": "7.0.0-beta.51",
-        "@babel/helper-simple-access": "7.0.0-beta.51",
-        "@babel/helper-split-export-declaration": "7.0.0-beta.51",
-        "@babel/template": "7.0.0-beta.51",
-        "@babel/types": "7.0.0-beta.51",
-        "lodash": "^4.17.5"
+        "@babel/helper-module-imports": "7.0.0-rc.1",
+        "@babel/helper-simple-access": "7.0.0-rc.1",
+        "@babel/helper-split-export-declaration": "7.0.0-rc.1",
+        "@babel/template": "7.0.0-rc.1",
+        "@babel/types": "7.0.0-rc.1",
+        "lodash": "^4.17.10"
       }
     },
     "@babel/helper-optimise-call-expression": {
@@ -263,31 +262,31 @@
       }
     },
     "@babel/helper-plugin-utils": {
-      "version": "7.0.0-beta.51",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.51.tgz",
-      "integrity": "sha1-D2pfK20cZERBP4+rYJQNebY8IDE=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-rc.1.tgz",
+      "integrity": "sha512-8ZNzqHXDhT/JjnBvrLKu8AL7NhONVIsnrfyQNm3PJNmufIER5kcIa3OxPMGWgNqox2R8WeQ6YYzYTLNXqq4kgQ==",
       "dev": true
     },
     "@babel/helper-regex": {
-      "version": "7.0.0-beta.51",
-      "resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.0.0-beta.51.tgz",
-      "integrity": "sha1-mXIqPAxwRZavsSMoSwqIihoAPYI=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.0.0-rc.1.tgz",
+      "integrity": "sha512-QXnTXVefioGuXlRMn+MnKKUHwhmdXGKnMvFI1tdHioMnBQEbEHGnmp+aYcddLwJ3KAH/hveaSR95BuWwprW+TA==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.5"
+        "lodash": "^4.17.10"
       }
     },
     "@babel/helper-remap-async-to-generator": {
-      "version": "7.0.0-beta.51",
-      "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.0.0-beta.51.tgz",
-      "integrity": "sha1-DtxX4F3LXd4qC27m+NAmGYLe8l8=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.0.0-rc.1.tgz",
+      "integrity": "sha512-skROQSC2fPwmrzAEPT/M7CObnWjJGpdbNLoICZDYHwDiUDe3dk5cQsU9j3tNlBhX14FaC9SjSpCJnSRpXDOWOw==",
       "dev": true,
       "requires": {
-        "@babel/helper-annotate-as-pure": "7.0.0-beta.51",
-        "@babel/helper-wrap-function": "7.0.0-beta.51",
-        "@babel/template": "7.0.0-beta.51",
-        "@babel/traverse": "7.0.0-beta.51",
-        "@babel/types": "7.0.0-beta.51"
+        "@babel/helper-annotate-as-pure": "7.0.0-rc.1",
+        "@babel/helper-wrap-function": "7.0.0-rc.1",
+        "@babel/template": "7.0.0-rc.1",
+        "@babel/traverse": "7.0.0-rc.1",
+        "@babel/types": "7.0.0-rc.1"
       }
     },
     "@babel/helper-replace-supers": {
@@ -387,52 +386,52 @@
       }
     },
     "@babel/helper-simple-access": {
-      "version": "7.0.0-beta.51",
-      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.0.0-beta.51.tgz",
-      "integrity": "sha1-ydf+zYShgdUKOvzEIvyUqWi+MFA=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.0.0-rc.1.tgz",
+      "integrity": "sha512-mfrHVSG0Dw51ajyL3Ltz+gEYrWAy4+Kl8lb1V/QWR31H7ovha6vNZ4guev/lR4KFu+4hMHogpjh4HB4AShqeMQ==",
       "dev": true,
       "requires": {
-        "@babel/template": "7.0.0-beta.51",
-        "@babel/types": "7.0.0-beta.51",
-        "lodash": "^4.17.5"
+        "@babel/template": "7.0.0-rc.1",
+        "@babel/types": "7.0.0-rc.1",
+        "lodash": "^4.17.10"
       }
     },
     "@babel/helper-split-export-declaration": {
-      "version": "7.0.0-beta.51",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.51.tgz",
-      "integrity": "sha1-imw/ZsTSZTUvwHdIT59ugKUauXg=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-rc.1.tgz",
+      "integrity": "sha512-hz6QmlnaBFYt4ra8DfRLCMgrI7yfwQ13kJtufSO5dVCasxmAng2LeeQiT6H4iN5TpFONcayp5f/2mXqHH/zn/g==",
       "dev": true,
       "requires": {
-        "@babel/types": "7.0.0-beta.51"
+        "@babel/types": "7.0.0-rc.1"
       }
     },
     "@babel/helper-wrap-function": {
-      "version": "7.0.0-beta.51",
-      "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.0.0-beta.51.tgz",
-      "integrity": "sha1-bFFvsEQQmWTuAxwiUAqDAxOGL7E=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.0.0-rc.1.tgz",
+      "integrity": "sha512-LrqRD4+jEkQGVQsCRi7bPkSmYFAUd3pv9tYAC8nsr9Y0Qfus8oycqxDj60QW4dmigRKBRRbVVLr/0kMI2pk0MA==",
       "dev": true,
       "requires": {
-        "@babel/helper-function-name": "7.0.0-beta.51",
-        "@babel/template": "7.0.0-beta.51",
-        "@babel/traverse": "7.0.0-beta.51",
-        "@babel/types": "7.0.0-beta.51"
+        "@babel/helper-function-name": "7.0.0-rc.1",
+        "@babel/template": "7.0.0-rc.1",
+        "@babel/traverse": "7.0.0-rc.1",
+        "@babel/types": "7.0.0-rc.1"
       }
     },
     "@babel/helpers": {
-      "version": "7.0.0-beta.51",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.0.0-beta.51.tgz",
-      "integrity": "sha1-lScr4qtGNNaCBCX4klAxqSiRg5c=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.0.0-rc.1.tgz",
+      "integrity": "sha512-4+AkDbZ0Usr7mNH4wGX8fVx4WJzHdrcjRkJy52EIWyBAQEoKqb5HXca1VjejWtnVwaGwW7zk/h6oQ9FQPywQfA==",
       "dev": true,
       "requires": {
-        "@babel/template": "7.0.0-beta.51",
-        "@babel/traverse": "7.0.0-beta.51",
-        "@babel/types": "7.0.0-beta.51"
+        "@babel/template": "7.0.0-rc.1",
+        "@babel/traverse": "7.0.0-rc.1",
+        "@babel/types": "7.0.0-rc.1"
       }
     },
     "@babel/highlight": {
-      "version": "7.0.0-beta.51",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.51.tgz",
-      "integrity": "sha1-6IRK4loVlcz9QriWI7Q3bKBtIl0=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-rc.1.tgz",
+      "integrity": "sha512-5PgPDV6F5s69XNznTcP0za3qH7qgBkr9DVQTXfZtpF+3iEyuIZB1Mjxu52F5CFxgzQUQJoBYHVxtH4Itdb5MgA==",
       "dev": true,
       "requires": {
         "chalk": "^2.0.0",
@@ -441,114 +440,114 @@
       }
     },
     "@babel/parser": {
-      "version": "7.0.0-beta.51",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.0.0-beta.51.tgz",
-      "integrity": "sha1-J87C30Cd9gr1gnDtj2qlVAnqhvY=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.0.0-rc.1.tgz",
+      "integrity": "sha512-rC+bIz2eZnJlacERmJO25UAbXVZttcSxh0Px0gRGinOTzug5tL7+L9urfIdSWlv1ZzP03+f2xkOFLOxZqSsVmQ==",
       "dev": true
     },
     "@babel/plugin-external-helpers": {
-      "version": "7.0.0-beta.51",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-external-helpers/-/plugin-external-helpers-7.0.0-beta.51.tgz",
-      "integrity": "sha1-tHg7z5FS0VlCy+DwvKJhuEnTXJg=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-external-helpers/-/plugin-external-helpers-7.0.0-rc.1.tgz",
+      "integrity": "sha512-g0POypf/vBWEFmNkuwYrWoANrzOL4iSBhFtjSN+0D4BCm4jKtmY6kAOKaqjvWwj5IcqQVQEXqdRUXU0seoBF/g==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.51"
+        "@babel/helper-plugin-utils": "7.0.0-rc.1"
       }
     },
     "@babel/plugin-proposal-async-generator-functions": {
-      "version": "7.0.0-beta.51",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.0.0-beta.51.tgz",
-      "integrity": "sha1-99aS+Uakp/ynjkM2QHoAvq+KTeo=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.0.0-rc.1.tgz",
+      "integrity": "sha512-ewJnWv10AFUh+Yi6axMVQKW8L1pZCm86a44m2biYtXNSyt6FyWgdRloBbR7iCviPkeurfTCVdPS61G/t5cXVkQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.51",
-        "@babel/helper-remap-async-to-generator": "7.0.0-beta.51",
-        "@babel/plugin-syntax-async-generators": "7.0.0-beta.51"
+        "@babel/helper-plugin-utils": "7.0.0-rc.1",
+        "@babel/helper-remap-async-to-generator": "7.0.0-rc.1",
+        "@babel/plugin-syntax-async-generators": "7.0.0-rc.1"
       }
     },
     "@babel/plugin-proposal-object-rest-spread": {
-      "version": "7.0.0-beta.51",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.0.0-beta.51.tgz",
-      "integrity": "sha1-W8Rp5ebRuEpdYEa1npDKAWwghtY=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.0.0-rc.1.tgz",
+      "integrity": "sha512-J9qLEkxuZrYh/mel9RA5wDrMGE7jQMOMa1XPZMysih4C0mveeQUExbAPyrVSrFQo5BXLcLIc6ccM24G9xPCCXA==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.51",
-        "@babel/plugin-syntax-object-rest-spread": "7.0.0-beta.51"
+        "@babel/helper-plugin-utils": "7.0.0-rc.1",
+        "@babel/plugin-syntax-object-rest-spread": "7.0.0-rc.1"
       }
     },
     "@babel/plugin-syntax-async-generators": {
-      "version": "7.0.0-beta.51",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.0.0-beta.51.tgz",
-      "integrity": "sha1-aSGvHcPaD87d4KYQc+7Hl7jKpwc=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.0.0-rc.1.tgz",
+      "integrity": "sha512-2F5FYc89TCrqE/8+qFlr5jVMTHfkhEOg9JUx+GXI3inW2OfcY+J6bN8EDc8PLz84PHaR8W630YOuh2PveJu3WA==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.51"
+        "@babel/helper-plugin-utils": "7.0.0-rc.1"
       }
     },
     "@babel/plugin-syntax-dynamic-import": {
-      "version": "7.0.0-beta.51",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.0.0-beta.51.tgz",
-      "integrity": "sha1-nAru9X0GeONybbFxqnPkdKJd5/I=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.0.0-rc.1.tgz",
+      "integrity": "sha512-9U93f+wnHLOqHYxk1pftQfvWIx4FAKce9C41ZaNPLUffr7+yE+D24rNG0KeG5/ROMbKE3so7d2Qv891ThVZtPw==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.51"
+        "@babel/helper-plugin-utils": "7.0.0-rc.1"
       }
     },
     "@babel/plugin-syntax-import-meta": {
-      "version": "7.0.0-beta.51",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.0.0-beta.51.tgz",
-      "integrity": "sha1-EfleSTZJIxliJxuokXdvouxJmCM=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.0.0-rc.1.tgz",
+      "integrity": "sha512-pECmr/Eh3GVtzzJYKOOaTcRvNW2+IOD7M/xPONlQ65KgbpMJVygVXS3lMIrdZx2M3buQeTgLGUplq0r28zA0NA==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.51"
+        "@babel/helper-plugin-utils": "7.0.0-rc.1"
       }
     },
     "@babel/plugin-syntax-object-rest-spread": {
-      "version": "7.0.0-beta.51",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.0.0-beta.51.tgz",
-      "integrity": "sha1-bVehGcHwZMRY5FutRb7wqD7RDAA=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.0.0-rc.1.tgz",
+      "integrity": "sha512-stOESgG+lc68DSFvXrqoH5dW91ZtedDoR40g9wJ1ruLahCdr9X5hVLv/ddf/g/1zzjevq59A1Q+xdUREhEnrvQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.51"
+        "@babel/helper-plugin-utils": "7.0.0-rc.1"
       }
     },
     "@babel/plugin-transform-arrow-functions": {
-      "version": "7.0.0-beta.51",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.0.0-beta.51.tgz",
-      "integrity": "sha1-KbnbbjhoigbsXCVjmZbYml6/2+M=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.0.0-rc.1.tgz",
+      "integrity": "sha512-9JnWkl+iKmjNgMFrLjfGJQm3f66SJxwaYjdsm49Vpvo9x7ADHMGMZYa5Yto9WNQBlIdtf+fhypwBcz6IPxdyvg==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.51"
+        "@babel/helper-plugin-utils": "7.0.0-rc.1"
       }
     },
     "@babel/plugin-transform-async-to-generator": {
-      "version": "7.0.0-beta.51",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.0.0-beta.51.tgz",
-      "integrity": "sha1-lFOFBVoubTVmv1WvEnyNclzToXM=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.0.0-rc.1.tgz",
+      "integrity": "sha512-8oE9Frx07ILINop9hOejXgcDVhmt4FuB3ZjXnIMcSMkAuiT3xLrxFMDo1Qo0kf5mty2jLlnOO6tbbH0kiIWxWA==",
       "dev": true,
       "requires": {
-        "@babel/helper-module-imports": "7.0.0-beta.51",
-        "@babel/helper-plugin-utils": "7.0.0-beta.51",
-        "@babel/helper-remap-async-to-generator": "7.0.0-beta.51"
+        "@babel/helper-module-imports": "7.0.0-rc.1",
+        "@babel/helper-plugin-utils": "7.0.0-rc.1",
+        "@babel/helper-remap-async-to-generator": "7.0.0-rc.1"
       }
     },
     "@babel/plugin-transform-block-scoped-functions": {
-      "version": "7.0.0-beta.51",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.0.0-beta.51.tgz",
-      "integrity": "sha1-IxKbr4FEcfOeqU7shKsf/nbJ/pY=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.0.0-rc.1.tgz",
+      "integrity": "sha512-dFEgZqmyWXaVYrFU11IgLX8M1+gK7GSU+CVRv42D7P1FFMNndg1u36jXIa7URExEuTeTUykLM/IWgk5pHWxo6A==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.51"
+        "@babel/helper-plugin-utils": "7.0.0-rc.1"
       }
     },
     "@babel/plugin-transform-block-scoping": {
-      "version": "7.0.0-beta.51",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.0.0-beta.51.tgz",
-      "integrity": "sha1-vlVcefDaTrFop/4W14eppxc3AeA=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.0.0-rc.1.tgz",
+      "integrity": "sha512-9uGwvSqJcmcKPEkLHA7ffrG0lKXTXprupwGjEKDw27OoRWXHdWUmA4VwpuzMrUsYyV+q+P6mgj6TPzoGJA3fAw==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.51",
-        "lodash": "^4.17.5"
+        "@babel/helper-plugin-utils": "7.0.0-rc.1",
+        "lodash": "^4.17.10"
       }
     },
     "@babel/plugin-transform-classes": {
@@ -636,245 +635,244 @@
       }
     },
     "@babel/plugin-transform-computed-properties": {
-      "version": "7.0.0-beta.51",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.0.0-beta.51.tgz",
-      "integrity": "sha1-jHKhqz4HZwNP+eZzLSWBwjwDLv4=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.0.0-rc.1.tgz",
+      "integrity": "sha512-dfJNqbyF6S8nvFzGc6NthqCqopn1PoY3q2E1KcgrFSgxwYAMOLuhu5eA5iFeXwggp6tIo6OVVXC55/Twsolmow==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.51"
+        "@babel/helper-plugin-utils": "7.0.0-rc.1"
       }
     },
     "@babel/plugin-transform-destructuring": {
-      "version": "7.0.0-beta.51",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.0.0-beta.51.tgz",
-      "integrity": "sha1-1dRU5XTH7zPuSekYsEivspvpNfY=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.0.0-rc.1.tgz",
+      "integrity": "sha512-YpuGA3cj5+gRD053nWtogo+3wxc10mNAAyf5syXXCVS/cOWpRjc3qPidzHtPodz+v8TgAwwaXwIz/ghLOojRQw==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.51"
+        "@babel/helper-plugin-utils": "7.0.0-rc.1"
       }
     },
     "@babel/plugin-transform-duplicate-keys": {
-      "version": "7.0.0-beta.51",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.0.0-beta.51.tgz",
-      "integrity": "sha1-VB6vipfRSpgJs1nY9UgAHwhbm38=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.0.0-rc.1.tgz",
+      "integrity": "sha512-cWyoUi1izJk5JbWFG07GZrZyZgG+DW4axPKI0MA+lSAxjP8VZwFUhJyjT7R4bGN81KTVv1aprKclQnKxN2R0Lw==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.51"
+        "@babel/helper-plugin-utils": "7.0.0-rc.1"
       }
     },
     "@babel/plugin-transform-exponentiation-operator": {
-      "version": "7.0.0-beta.51",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.0.0-beta.51.tgz",
-      "integrity": "sha1-BLTj5As3AREt1u2jliUTJ1eIH9Q=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.0.0-rc.1.tgz",
+      "integrity": "sha512-5lc0nlX8TPdkHSIX3/3jMtqvvJfzcARcev4qqsaVkXWQ6XNrNnD8ExyTEVgoGhr5Ppz1wA0ymAK8W33uGeKSOg==",
       "dev": true,
       "requires": {
-        "@babel/helper-builder-binary-assignment-operator-visitor": "7.0.0-beta.51",
-        "@babel/helper-plugin-utils": "7.0.0-beta.51"
+        "@babel/helper-builder-binary-assignment-operator-visitor": "7.0.0-rc.1",
+        "@babel/helper-plugin-utils": "7.0.0-rc.1"
       }
     },
     "@babel/plugin-transform-for-of": {
-      "version": "7.0.0-beta.51",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.0.0-beta.51.tgz",
-      "integrity": "sha1-RPR2sGxANVF6hAOiYk+xZMQ3FFU=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.0.0-rc.1.tgz",
+      "integrity": "sha512-v09o2ywKHu+b/vkLknjKPV9QXCxuU2cVFxkWhBqcKwl3ERe3clhiab7a/8T9Sc332o4Im6n/LLugKMtpfxqRsQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.51"
+        "@babel/helper-plugin-utils": "7.0.0-rc.1"
       }
     },
     "@babel/plugin-transform-function-name": {
-      "version": "7.0.0-beta.51",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.0.0-beta.51.tgz",
-      "integrity": "sha1-cGU8NgtTJUJG9GWexFCwwKVthqo=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.0.0-rc.1.tgz",
+      "integrity": "sha512-MiUORPQo3kvSCYBn/T6kKIfdDKqFAnEsaiRnTz36Y6M/p6NX7br5MgqPumVNgDboYKQ9kzaFNM8YJvWLcjL6SQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-function-name": "7.0.0-beta.51",
-        "@babel/helper-plugin-utils": "7.0.0-beta.51"
+        "@babel/helper-function-name": "7.0.0-rc.1",
+        "@babel/helper-plugin-utils": "7.0.0-rc.1"
       }
     },
     "@babel/plugin-transform-instanceof": {
-      "version": "7.0.0-beta.51",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-instanceof/-/plugin-transform-instanceof-7.0.0-beta.51.tgz",
-      "integrity": "sha1-ft1hag3njWuvU0NgpHWGWQbt6Zk=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-instanceof/-/plugin-transform-instanceof-7.0.0-rc.1.tgz",
+      "integrity": "sha512-AZc7Ln5Rk3TAPQ3tkuuqL7/p1cUHoVEXBLX19xNXL+pauQ+vllpEcAQdkugkuojZ5KNmBYNRKoGf9oRSxixwDQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.51"
+        "@babel/helper-plugin-utils": "7.0.0-rc.1"
       }
     },
     "@babel/plugin-transform-literals": {
-      "version": "7.0.0-beta.51",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.0.0-beta.51.tgz",
-      "integrity": "sha1-RbB6lCI8+iJnAaeUYLQrMt8d7AU=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.0.0-rc.1.tgz",
+      "integrity": "sha512-iI468X7shsmB/oIPi8+UfMcOpcQPEsMAz5hDc0H8dKBGUWbPcAlyQpC8CaNDZ7y1/7lK65wtvXs5OGTQd3OsJg==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.51"
+        "@babel/helper-plugin-utils": "7.0.0-rc.1"
       }
     },
     "@babel/plugin-transform-modules-amd": {
-      "version": "7.0.0-beta.51",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.0.0-beta.51.tgz",
-      "integrity": "sha1-9oqL5/ZRd9JGUGo5FNrk1m5nWh8=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.0.0-rc.1.tgz",
+      "integrity": "sha512-xKIF2ZAFOZRgIhEeW6zuyieyqfjft59NaHvb2C7+N9omdFDVkrx5ZeHVLb8y163a3mUb2MqJg1PLfZXdwvz1EA==",
       "dev": true,
       "requires": {
-        "@babel/helper-module-transforms": "7.0.0-beta.51",
-        "@babel/helper-plugin-utils": "7.0.0-beta.51"
+        "@babel/helper-module-transforms": "7.0.0-rc.1",
+        "@babel/helper-plugin-utils": "7.0.0-rc.1"
       }
     },
     "@babel/plugin-transform-object-super": {
-      "version": "7.0.0-beta.51",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.0.0-beta.51.tgz",
-      "integrity": "sha1-rBjoi8HXm3GL2vSKdWgzzfW9zr8=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.0.0-rc.1.tgz",
+      "integrity": "sha512-mwoid0Rx+L55NupRE9xs1JAgFRz0JIYS/JR0aqBlLOQwBY1KrbrAtQfNwHQobwZrP9O24VBRfViMsiYLh/UV4A==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.51",
-        "@babel/helper-replace-supers": "7.0.0-beta.51"
+        "@babel/helper-plugin-utils": "7.0.0-rc.1",
+        "@babel/helper-replace-supers": "7.0.0-rc.1"
       },
       "dependencies": {
         "@babel/helper-optimise-call-expression": {
-          "version": "7.0.0-beta.51",
-          "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.0.0-beta.51.tgz",
-          "integrity": "sha1-IfIVjvCDoSPOHgRmW1u4TzcAgNc=",
+          "version": "7.0.0-rc.1",
+          "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.0.0-rc.1.tgz",
+          "integrity": "sha512-XOKPnL/AJz8ZyY553FsMAVt9g/mE1+RQfg5/m3X0K4+RqYviPGZlxwe5mGSd8s2kPSB6D6nZRUfvZFtmFIXEvA==",
           "dev": true,
           "requires": {
-            "@babel/types": "7.0.0-beta.51"
+            "@babel/types": "7.0.0-rc.1"
           }
         },
         "@babel/helper-replace-supers": {
-          "version": "7.0.0-beta.51",
-          "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.0.0-beta.51.tgz",
-          "integrity": "sha1-J5phr7hJR2xsxw1VGfg99KdP+m8=",
+          "version": "7.0.0-rc.1",
+          "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.0.0-rc.1.tgz",
+          "integrity": "sha512-mcv+NKCazZfdEw7yBe/xROekR3qlFcy18d//mJTKnZb7xx2qFPjZAafkeIlpvzNHwd/WMTHShC4+3WjOL8FD5g==",
           "dev": true,
           "requires": {
-            "@babel/helper-member-expression-to-functions": "7.0.0-beta.51",
-            "@babel/helper-optimise-call-expression": "7.0.0-beta.51",
-            "@babel/traverse": "7.0.0-beta.51",
-            "@babel/types": "7.0.0-beta.51"
+            "@babel/helper-member-expression-to-functions": "7.0.0-rc.1",
+            "@babel/helper-optimise-call-expression": "7.0.0-rc.1",
+            "@babel/traverse": "7.0.0-rc.1",
+            "@babel/types": "7.0.0-rc.1"
           }
         }
       }
     },
     "@babel/plugin-transform-parameters": {
-      "version": "7.0.0-beta.51",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.0.0-beta.51.tgz",
-      "integrity": "sha1-mQGVsd/bG8yUkG8wNJUQie0e3U4=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.0.0-rc.1.tgz",
+      "integrity": "sha512-PKjm+xf23XvdP0WRj/fIiP3xa5DYOg6qd0150Mpu4JvCIci6vrWvkc+kU9RtwkXLycWRfzdSnnyuSZABxPAP8A==",
       "dev": true,
       "requires": {
-        "@babel/helper-call-delegate": "7.0.0-beta.51",
-        "@babel/helper-get-function-arity": "7.0.0-beta.51",
-        "@babel/helper-plugin-utils": "7.0.0-beta.51"
+        "@babel/helper-call-delegate": "7.0.0-rc.1",
+        "@babel/helper-get-function-arity": "7.0.0-rc.1",
+        "@babel/helper-plugin-utils": "7.0.0-rc.1"
       }
     },
     "@babel/plugin-transform-regenerator": {
-      "version": "7.0.0-beta.51",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.0.0-beta.51.tgz",
-      "integrity": "sha1-U28NWZ0nU9ygor6KZeLCRKe1YSs=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.0.0-rc.1.tgz",
+      "integrity": "sha512-a73XZOJGt0Ft8/YbRAUl0Vs1GuPpjB6QVQNYPxWUNXblSiywhkkZxLssHZnao2xTD26kLRfMoXfOtj9FMz5fcw==",
       "dev": true,
       "requires": {
-        "regenerator-transform": "^0.12.4"
+        "regenerator-transform": "^0.13.3"
       }
     },
     "@babel/plugin-transform-shorthand-properties": {
-      "version": "7.0.0-beta.51",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.0.0-beta.51.tgz",
-      "integrity": "sha1-3bwLGuHds7z+aWnyyWgQPxHjK9k=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.0.0-rc.1.tgz",
+      "integrity": "sha512-NkUsTSKL8txvPt9vtdkcbJEyiUtcSOAr6ZnAE+Vg4mB0hYI0sWEJCAzl26KDDFgdVSKJSAaenjX5UR3BAF3KaA==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.51"
+        "@babel/helper-plugin-utils": "7.0.0-rc.1"
       }
     },
     "@babel/plugin-transform-spread": {
-      "version": "7.0.0-beta.51",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.0.0-beta.51.tgz",
-      "integrity": "sha1-EAEpvI19z0vHmtzWEppCFCWdilA=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.0.0-rc.1.tgz",
+      "integrity": "sha512-/3EkUVVi55i/JCbL2CxXTaoCXCopj3qQMTZ0lvgtpepx1yAMpoHYFBNWLIuQmjG7JhDauOwEdBg8TRsneYRmmw==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.51"
+        "@babel/helper-plugin-utils": "7.0.0-rc.1"
       }
     },
     "@babel/plugin-transform-sticky-regex": {
-      "version": "7.0.0-beta.51",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.0.0-beta.51.tgz",
-      "integrity": "sha1-SMvqzTG9Be6AC1+svLCcV4G9lhk=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.0.0-rc.1.tgz",
+      "integrity": "sha512-sXPFGI3GTtSMxVTDwrRmgwmUcq+l0ovzUZFfAd4YK1zJQ7YQCaCjcmLskuiGM20SoteYserDADg0SrLw+8B8hA==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.51",
-        "@babel/helper-regex": "7.0.0-beta.51"
+        "@babel/helper-plugin-utils": "7.0.0-rc.1",
+        "@babel/helper-regex": "7.0.0-rc.1"
       }
     },
     "@babel/plugin-transform-template-literals": {
-      "version": "7.0.0-beta.51",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.0.0-beta.51.tgz",
-      "integrity": "sha1-LQWV9WRh1DRbo1w41zAz+H7Lu8g=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.0.0-rc.1.tgz",
+      "integrity": "sha512-xq9eSNA65VXbMmVEjKUXB0czP8y/CRs88S8HcwZbJ7XGo4FARUJV3aGQfIPvGUmbkQegsxZx5rlTPlw3NPl+Aw==",
       "dev": true,
       "requires": {
-        "@babel/helper-annotate-as-pure": "7.0.0-beta.51",
-        "@babel/helper-plugin-utils": "7.0.0-beta.51"
+        "@babel/helper-annotate-as-pure": "7.0.0-rc.1",
+        "@babel/helper-plugin-utils": "7.0.0-rc.1"
       }
     },
     "@babel/plugin-transform-typeof-symbol": {
-      "version": "7.0.0-beta.51",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.0.0-beta.51.tgz",
-      "integrity": "sha1-SVDAyOPJ4eFB5Fzrq15hSCYyBMM=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.0.0-rc.1.tgz",
+      "integrity": "sha512-wUKNscuv3WOOFy3tGOBeayeOLyZjixjOSvb0QNXrCDRuENhfPaFQjZt/T0UDAZN0mXvAQ7Ksx2pOtXBsyIBxUA==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.51"
+        "@babel/helper-plugin-utils": "7.0.0-rc.1"
       }
     },
     "@babel/plugin-transform-unicode-regex": {
-      "version": "7.0.0-beta.51",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.0.0-beta.51.tgz",
-      "integrity": "sha1-kBn5FQj0C1CmRDUEMijEFCws2GQ=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.0.0-rc.1.tgz",
+      "integrity": "sha512-3yz7ehk0VFLqoKVV1GbTdH2sfMtYznhllkBDtnybveM6MeFA5WYCf6iWf+I/vF/8QIMDd1b4359GGWKCI+KuIQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.51",
-        "@babel/helper-regex": "7.0.0-beta.51",
+        "@babel/helper-plugin-utils": "7.0.0-rc.1",
+        "@babel/helper-regex": "7.0.0-rc.1",
         "regexpu-core": "^4.1.3"
       }
     },
     "@babel/template": {
-      "version": "7.0.0-beta.51",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.51.tgz",
-      "integrity": "sha1-lgKkCuvPNXrpZ34lMu9fyBD1+/8=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-rc.1.tgz",
+      "integrity": "sha512-gPLng2iedNlkaGD0UdwaUByQXK8k4bnaoq2RH5JgR2mqHvh2RyjkDdaMbZFlSss1Iu8+PrXwbIRworTl8iRqbA==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "7.0.0-beta.51",
-        "@babel/parser": "7.0.0-beta.51",
-        "@babel/types": "7.0.0-beta.51",
-        "lodash": "^4.17.5"
+        "@babel/code-frame": "7.0.0-rc.1",
+        "@babel/parser": "7.0.0-rc.1",
+        "@babel/types": "7.0.0-rc.1",
+        "lodash": "^4.17.10"
       }
     },
     "@babel/traverse": {
-      "version": "7.0.0-beta.51",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.51.tgz",
-      "integrity": "sha1-mB2vLOw0emIx06odnhgDsDqqpKg=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-rc.1.tgz",
+      "integrity": "sha512-lNOpJ5xzakg+fCobQQHdeDRYeN54b+bAZpeTYMeeYPAvN+hTldg9/FSNKYEMRs5EWoQ0Yt74gwq98InSORdSDQ==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "7.0.0-beta.51",
-        "@babel/generator": "7.0.0-beta.51",
-        "@babel/helper-function-name": "7.0.0-beta.51",
-        "@babel/helper-split-export-declaration": "7.0.0-beta.51",
-        "@babel/parser": "7.0.0-beta.51",
-        "@babel/types": "7.0.0-beta.51",
+        "@babel/code-frame": "7.0.0-rc.1",
+        "@babel/generator": "7.0.0-rc.1",
+        "@babel/helper-function-name": "7.0.0-rc.1",
+        "@babel/helper-split-export-declaration": "7.0.0-rc.1",
+        "@babel/parser": "7.0.0-rc.1",
+        "@babel/types": "7.0.0-rc.1",
         "debug": "^3.1.0",
         "globals": "^11.1.0",
-        "invariant": "^2.2.0",
-        "lodash": "^4.17.5"
+        "lodash": "^4.17.10"
       }
     },
     "@babel/types": {
-      "version": "7.0.0-beta.51",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.51.tgz",
-      "integrity": "sha1-2AK3tUO1g2x3iqaReXq/APPZfqk=",
+      "version": "7.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-rc.1.tgz",
+      "integrity": "sha512-MBwO1JQKin9BwKTGydrYe4VDJbStCUy35IhJzeZt3FByOdx/q3CYaqMRrH70qVD2RA7+Xk8e3RN0mzKZkYBYuQ==",
       "dev": true,
       "requires": {
         "esutils": "^2.0.2",
-        "lodash": "^4.17.5",
+        "lodash": "^4.17.10",
         "to-fast-properties": "^2.0.0"
       }
     },
     "@polymer/esm-amd-loader": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@polymer/esm-amd-loader/-/esm-amd-loader-1.0.1.tgz",
-      "integrity": "sha512-yqa8Go1CJ07sTdjYXzl4cBa9W4MoTdwF1We94P/nENWCCVWMItWQmUKmKEpQBJOYWd6DZSgEOdVEXa4HS2QAkA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@polymer/esm-amd-loader/-/esm-amd-loader-1.0.2.tgz",
+      "integrity": "sha512-n45zYqDfZUKBiM+Nj0jU6An2xEP5avKKdsl8ecgh2PbA0I0lamEExs0BmHfD4Br+lJDNbbDEVsUMDlrqNqcceg==",
       "dev": true
     },
     "@polymer/polymer": {
@@ -941,9 +939,9 @@
       }
     },
     "@types/bluebird": {
-      "version": "3.5.20",
-      "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.20.tgz",
-      "integrity": "sha512-Wk41MVdF+cHBfVXj/ufUHJeO3BlIQr1McbHZANErMykaCWeDSZbH5erGjNBw2/3UlRdSxZbLfSuQTzFmPOYFsA==",
+      "version": "3.5.23",
+      "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.23.tgz",
+      "integrity": "sha512-xlehmc6RT+wMEhy9ZqeqmozVmuFzTfsaV2NlfFFWhigy7n6sjMbUUB+SZBWK78lZgWHA4DBAdQvQxUvcB8N1tw==",
       "dev": true
     },
     "@types/body-parser": {
@@ -1161,9 +1159,9 @@
       "dev": true
     },
     "@types/mime": {
-      "version": "0.0.29",
-      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-0.0.29.tgz",
-      "integrity": "sha1-+8/TMFc7kS71nu7hRgK/rOYwdUs=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.0.tgz",
+      "integrity": "sha512-A2TAGbTFdBw9azHbpVd+/FkdW2T6msN1uct1O9bH3vTerEHKZhTXJUQXy+hNq1B0RagfU8U+KBdqiZpxjhOUQA==",
       "dev": true
     },
     "@types/minimatch": {
@@ -1281,9 +1279,9 @@
       "dev": true
     },
     "@types/uglify-js": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@types/uglify-js/-/uglify-js-3.0.2.tgz",
-      "integrity": "sha512-o8hU2+4xsyGC27Vujoklvxl88Ew5zmJuTBYMX1Uro2rYUt4HEFJKL6fuq8aGykvS+ssIsIzerWWP2DRxonownQ==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/uglify-js/-/uglify-js-3.0.3.tgz",
+      "integrity": "sha512-MAT0BW2ruO0LhQKjvlipLGCF/Yx0y/cj+tT67tK3QIQDrM2+9R78HgJ54VlrE8AbfjYJJBCQCEPM5ZblPVTuww==",
       "dev": true,
       "requires": {
         "source-map": "^0.6.1"
@@ -1316,11 +1314,12 @@
       }
     },
     "@types/vinyl-fs": {
-      "version": "2.4.8",
-      "resolved": "https://registry.npmjs.org/@types/vinyl-fs/-/vinyl-fs-2.4.8.tgz",
-      "integrity": "sha512-yE2pN9OOrxJVeO7IZLHAHrh5R4Q0osbn5WQRuQU6GdXoK7dNFrMK3K7YhATkzf3z0yQBkol3+gafs7Rp0s7dDg==",
+      "version": "2.4.9",
+      "resolved": "https://registry.npmjs.org/@types/vinyl-fs/-/vinyl-fs-2.4.9.tgz",
+      "integrity": "sha512-Q0EXd6c1fORjiOuK4ZaKdfFcMyFzJlTi56dqktwaWVLIDAzE49wUs3bKnYbZwzyMWoH+NcMWnRuR73S9A0jnRA==",
       "dev": true,
       "requires": {
+        "@types/events": "*",
         "@types/glob-stream": "*",
         "@types/node": "*",
         "@types/vinyl": "*"
@@ -1380,9 +1379,9 @@
       "dev": true
     },
     "acorn": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.6.2.tgz",
-      "integrity": "sha512-zUzo1E5dI2Ey8+82egfnttyMlMZ2y0D8xOCO3PNPPlYXpl8NZvF6Qk9L9BEtJs+43FqEmfBViDqc5d1ckRDguw==",
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.1.tgz",
+      "integrity": "sha512-d+nbxBUGKg7Arpsvbnlq61mc12ek3EY8EQldM3GPAhWJ1UVxC6TDGbIvUMNU6obBX3i1+ptCIzV4vq0gFPEGVQ==",
       "dev": true
     },
     "acorn-import-meta": {
@@ -1425,9 +1424,9 @@
       "dev": true
     },
     "agent-base": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.0.tgz",
-      "integrity": "sha512-c+R/U5X+2zz2+UCrCFv6odQzJdoqI+YecuhnAJLa1zYaMc13zPfwMwZrr91Pd1DYNo/yPRbiM4WVf9whgwFsIg==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.1.tgz",
+      "integrity": "sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -1470,15 +1469,6 @@
       "dev": true,
       "requires": {
         "string-width": "^2.0.0"
-      }
-    },
-    "ansi-escape-sequences": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-escape-sequences/-/ansi-escape-sequences-3.0.0.tgz",
-      "integrity": "sha1-HBg5S2r5t2/5pjUJ+kl2af0s5T4=",
-      "dev": true,
-      "requires": {
-        "array-back": "^1.0.3"
       }
     },
     "ansi-regex": {
@@ -1613,37 +1603,6 @@
       "requires": {
         "array-back": "^2.0.0",
         "find-replace": "^2.0.1"
-      },
-      "dependencies": {
-        "array-back": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/array-back/-/array-back-2.0.0.tgz",
-          "integrity": "sha512-eJv4pLLufP3g5kcZry0j6WXpIbzYw9GUB4mVJZno9wfwiBxbizTnHCw3VJb07cBihbFX48Y7oSrW9y+gt4glyw==",
-          "dev": true,
-          "requires": {
-            "typical": "^2.6.1"
-          }
-        },
-        "find-replace": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-2.0.1.tgz",
-          "integrity": "sha512-LzDo3Fpa30FLIBsh6DCDnMN1KW2g4QKkqKmejlImgWY67dDFPX/x9Kh/op/GK522DchQXEvDi/wD48HKW49XOQ==",
-          "dev": true,
-          "requires": {
-            "array-back": "^2.0.0",
-            "test-value": "^3.0.0"
-          }
-        },
-        "test-value": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/test-value/-/test-value-3.0.0.tgz",
-          "integrity": "sha512-sVACdAWcZkSU9x7AOmJo5TqE+GyNJknHaHsMrR6ZnhjVlVN9Yx6FjHrsKZ3BjIpPCT68zYesPWkakrNupwfOTQ==",
-          "dev": true,
-          "requires": {
-            "array-back": "^2.0.0",
-            "typical": "^2.6.1"
-          }
-        }
       }
     },
     "arr-diff": {
@@ -1665,12 +1624,12 @@
       "dev": true
     },
     "array-back": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
-      "integrity": "sha1-ZEun8JX3/898Q7Xw3DnTwfA8Bjs=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-2.0.0.tgz",
+      "integrity": "sha512-eJv4pLLufP3g5kcZry0j6WXpIbzYw9GUB4mVJZno9wfwiBxbizTnHCw3VJb07cBihbFX48Y7oSrW9y+gt4glyw==",
       "dev": true,
       "requires": {
-        "typical": "^2.6.0"
+        "typical": "^2.6.1"
       }
     },
     "array-find-index": {
@@ -1697,17 +1656,14 @@
       "integrity": "sha512-wGUIVQXuehL5TCqQun8OW81jGzAWycqzFF8lFp+GOM5BXLYj3bKNsYC4daB7n6XjCqxQA/qgTJ+8ANR3acjrog==",
       "dev": true
     },
-    "asap": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
-      "dev": true
-    },
     "asn1": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
-      "dev": true
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
+      "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+      "dev": true,
+      "requires": {
+        "safer-buffer": "~2.1.0"
+      }
     },
     "assert-plus": {
       "version": "1.0.0",
@@ -1758,9 +1714,9 @@
       "dev": true
     },
     "aws4": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.7.0.tgz",
-      "integrity": "sha512-32NDda82rhwD9/JBCCkB+MRYDp0oSvlo2IL6rQWA10PQi7tDUM3eqMSltXmY+Oyl/7N3P3qNtAlv7X0d9bI28w==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
+      "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
       "dev": true
     },
     "babel-code-frame": {
@@ -2082,14 +2038,6 @@
       "requires": {
         "core-js": "^2.4.0",
         "regenerator-runtime": "^0.11.0"
-      },
-      "dependencies": {
-        "regenerator-runtime": {
-          "version": "0.11.1",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-          "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
-          "dev": true
-        }
       }
     },
     "babel-traverse": {
@@ -2241,8 +2189,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.0.tgz",
       "integrity": "sha1-o5mS1yNYSBGYK+XikLtqU9hnAPE=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "base64id": {
       "version": "1.0.0",
@@ -2251,9 +2198,9 @@
       "dev": true
     },
     "bcrypt-pbkdf": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
-      "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
       "dev": true,
       "optional": true,
       "requires": {
@@ -2425,9 +2372,9 @@
       }
     },
     "browser-capabilities": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/browser-capabilities/-/browser-capabilities-1.1.0.tgz",
-      "integrity": "sha512-D0AhTybfR0KbVxy1DShQut4eCeluMyJhbTgVTIxvItJKzEGG9pNvOBFZfpeCASo2z0XdfczuvSfNZe/vmNlqwQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/browser-capabilities/-/browser-capabilities-1.1.1.tgz",
+      "integrity": "sha512-b+zF28HRpaKhdvLGqirkvn8XO+WEpLxAWg+dqa3OAoriVMS2UucVc1xis4Et9vMnQGLSipWks8bDeCeUvuZ0EQ==",
       "dev": true,
       "requires": {
         "@types/ua-parser-js": "^0.7.31",
@@ -2448,6 +2395,16 @@
       "optional": true,
       "requires": {
         "https-proxy-agent": "^2.2.1"
+      }
+    },
+    "buffer": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.2.0.tgz",
+      "integrity": "sha512-nUJyfChH7PMJy75eRDCCKtszSEFokUNXC1hNVSe+o+VdcgvDPLs20k3v8UXI8ruRYAJiYtyRea8mYyqPxoHWDw==",
+      "dev": true,
+      "requires": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4"
       }
     },
     "buffer-alloc": {
@@ -2479,9 +2436,9 @@
       "dev": true
     },
     "buffer-from": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.0.tgz",
-      "integrity": "sha512-c5mRlguI/Pe2dSZmpER62rSCu0ryKmWddzRYsuXc50U2/g8jMOulc31VZMa4mYx31U5xsmSOpDCgH88Vl9cDGQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
       "dev": true
     },
     "builtin-modules": {
@@ -2653,9 +2610,9 @@
       "dev": true
     },
     "ci-info": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.1.3.tgz",
-      "integrity": "sha512-SK/846h/Rcy8q9Z9CAwGBLfCJ6EkjJWdpelWDufQpqVDYq2Wnnv8zlSO6AMQap02jvhVruKKpEtQOufo3pFhLg==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.3.1.tgz",
+      "integrity": "sha512-l4wK/SFEN8VVTQ9RO1I5yzIL2vw1w6My29qA6Gwaec80QeHxfXbruuUWqn1knyMoJn/X5kav3zVY1TlRHSKeIA==",
       "dev": true
     },
     "class-utils": {
@@ -2732,9 +2689,9 @@
       }
     },
     "clone": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.1.tgz",
-      "integrity": "sha1-0hfR6WERjjrJpLi7oyhVU79kfNs=",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
       "dev": true
     },
     "clone-stats": {
@@ -2790,28 +2747,28 @@
       }
     },
     "command-line-args": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-3.0.5.tgz",
-      "integrity": "sha1-W9StReeYPlwTRJGOQCgO4mk8WsA=",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-5.0.2.tgz",
+      "integrity": "sha512-/qPcbL8zpqg53x4rAaqMFlRV4opN3pbla7I7k9x8kyOBMQoGT6WltjN6sXZuxOXw6DgdK7Ad+ijYS5gjcr7vlA==",
       "dev": true,
       "requires": {
-        "array-back": "^1.0.4",
-        "feature-detect-es6": "^1.3.1",
-        "find-replace": "^1.0.2",
-        "typical": "^2.6.0"
+        "argv-tools": "^0.1.1",
+        "array-back": "^2.0.0",
+        "find-replace": "^2.0.1",
+        "lodash.camelcase": "^4.3.0",
+        "typical": "^2.6.1"
       }
     },
     "command-line-usage": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-3.0.8.tgz",
-      "integrity": "sha1-tqIJeMGzg0d/XBGlKUKLiAv+D00=",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-5.0.5.tgz",
+      "integrity": "sha512-d8NrGylA5oCXSbGoKz05FkehDAzSmIm4K03S5VDh4d5lZAtTWfc3D1RuETtuQCn8129nYfJfDdF7P/lwcz1BlA==",
       "dev": true,
       "requires": {
-        "ansi-escape-sequences": "^3.0.0",
-        "array-back": "^1.0.3",
-        "feature-detect-es6": "^1.3.1",
-        "table-layout": "^0.3.0",
-        "typical": "^2.6.0"
+        "array-back": "^2.0.0",
+        "chalk": "^2.4.1",
+        "table-layout": "^0.4.3",
+        "typical": "^2.6.1"
       }
     },
     "commander": {
@@ -2883,28 +2840,20 @@
       "dev": true,
       "requires": {
         "mime-db": ">= 1.34.0 < 2"
-      },
-      "dependencies": {
-        "mime-db": {
-          "version": "1.34.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.34.0.tgz",
-          "integrity": "sha1-RS0Oz/XDA0am3B5kseruDTcZ/5o=",
-          "dev": true
-        }
       }
     },
     "compression": {
-      "version": "1.7.2",
-      "resolved": "http://registry.npmjs.org/compression/-/compression-1.7.2.tgz",
-      "integrity": "sha1-qv+81qr4VLROuygDU9WtFlH1mmk=",
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/compression/-/compression-1.7.3.tgz",
+      "integrity": "sha512-HSjyBG5N1Nnz7tF2+O7A9XUhyjru71/fwgNb7oIsEVHR0WShfs2tIS/EySLgiTe98aOK18YDlMXpzjCXY/n9mg==",
       "dev": true,
       "requires": {
-        "accepts": "~1.3.4",
+        "accepts": "~1.3.5",
         "bytes": "3.0.0",
-        "compressible": "~2.0.13",
+        "compressible": "~2.0.14",
         "debug": "2.6.9",
         "on-headers": "~1.0.1",
-        "safe-buffer": "5.1.1",
+        "safe-buffer": "5.1.2",
         "vary": "~1.1.2"
       },
       "dependencies": {
@@ -2916,6 +2865,12 @@
           "requires": {
             "ms": "2.0.0"
           }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true
         }
       }
     },
@@ -3042,10 +2997,13 @@
       },
       "dependencies": {
         "crc": {
-          "version": "3.5.0",
-          "resolved": "https://registry.npmjs.org/crc/-/crc-3.5.0.tgz",
-          "integrity": "sha1-mLi6fUiWZbo5efWbITgTdBAaGWQ=",
-          "dev": true
+          "version": "3.8.0",
+          "resolved": "https://registry.npmjs.org/crc/-/crc-3.8.0.tgz",
+          "integrity": "sha512-iX3mfgcTMIq3ZKLIsVFAbv7+Mc10kxabAGQb8HvjA1o3T1PIYprbakQ65d3I+2HGHt6nSKkM9PYjgoJO2KcFBQ==",
+          "dev": true,
+          "requires": {
+            "buffer": "^5.1.0"
+          }
         },
         "readable-stream": {
           "version": "2.3.6",
@@ -3136,91 +3094,6 @@
         "dom5": "^3.0.0",
         "parse5": "^4.0.0",
         "shady-css-parser": "^0.1.0"
-      },
-      "dependencies": {
-        "array-back": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/array-back/-/array-back-2.0.0.tgz",
-          "integrity": "sha512-eJv4pLLufP3g5kcZry0j6WXpIbzYw9GUB4mVJZno9wfwiBxbizTnHCw3VJb07cBihbFX48Y7oSrW9y+gt4glyw==",
-          "dev": true,
-          "requires": {
-            "typical": "^2.6.1"
-          }
-        },
-        "command-line-args": {
-          "version": "5.0.2",
-          "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-5.0.2.tgz",
-          "integrity": "sha512-/qPcbL8zpqg53x4rAaqMFlRV4opN3pbla7I7k9x8kyOBMQoGT6WltjN6sXZuxOXw6DgdK7Ad+ijYS5gjcr7vlA==",
-          "dev": true,
-          "requires": {
-            "argv-tools": "^0.1.1",
-            "array-back": "^2.0.0",
-            "find-replace": "^2.0.1",
-            "lodash.camelcase": "^4.3.0",
-            "typical": "^2.6.1"
-          }
-        },
-        "command-line-usage": {
-          "version": "5.0.5",
-          "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-5.0.5.tgz",
-          "integrity": "sha512-d8NrGylA5oCXSbGoKz05FkehDAzSmIm4K03S5VDh4d5lZAtTWfc3D1RuETtuQCn8129nYfJfDdF7P/lwcz1BlA==",
-          "dev": true,
-          "requires": {
-            "array-back": "^2.0.0",
-            "chalk": "^2.4.1",
-            "table-layout": "^0.4.3",
-            "typical": "^2.6.1"
-          }
-        },
-        "deep-extend": {
-          "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-          "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-          "dev": true
-        },
-        "find-replace": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-2.0.1.tgz",
-          "integrity": "sha512-LzDo3Fpa30FLIBsh6DCDnMN1KW2g4QKkqKmejlImgWY67dDFPX/x9Kh/op/GK522DchQXEvDi/wD48HKW49XOQ==",
-          "dev": true,
-          "requires": {
-            "array-back": "^2.0.0",
-            "test-value": "^3.0.0"
-          }
-        },
-        "table-layout": {
-          "version": "0.4.4",
-          "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-0.4.4.tgz",
-          "integrity": "sha512-uNaR3SRMJwfdp9OUr36eyEi6LLsbcTqTO/hfTsNviKsNeyMBPICJCC7QXRF3+07bAP6FRwA8rczJPBqXDc0CkQ==",
-          "dev": true,
-          "requires": {
-            "array-back": "^2.0.0",
-            "deep-extend": "~0.6.0",
-            "lodash.padend": "^4.6.1",
-            "typical": "^2.6.1",
-            "wordwrapjs": "^3.0.0"
-          }
-        },
-        "test-value": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/test-value/-/test-value-3.0.0.tgz",
-          "integrity": "sha512-sVACdAWcZkSU9x7AOmJo5TqE+GyNJknHaHsMrR6ZnhjVlVN9Yx6FjHrsKZ3BjIpPCT68zYesPWkakrNupwfOTQ==",
-          "dev": true,
-          "requires": {
-            "array-back": "^2.0.0",
-            "typical": "^2.6.1"
-          }
-        },
-        "wordwrapjs": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-3.0.0.tgz",
-          "integrity": "sha512-mO8XtqyPvykVCsrwj5MlOVWvSnCdT+C+QVbm6blradR7JExAhbkZ7hZ9A+9NUtwzSqrlUo9a67ws0EiILrvRpw==",
-          "dev": true,
-          "requires": {
-            "reduce-flatten": "^1.0.1",
-            "typical": "^2.6.1"
-          }
-        }
       }
     },
     "cssbeautify": {
@@ -3284,9 +3157,9 @@
       }
     },
     "deep-extend": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
-      "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
       "dev": true
     },
     "define-property": {
@@ -3410,12 +3283,12 @@
       }
     },
     "dom5": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/dom5/-/dom5-3.0.0.tgz",
-      "integrity": "sha512-PbE+7C4Sh1dHDTLNuSDaMUGD1ivDiSZw0L+a9xVUzUKeQ8w3vdzfKHRA07CxcrFZZOa1SGl2nIJ9T49j63q+bg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/dom5/-/dom5-3.0.1.tgz",
+      "integrity": "sha512-JPFiouQIr16VQ4dX6i0+Hpbg3H2bMKPmZ+WZgBOSSvOPx9QHwwY8sPzeM2baUtViESYto6wC2nuZOMC/6gulcA==",
       "dev": true,
       "requires": {
-        "@types/parse5": "^2.2.32",
+        "@types/parse5": "^2.2.34",
         "clone": "^2.1.0",
         "parse5": "^4.0.0"
       }
@@ -3509,13 +3382,14 @@
       }
     },
     "ecc-jsbn": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-      "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
       "dev": true,
       "optional": true,
       "requires": {
-        "jsbn": "~0.1.0"
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.1.0"
       }
     },
     "ee-first": {
@@ -3592,9 +3466,9 @@
       }
     },
     "error-ex": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
-      "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
       "dev": true,
       "requires": {
         "is-arrayish": "^0.2.1"
@@ -3917,9 +3791,9 @@
       }
     },
     "extend": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "dev": true
     },
     "extend-shallow": {
@@ -4048,15 +3922,6 @@
         "pend": "~1.2.0"
       }
     },
-    "feature-detect-es6": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/feature-detect-es6/-/feature-detect-es6-1.4.1.tgz",
-      "integrity": "sha512-iMxKpKdIBgcWiBPtz2qnEsNjCE2dBQvDyUqgrXLJboiaHwJa+2vDIZ8XbgNZGh1Rx1PUfZmI7uhG6Z4iQYWVjg==",
-      "dev": true,
-      "requires": {
-        "array-back": "^1.0.4"
-      }
-    },
     "filename-regex": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
@@ -4136,13 +4001,13 @@
       }
     },
     "find-replace": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-1.0.3.tgz",
-      "integrity": "sha1-uI5zZNLZyVlVnziMZmcNYTBEH6A=",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-2.0.1.tgz",
+      "integrity": "sha512-LzDo3Fpa30FLIBsh6DCDnMN1KW2g4QKkqKmejlImgWY67dDFPX/x9Kh/op/GK522DchQXEvDi/wD48HKW49XOQ==",
       "dev": true,
       "requires": {
-        "array-back": "^1.0.4",
-        "test-value": "^2.1.0"
+        "array-back": "^2.0.0",
+        "test-value": "^3.0.0"
       }
     },
     "find-up": {
@@ -4174,9 +4039,9 @@
       "dev": true
     },
     "follow-redirects": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.0.tgz",
-      "integrity": "sha512-fdrt472/9qQ6Kgjvb935ig6vJCuofpBUD14f9Vb+SLlm7xIe4Qva5gey8EKtv8lp7ahE1wilg3xL1znpVGtZIA==",
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.5.tgz",
+      "integrity": "sha512-GHjtHDlY/ehslqv0Gr5N0PUJppgg/q0rOBvX0na1s7y1A3LWxPqCYU76s3Z1bM4+UZB4QF0usaXLT5wFpof5PA==",
       "dev": true,
       "requires": {
         "debug": "^3.1.0"
@@ -4565,9 +4430,9 @@
       }
     },
     "globals": {
-      "version": "11.5.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-11.5.0.tgz",
-      "integrity": "sha512-hYyf+kI8dm3nORsiiXUQigOU62hDLfJ9G01uyGMxhc6BKsircrUhC4uJPQPUSuq2GrTmiiEt7ewxlMdBewfmKQ==",
+      "version": "11.7.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.7.0.tgz",
+      "integrity": "sha512-K8BNSPySfeShBQXsahYB/AbbWruVOTyVpgoIDnl8odPpeSfP2J5QO2oLFFdl2j7GfDCtZj2bMKar2T49itTPCg==",
       "dev": true
     },
     "got": {
@@ -4813,9 +4678,9 @@
       }
     },
     "hosted-git-info": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.6.0.tgz",
-      "integrity": "sha512-lIbgIIQA3lz5XaB6vxakj6sDHADJiZadYEJB+FgA+C4nubM1NwcuvUr9EJPmnH1skZqpqUzWborWo8EIUi0Sdw==",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
+      "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
       "dev": true
     },
     "hpack.js": {
@@ -4857,20 +4722,26 @@
       }
     },
     "html-minifier": {
-      "version": "3.5.16",
-      "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-3.5.16.tgz",
-      "integrity": "sha512-zP5EfLSpiLRp0aAgud4CQXPQZm9kXwWjR/cF0PfdOj+jjWnOaCgeZcll4kYXSvIBPeUMmyaSc7mM4IDtA+kboA==",
+      "version": "3.5.19",
+      "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-3.5.19.tgz",
+      "integrity": "sha512-Qr2JC9nsjK8oCrEmuB430ZIA8YWbF3D5LSjywD75FTuXmeqacwHgIM8wp3vHYzzPbklSjp53RdmDuzR4ub2HzA==",
       "dev": true,
       "requires": {
         "camel-case": "3.0.x",
         "clean-css": "4.1.x",
-        "commander": "2.15.x",
+        "commander": "2.16.x",
         "he": "1.1.x",
         "param-case": "2.1.x",
         "relateurl": "0.2.x",
-        "uglify-js": "3.3.x"
+        "uglify-js": "3.4.x"
       },
       "dependencies": {
+        "commander": {
+          "version": "2.16.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.16.0.tgz",
+          "integrity": "sha512-sVXqklSaotK9at437sFlFpyOcJonxe0yST/AG9DkQKUdIE6IqGIMv4SfAQSKaJbSdVEJYItASCrBiVQHq1HQew==",
+          "dev": true
+        },
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -4878,12 +4749,12 @@
           "dev": true
         },
         "uglify-js": {
-          "version": "3.3.28",
-          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.3.28.tgz",
-          "integrity": "sha512-68Rc/aA6cswiaQ5SrE979UJcXX+ADA1z33/ZsPd+fbAiVdjZ16OXdbtGO+rJUUBgK6qdf3SOPhQf3K/ybF5Miw==",
+          "version": "3.4.7",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.7.tgz",
+          "integrity": "sha512-J0M2i1mQA+ze3EdN9SBi751DNdAXmeFLfJrd/MDIkRc3G3Gbb9OPVSx7GIQvVwfWxQARcYV2DTxIkMyDAk3o9Q==",
           "dev": true,
           "requires": {
-            "commander": "~2.15.0",
+            "commander": "~2.16.0",
             "source-map": "~0.6.1"
           }
         }
@@ -5045,6 +4916,12 @@
         "safer-buffer": ">= 2.1.2 < 3"
       }
     },
+    "ieee754": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.12.tgz",
+      "integrity": "sha512-GguP+DRY+pJ3soyIiGPTvdiVXjZ+DbXOxGpXn3eMvNW4x4irjqXm4wHKscC+TfxSJ0yw/S1F24tqdMNsMZTiLA==",
+      "dev": true
+    },
     "import-lazy": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-2.1.0.tgz",
@@ -5116,9 +4993,9 @@
       }
     },
     "ipaddr.js": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.6.0.tgz",
-      "integrity": "sha1-4/o1e3c9phnybpXwSdBVxyeW+Gs=",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.8.0.tgz",
+      "integrity": "sha1-6qM9bd16zo9/b+DJygRA5wZzix4=",
       "dev": true
     },
     "is-accessor-descriptor": {
@@ -5152,12 +5029,12 @@
       }
     },
     "is-ci": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.1.0.tgz",
-      "integrity": "sha512-c7TnwxLePuqIlxHgr7xtxzycJPegNHFuIrBkwbf8hc58//+Op1CqFkyS+xnIMkwn9UsJIwc174BIjkyBmSpjKg==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.2.0.tgz",
+      "integrity": "sha512-plgvKjQtalH2P3Gytb7L61Lmz95g2DlpzFiQyRSFew8WoJKxtKRzrZMeyRN2supblm3Psc8OQGy7Xjb6XG11jw==",
       "dev": true,
       "requires": {
-        "ci-info": "^1.0.0"
+        "ci-info": "^1.3.0"
       }
     },
     "is-data-descriptor": {
@@ -5269,23 +5146,6 @@
       "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
       "dev": true
-    },
-    "is-odd": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-odd/-/is-odd-2.0.0.tgz",
-      "integrity": "sha512-OTiixgpZAT1M4NHgS5IguFp/Vz2VI3U7Goh4/HA1adtwyLtSBrxYlcSYkhpAE07s4fKEcjrFxyvtQBND4vFQyQ==",
-      "dev": true,
-      "requires": {
-        "is-number": "^4.0.0"
-      },
-      "dependencies": {
-        "is-number": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
-          "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
-          "dev": true
-        }
-      }
     },
     "is-path-inside": {
       "version": "1.0.1",
@@ -5755,12 +5615,12 @@
       "dev": true
     },
     "loose-envify": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
-      "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
       "dev": true,
       "requires": {
-        "js-tokens": "^3.0.0"
+        "js-tokens": "^3.0.0 || ^4.0.0"
       }
     },
     "loud-rejection": {
@@ -5995,18 +5855,18 @@
       "dev": true
     },
     "mime-db": {
-      "version": "1.33.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
-      "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ==",
+      "version": "1.35.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.35.0.tgz",
+      "integrity": "sha512-JWT/IcCTsB0Io3AhWUMjRqucrHSPsSf2xKLaRldJVULioggvkJvggZ3VXNNSRkCddE6D+BUI4HEIZIA2OjwIvg==",
       "dev": true
     },
     "mime-types": {
-      "version": "2.1.18",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
-      "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
+      "version": "2.1.19",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.19.tgz",
+      "integrity": "sha512-P1tKYHVSZ6uFo26mtnve4HQFE3koh1UWVkp8YUC+ESBHe945xWSoXuHHiGarDqcEZ+whpCDnlNw5LON0kLo+sw==",
       "dev": true,
       "requires": {
-        "mime-db": "~1.33.0"
+        "mime-db": "~1.35.0"
       }
     },
     "minimalistic-assert": {
@@ -6101,14 +5961,14 @@
       "dev": true
     },
     "multer": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/multer/-/multer-1.3.0.tgz",
-      "integrity": "sha1-CSsmcPaEb6SRSWXvyM+Uwg/sbNI=",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-1.3.1.tgz",
+      "integrity": "sha512-JHdEoxkA/5NgZRo91RNn4UT+HdcJV9XUo01DTkKC7vo1erNIngtuaw9Y0WI8RdTlyi+wMIbunflhghzVLuGJyw==",
       "dev": true,
       "requires": {
         "append-field": "^0.1.0",
         "busboy": "^0.2.11",
-        "concat-stream": "^1.5.0",
+        "concat-stream": "^1.5.2",
         "mkdirp": "^0.5.1",
         "object-assign": "^3.0.0",
         "on-finished": "^2.3.0",
@@ -6154,9 +6014,9 @@
       }
     },
     "nanomatch": {
-      "version": "1.2.9",
-      "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.9.tgz",
-      "integrity": "sha512-n8R9bS8yQ6eSXaV6jHUpKzD8gLsin02w1HSFiegwrs9E098Ylhw5jdyKPaYqvHknHaSCKTPp7C8dGCQ0q9koXA==",
+      "version": "1.2.13",
+      "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
+      "integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
       "dev": true,
       "requires": {
         "arr-diff": "^4.0.0",
@@ -6164,7 +6024,6 @@
         "define-property": "^2.0.2",
         "extend-shallow": "^3.0.2",
         "fragment-cache": "^0.2.1",
-        "is-odd": "^2.0.0",
         "is-windows": "^1.0.2",
         "kind-of": "^6.0.2",
         "object.pick": "^1.3.0",
@@ -6207,15 +6066,6 @@
       "dev": true,
       "requires": {
         "lower-case": "^1.1.1"
-      }
-    },
-    "nodegit-promise": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/nodegit-promise/-/nodegit-promise-4.0.0.tgz",
-      "integrity": "sha1-VyKxhPLfcycWEGSnkdLoQskWezQ=",
-      "dev": true,
-      "requires": {
-        "asap": "~2.0.3"
       }
     },
     "nomnom": {
@@ -6719,9 +6569,9 @@
       }
     },
     "polymer-analyzer": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/polymer-analyzer/-/polymer-analyzer-3.0.1.tgz",
-      "integrity": "sha512-s1fEMUeUHs7EWZQ5cxL/RL6qzDcYnkJcLeQbNvVD1qOPtxRejGeonq5xsxmb8o7mstzSYb1x0Iba2Bdbfr+PAQ==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/polymer-analyzer/-/polymer-analyzer-3.1.1.tgz",
+      "integrity": "sha512-h/szQRobLO/fld2BsvTsmCFwtXQRF/tQcwquBuBl7qzgodaHWdvDIOE+VmzmYzM6W9/DW637O7JaeFnbXK/IgA==",
       "dev": true,
       "requires": {
         "@babel/generator": "^7.0.0-beta.42",
@@ -6738,7 +6588,6 @@
         "@types/doctrine": "^0.0.1",
         "@types/is-windows": "^0.2.0",
         "@types/minimatch": "^3.0.1",
-        "@types/node": "^9.6.4",
         "@types/parse5": "^2.2.34",
         "@types/path-is-inside": "^1.0.0",
         "@types/resolve": "0.0.6",
@@ -6764,12 +6613,6 @@
         "whatwg-url": "^6.4.0"
       },
       "dependencies": {
-        "@types/node": {
-          "version": "9.6.21",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.21.tgz",
-          "integrity": "sha512-zQS6mHzxEstR8Vvnpc3JDUCDGWnHFzMTcBu9UCZoVLuj1Uvkkk0qFKJQEhlvbsX34m3xt12ejV09eO/ljZcn7A==",
-          "dev": true
-        },
         "chalk": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
@@ -6792,9 +6635,9 @@
       }
     },
     "polymer-build": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/polymer-build/-/polymer-build-3.0.1.tgz",
-      "integrity": "sha512-XnNP9M/fUbwYYOPijMK6t+o9DOjO8kpj2rm6irefA00TGfaQXHZhgPpT0zdd5xjAyAcZ4lpaLGcjIcCLY5mkgg==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/polymer-build/-/polymer-build-3.0.4.tgz",
+      "integrity": "sha512-YSppvctpcO2do3XHXNo2WnD4mxpzTpjgLlByPXE0Jfz9N+Ez6EGmge7Xwd6NsFH9ch6IMyV1P9H238I/C/KZRw==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.0.0-beta.46",
@@ -6845,7 +6688,7 @@
         "babel-plugin-minify-guarded-expressions": "=0.4.1",
         "babel-preset-minify": "=0.4.0-alpha.caaefb4c",
         "babylon": "^7.0.0-beta.42",
-        "css-slam": "^2.1.1",
+        "css-slam": "^2.1.2",
         "dom5": "^3.0.0",
         "gulp-if": "^2.0.2",
         "html-minifier": "^3.5.10",
@@ -6875,9 +6718,9 @@
           }
         },
         "@types/node": {
-          "version": "9.6.21",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.21.tgz",
-          "integrity": "sha512-zQS6mHzxEstR8Vvnpc3JDUCDGWnHFzMTcBu9UCZoVLuj1Uvkkk0qFKJQEhlvbsX34m3xt12ejV09eO/ljZcn7A==",
+          "version": "9.6.28",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.28.tgz",
+          "integrity": "sha512-LMSOxMKNJ8tGqUVs8lSIT8RGo1XGWYada/ZU2QZcbcD6AW9futXDE99tfQA0K6DK60GXcwplsGGK5KABRmI5GA==",
           "dev": true
         },
         "@types/resolve": {
@@ -6888,19 +6731,13 @@
           "requires": {
             "@types/node": "*"
           }
-        },
-        "regenerator-runtime": {
-          "version": "0.11.1",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-          "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
-          "dev": true
         }
       }
     },
     "polymer-bundler": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/polymer-bundler/-/polymer-bundler-4.0.1.tgz",
-      "integrity": "sha512-nG+mpWn5h6nflOqZwtcpIKlYxXMznKFODa5XMQsUgD2126BT5cdznbMXCkH9vCIpbV5iBm5lCunmTyoYF+3BqA==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/polymer-bundler/-/polymer-bundler-4.0.2.tgz",
+      "integrity": "sha512-eH+MNSVb/bCqchxYE1gVtdLP9eq1pLsr9NdcHhiJGEgSoZOYq7lGm2M/L7DHGJqa1/OqC7ZC9Sz3eQKAB8FaJQ==",
       "dev": true,
       "requires": {
         "@types/acorn": "^4.0.3",
@@ -6911,44 +6748,19 @@
         "babel-traverse": "^6.26.0",
         "babel-types": "^6.26.0",
         "clone": "^2.1.0",
-        "command-line-args": "^3.0.1",
-        "command-line-usage": "^3.0.3",
-        "dom5": "^2.2.0",
+        "command-line-args": "^5.0.2",
+        "command-line-usage": "^5.0.5",
+        "dom5": "^3.0.0",
         "espree": "^3.5.2",
         "magic-string": "^0.22.4",
         "mkdirp": "^0.5.1",
-        "parse5": "^2.2.2",
+        "parse5": "^4.0.0",
         "polymer-analyzer": "^3.0.1",
         "rollup": "^0.58.2",
         "source-map": "^0.5.6",
         "vscode-uri": "^1.0.1"
       },
       "dependencies": {
-        "@types/node": {
-          "version": "6.0.113",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.113.tgz",
-          "integrity": "sha512-f9XXUWFqryzjkZA1EqFvJHSFyqyasV17fq8zCDIzbRV4ctL7RrJGKvG+lcex86Rjbzd1GrER9h9VmF5sSjV0BQ==",
-          "dev": true
-        },
-        "dom5": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/dom5/-/dom5-2.3.0.tgz",
-          "integrity": "sha1-+CBJdb0NrLvltYqKk//B/tD/zSo=",
-          "dev": true,
-          "requires": {
-            "@types/clone": "^0.1.29",
-            "@types/node": "^6.0.0",
-            "@types/parse5": "^2.2.32",
-            "clone": "^2.1.0",
-            "parse5": "^2.2.2"
-          }
-        },
-        "parse5": {
-          "version": "2.2.3",
-          "resolved": "https://registry.npmjs.org/parse5/-/parse5-2.2.3.tgz",
-          "integrity": "sha1-DE/EHBAAxea5PUiwP4CDg3g06fY=",
-          "dev": true
-        },
         "source-map": {
           "version": "0.5.7",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -6958,9 +6770,9 @@
       }
     },
     "polymer-project-config": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/polymer-project-config/-/polymer-project-config-4.0.1.tgz",
-      "integrity": "sha512-NJjP5gf6tOQ5YY8u0UM3hzrXPF2hpNIIyXCtd5VNCYoRGJdT//UFubyWFDd9Aje09yNWjS1SAfjZIhMgZ5DESg==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/polymer-project-config/-/polymer-project-config-4.0.2.tgz",
+      "integrity": "sha512-nnxLkbpYYPIVBYooeercovQIWqq4coHzQ5PwK2+NxNpVWUJ5tW3OCDt46dqw3CtJNe4r/qIOkPgBJdVwXAAEmw==",
       "dev": true,
       "requires": {
         "@types/node": "^9.6.4",
@@ -6971,24 +6783,24 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "9.6.21",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.21.tgz",
-          "integrity": "sha512-zQS6mHzxEstR8Vvnpc3JDUCDGWnHFzMTcBu9UCZoVLuj1Uvkkk0qFKJQEhlvbsX34m3xt12ejV09eO/ljZcn7A==",
+          "version": "9.6.28",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.28.tgz",
+          "integrity": "sha512-LMSOxMKNJ8tGqUVs8lSIT8RGo1XGWYada/ZU2QZcbcD6AW9futXDE99tfQA0K6DK60GXcwplsGGK5KABRmI5GA==",
           "dev": true
         }
       }
     },
     "polyserve": {
-      "version": "0.27.11",
-      "resolved": "https://registry.npmjs.org/polyserve/-/polyserve-0.27.11.tgz",
-      "integrity": "sha512-C6laEBzDawtKzJEojv2wjUbuu66fNFEOfHsbHztrw0jn0CZsaV1okWEuFczgMNgW5ZL+Eg+QC4hzsHNA1dZZaw==",
+      "version": "0.27.12",
+      "resolved": "https://registry.npmjs.org/polyserve/-/polyserve-0.27.12.tgz",
+      "integrity": "sha512-P4lb0fNqkSSRHrKTp9/bUnTjZOmnNnLWJ5zMBiWjkkJe3vzNcRpdL0vMQO6RxZ8MUvBI2Iv9mqGPVPY+Dk+Z1w==",
       "dev": true,
       "requires": {
         "@types/compression": "^0.0.33",
         "@types/content-type": "^1.1.0",
         "@types/escape-html": "0.0.20",
         "@types/express": "^4.0.36",
-        "@types/mime": "0.0.29",
+        "@types/mime": "^2.0.0",
         "@types/mz": "0.0.29",
         "@types/node": "^9.6.4",
         "@types/opn": "^3.0.28",
@@ -6999,8 +6811,8 @@
         "@types/spdy": "^3.4.1",
         "bower-config": "^1.4.1",
         "browser-capabilities": "^1.0.0",
-        "command-line-args": "^3.0.1",
-        "command-line-usage": "^3.0.3",
+        "command-line-args": "^5.0.2",
+        "command-line-usage": "^5.0.5",
         "compression": "^1.6.2",
         "content-type": "^1.0.2",
         "escape-html": "^1.0.3",
@@ -7008,109 +6820,72 @@
         "find-port": "^1.0.1",
         "http-proxy-middleware": "^0.17.2",
         "lru-cache": "^4.0.2",
-        "mime": "^1.3.4",
+        "mime": "^2.3.1",
         "mz": "^2.4.0",
         "opn": "^3.0.2",
         "pem": "^1.8.3",
-        "polymer-build": "^3.0.0",
+        "polymer-build": "^3.0.3",
         "polymer-project-config": "^4.0.0",
         "requirejs": "^2.3.4",
         "resolve": "^1.5.0",
-        "send": "^0.14.1",
+        "send": "^0.16.2",
         "spdy": "^3.3.3"
       },
       "dependencies": {
         "@types/node": {
-          "version": "9.6.21",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.21.tgz",
-          "integrity": "sha512-zQS6mHzxEstR8Vvnpc3JDUCDGWnHFzMTcBu9UCZoVLuj1Uvkkk0qFKJQEhlvbsX34m3xt12ejV09eO/ljZcn7A==",
+          "version": "9.6.28",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.28.tgz",
+          "integrity": "sha512-LMSOxMKNJ8tGqUVs8lSIT8RGo1XGWYada/ZU2QZcbcD6AW9futXDE99tfQA0K6DK60GXcwplsGGK5KABRmI5GA==",
           "dev": true
         },
         "debug": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "dev": true,
           "requires": {
-            "ms": "0.7.1"
-          },
-          "dependencies": {
-            "ms": {
-              "version": "0.7.1",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-              "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
-              "dev": true
-            }
+            "ms": "2.0.0"
           }
         },
-        "etag": {
-          "version": "1.7.0",
-          "resolved": "https://registry.npmjs.org/etag/-/etag-1.7.0.tgz",
-          "integrity": "sha1-A9MLX2fdbmMtKUXTDWZScxo01dg=",
-          "dev": true
-        },
-        "fresh": {
-          "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.3.0.tgz",
-          "integrity": "sha1-ZR+DjiJCTnVm3hYdg1jKoZn4PU8=",
-          "dev": true
-        },
-        "http-errors": {
-          "version": "1.5.1",
-          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.5.1.tgz",
-          "integrity": "sha1-eIwNLB3iyBuebowBhDtrl+uSB1A=",
-          "dev": true,
-          "requires": {
-            "inherits": "2.0.3",
-            "setprototypeof": "1.0.2",
-            "statuses": ">= 1.3.1 < 2"
-          }
-        },
-        "ms": {
-          "version": "0.7.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
-          "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U=",
+        "mime": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-2.3.1.tgz",
+          "integrity": "sha512-OEUllcVoydBHGN1z84yfQDimn58pZNNNXgZlHXSboxMlFvgI6MXSWpWKpFRra7H1HxpVhHTkrghfRW49k6yjeg==",
           "dev": true
         },
         "send": {
-          "version": "0.14.2",
-          "resolved": "https://registry.npmjs.org/send/-/send-0.14.2.tgz",
-          "integrity": "sha1-ObBDiz9RC+Xcb2Z6EfcWiTaM3u8=",
+          "version": "0.16.2",
+          "resolved": "https://registry.npmjs.org/send/-/send-0.16.2.tgz",
+          "integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
           "dev": true,
           "requires": {
-            "debug": "~2.2.0",
-            "depd": "~1.1.0",
+            "debug": "2.6.9",
+            "depd": "~1.1.2",
             "destroy": "~1.0.4",
-            "encodeurl": "~1.0.1",
+            "encodeurl": "~1.0.2",
             "escape-html": "~1.0.3",
-            "etag": "~1.7.0",
-            "fresh": "0.3.0",
-            "http-errors": "~1.5.1",
-            "mime": "1.3.4",
-            "ms": "0.7.2",
+            "etag": "~1.8.1",
+            "fresh": "0.5.2",
+            "http-errors": "~1.6.2",
+            "mime": "1.4.1",
+            "ms": "2.0.0",
             "on-finished": "~2.3.0",
             "range-parser": "~1.2.0",
-            "statuses": "~1.3.1"
+            "statuses": "~1.4.0"
           },
           "dependencies": {
             "mime": {
-              "version": "1.3.4",
-              "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
-              "integrity": "sha1-EV+eO2s9rylZmDyzjxSaLUDrXVM=",
+              "version": "1.4.1",
+              "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
+              "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==",
               "dev": true
             }
           }
         },
-        "setprototypeof": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.2.tgz",
-          "integrity": "sha1-gaVSFB7BBLiOic44MQOtXGZWTQg=",
-          "dev": true
-        },
         "statuses": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
-          "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4=",
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
+          "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==",
           "dev": true
         }
       }
@@ -7157,32 +6932,14 @@
       "integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8=",
       "dev": true
     },
-    "promisify-node": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/promisify-node/-/promisify-node-0.4.0.tgz",
-      "integrity": "sha1-MoA4dOxBF4TkeGwzmQKoeheaRpw=",
-      "dev": true,
-      "requires": {
-        "nodegit-promise": "~4.0.0",
-        "object-assign": "^4.0.1"
-      },
-      "dependencies": {
-        "object-assign": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-          "dev": true
-        }
-      }
-    },
     "proxy-addr": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.3.tgz",
-      "integrity": "sha512-jQTChiCJteusULxjBp8+jftSQE5Obdl3k4cnmLA6WXtK6XFuWRnvVL7aCiBqaLPM8c4ph0S4tKna8XvmIwEnXQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.4.tgz",
+      "integrity": "sha512-5erio2h9jp5CHGwcybmxmVqHmnCBZeewlfJ0pex+UW7Qny7OOZXTtH56TGNyBizkgiOwhJtMKrVzDTeKcySZwA==",
       "dev": true,
       "requires": {
         "forwarded": "~0.1.2",
-        "ipaddr.js": "1.6.0"
+        "ipaddr.js": "1.8.0"
       }
     },
     "pseudomap": {
@@ -7211,9 +6968,9 @@
       "dev": true
     },
     "randomatic": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.0.0.tgz",
-      "integrity": "sha512-VdxFOIEY3mNO5PtSRkkle/hPJDHvQhK21oa73K4yAc9qmp6N429gAyF1gZMOTMeS0/AYzaV/2Trcef+NaIonSA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.1.0.tgz",
+      "integrity": "sha512-KnGPVE0lo2WoXxIZ7cPR8YBpiol4gsSuOwDSg410oHh80ZMp5EiypNqL2K4Z77vJn6lB5rap7IkAmcUlalcnBQ==",
       "dev": true,
       "requires": {
         "is-number": "^4.0.0",
@@ -7265,12 +7022,6 @@
         "strip-json-comments": "~2.0.1"
       },
       "dependencies": {
-        "deep-extend": {
-          "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-          "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-          "dev": true
-        },
         "minimist": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
@@ -7371,10 +7122,16 @@
         "regenerate": "^1.4.0"
       }
     },
+    "regenerator-runtime": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
+      "dev": true
+    },
     "regenerator-transform": {
-      "version": "0.12.4",
-      "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.12.4.tgz",
-      "integrity": "sha512-p2I0fY+TbSLD2/VFTFb/ypEHxs3e3AjU0DzttdPqk2bSmDhfSh5E54b86Yc6XhUa5KykK1tgbvZ4Nr82oCJWkQ==",
+      "version": "0.13.3",
+      "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.13.3.tgz",
+      "integrity": "sha512-5ipTrZFSq5vU2YoGoww4uaRVAK4wyYC4TSICibbfEPOruUu8FFP7ErV0BjmbIOEpn3O/k9na9UEdYR/3m7N6uA==",
       "dev": true,
       "requires": {
         "private": "^0.1.6"
@@ -7664,9 +7421,9 @@
       "dev": true
     },
     "selenium-standalone": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/selenium-standalone/-/selenium-standalone-6.15.0.tgz",
-      "integrity": "sha512-SUEbbxo/IK2RsuPQ1QFgdyKXvxDYJUen6nR40zWL9P0FrqeuAXHNCWdtqnwbgGeoCxCVbPVzUsXfSKtjp2+j0g==",
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/selenium-standalone/-/selenium-standalone-6.15.1.tgz",
+      "integrity": "sha512-2VXqkcpd+RNJZwCp8UMmqubeSkLvscraRZtg2qdkXwoNNmx5Hu6uaOBy45VJNG6PiUJNZtBZQpnOUfNN2aD1EA==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -8566,17 +8323,16 @@
       }
     },
     "table-layout": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-0.3.0.tgz",
-      "integrity": "sha1-buINxIPbNxs+XIf3BO0vfHmdLJo=",
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-0.4.4.tgz",
+      "integrity": "sha512-uNaR3SRMJwfdp9OUr36eyEi6LLsbcTqTO/hfTsNviKsNeyMBPICJCC7QXRF3+07bAP6FRwA8rczJPBqXDc0CkQ==",
       "dev": true,
       "requires": {
-        "array-back": "^1.0.3",
-        "core-js": "^2.4.1",
-        "deep-extend": "~0.4.1",
-        "feature-detect-es6": "^1.3.1",
-        "typical": "^2.6.0",
-        "wordwrapjs": "^2.0.0-0"
+        "array-back": "^2.0.0",
+        "deep-extend": "~0.6.0",
+        "lodash.padend": "^4.6.1",
+        "typical": "^2.6.1",
+        "wordwrapjs": "^3.0.0"
       }
     },
     "tar-stream": {
@@ -8662,13 +8418,13 @@
       }
     },
     "test-value": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/test-value/-/test-value-2.1.0.tgz",
-      "integrity": "sha1-Edpv9nDzRxpztiXKTz/c97t0gpE=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/test-value/-/test-value-3.0.0.tgz",
+      "integrity": "sha512-sVACdAWcZkSU9x7AOmJo5TqE+GyNJknHaHsMrR6ZnhjVlVN9Yx6FjHrsKZ3BjIpPCT68zYesPWkakrNupwfOTQ==",
       "dev": true,
       "requires": {
-        "array-back": "^1.0.3",
-        "typical": "^2.6.0"
+        "array-back": "^2.0.0",
+        "typical": "^2.6.1"
       }
     },
     "text-encoding": {
@@ -9027,16 +8783,6 @@
       "integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag=",
       "dev": true
     },
-    "underscore.string": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.3.4.tgz",
-      "integrity": "sha1-LCo/n4PmR2L9xF5s6sZRQoZCE9s=",
-      "dev": true,
-      "requires": {
-        "sprintf-js": "^1.0.3",
-        "util-deprecate": "^1.0.2"
-      }
-    },
     "unicode-canonical-property-names-ecmascript": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz",
@@ -9232,21 +8978,10 @@
       }
     },
     "use": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/use/-/use-3.1.0.tgz",
-      "integrity": "sha512-6UJEQM/L+mzC3ZJNM56Q4DFGLX/evKGRg15UJHGB9X5j5Z3AFbgZvjUh2yq/UJUY4U5dh7Fal++XbNg1uzpRAw==",
-      "dev": true,
-      "requires": {
-        "kind-of": "^6.0.2"
-      },
-      "dependencies": {
-        "kind-of": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-          "dev": true
-        }
-      }
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
+      "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
+      "dev": true
     },
     "util": {
       "version": "0.11.0",
@@ -9270,9 +9005,9 @@
       "dev": true
     },
     "uuid": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
-      "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
       "dev": true
     },
     "vali-date": {
@@ -9282,9 +9017,9 @@
       "dev": true
     },
     "validate-npm-package-license": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz",
-      "integrity": "sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
       "dev": true,
       "requires": {
         "spdx-correct": "^3.0.0",
@@ -9397,9 +9132,9 @@
       "dev": true
     },
     "vscode-uri": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-1.0.5.tgz",
-      "integrity": "sha1-O4majvccN/MFTXm9vdoxx7828g0=",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-1.0.6.tgz",
+      "integrity": "sha512-sLI2L0uGov3wKVb9EB+vIQBl9tVP90nqRvxSoJ35vI3NjxE8jfsE5DSOhWgSunHSZmKS4OCi2jrtfxK7uyp2ww==",
       "dev": true
     },
     "wbuf": {
@@ -9559,9 +9294,9 @@
       }
     },
     "wct-local": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/wct-local/-/wct-local-2.1.0.tgz",
-      "integrity": "sha512-OiMSbxp6e5tyvTbUA4VAQbw4we53EXEmekx9BbIgS/HryoQISzap5DSAE/kvpRpJ2Axt0z12d8ChxqwNflApfA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/wct-local/-/wct-local-2.1.1.tgz",
+      "integrity": "sha512-U0qcIzsjl0vJ2KR5K766WVzJlmqfMRo8VqgRVQmrePGBsE40vj9hD+XiFw8yusamibZEWRU+DtVP3GKSwJz2EQ==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -9574,77 +9309,39 @@
         "cleankill": "^2.0.0",
         "freeport": "^1.0.4",
         "launchpad": "^0.7.0",
-        "promisify-node": "^0.4.0",
         "selenium-standalone": "^6.7.0",
         "which": "^1.0.8"
       },
       "dependencies": {
         "@types/node": {
-          "version": "9.6.21",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.21.tgz",
-          "integrity": "sha512-zQS6mHzxEstR8Vvnpc3JDUCDGWnHFzMTcBu9UCZoVLuj1Uvkkk0qFKJQEhlvbsX34m3xt12ejV09eO/ljZcn7A==",
+          "version": "9.6.28",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.28.tgz",
+          "integrity": "sha512-LMSOxMKNJ8tGqUVs8lSIT8RGo1XGWYada/ZU2QZcbcD6AW9futXDE99tfQA0K6DK60GXcwplsGGK5KABRmI5GA==",
           "dev": true,
           "optional": true
         }
       }
     },
     "wct-sauce": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/wct-sauce/-/wct-sauce-2.0.1.tgz",
-      "integrity": "sha512-nk6cPKdACVt3R+n9XyCTQTeRKOhhajyh0WaF5U1BsxPlVS8tNOUGleXQDUUjB+q1DPS7+j1F3UJqhnmrUMDVJA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/wct-sauce/-/wct-sauce-2.1.0.tgz",
+      "integrity": "sha512-c3R4PJcbpS7Gxv2vZ4HDAqpXV6cT9peslAWMU7hHH9PMhKDPbn8RNa6E4DVL0tOmZznB+3cRmtZ6+vJ/aDwu1A==",
       "dev": true,
       "optional": true,
       "requires": {
-        "chalk": "^1.1.1",
+        "chalk": "^2.4.1",
         "cleankill": "^2.0.0",
-        "lodash": "^3.0.1",
+        "lodash": "^4.17.10",
         "request": "^2.85.0",
         "sauce-connect-launcher": "^1.0.0",
         "temp": "^0.8.1",
-        "uuid": "^2.0.1"
-      },
-      "dependencies": {
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
-          }
-        },
-        "lodash": {
-          "version": "3.10.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
-          "dev": true,
-          "optional": true
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true,
-          "optional": true
-        },
-        "uuid": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
-          "integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho=",
-          "dev": true,
-          "optional": true
-        }
+        "uuid": "^3.2.1"
       }
     },
     "wd": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/wd/-/wd-1.9.0.tgz",
-      "integrity": "sha512-etqaVS5YFPuwaBRXNFnG0UIoCJHIPoWbVgdbK0v8MQRPQx2sNJc/wu0cRzLEuQjhGt/b0NGxcO1CvA5IAqoWrg==",
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/wd/-/wd-1.10.3.tgz",
+      "integrity": "sha512-ffqqZDtFFLeg5u/4pw2vYKECW+z+vW6vc+7rcqF15uu1/rmw3BydV84BONNc9DIcQ5Z7gQFS/hAuMvj53eVtSg==",
       "dev": true,
       "requires": {
         "archiver": "2.1.1",
@@ -9653,7 +9350,6 @@
         "mkdirp": "^0.5.1",
         "q": "1.4.1",
         "request": "2.85.0",
-        "underscore.string": "3.3.4",
         "vargs": "0.1.0"
       },
       "dependencies": {
@@ -9705,9 +9401,9 @@
       }
     },
     "web-component-tester": {
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/web-component-tester/-/web-component-tester-6.6.0.tgz",
-      "integrity": "sha512-f+LqR4rHUtVIg6T79uo6BYuyrIOzInPWzOJo69sGxX3tRTDeTwQzJSrfX4/MKA4qa3ldGPODJHizRYgZbjYjbQ==",
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/web-component-tester/-/web-component-tester-6.8.0.tgz",
+      "integrity": "sha512-zj1nZ7dq270svfkdPo4Mc4CuCTab/Wp0SMIKb8g6xD0Q76g15ttHyscYAxQkywVuabwgWeTXiotUOiQaiwX8uA==",
       "dev": true,
       "requires": {
         "@polymer/sinonjs": "^1.14.1",
@@ -9717,18 +9413,15 @@
         "async": "^2.4.1",
         "body-parser": "^1.17.2",
         "bower-config": "^1.4.0",
-        "chai": "^4.0.2",
         "chalk": "^1.1.3",
         "cleankill": "^2.0.0",
         "express": "^4.15.3",
         "findup-sync": "^2.0.0",
         "glob": "^7.1.2",
         "lodash": "^3.10.1",
-        "mocha": "^3.4.2",
         "multer": "^1.3.0",
         "nomnom": "^1.8.1",
         "polyserve": "^0.27.11",
-        "promisify-node": "^0.4.0",
         "resolve": "^1.5.0",
         "semver": "^5.3.0",
         "send": "^0.11.1",
@@ -9738,8 +9431,8 @@
         "socket.io": "^2.0.3",
         "stacky": "^1.3.1",
         "update-notifier": "^2.2.0",
-        "wct-local": "^2.1.0",
-        "wct-sauce": "^2.0.0",
+        "wct-local": "^2.1.1",
+        "wct-sauce": "^2.0.2",
         "wd": "^1.2.0"
       },
       "dependencies": {
@@ -9750,9 +9443,9 @@
           "dev": true
         },
         "@webcomponents/webcomponentsjs": {
-          "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/@webcomponents/webcomponentsjs/-/webcomponentsjs-1.2.2.tgz",
-          "integrity": "sha512-VQlEKZwJFBz4x7VwYdZYeCNYvF39hJHoaGKfcKnv6u01tkXK9c0UCl1Zx4yBrMF+H1+rFvX6PLzDLFgUvZagmQ==",
+          "version": "1.2.4",
+          "resolved": "https://registry.npmjs.org/@webcomponents/webcomponentsjs/-/webcomponentsjs-1.2.4.tgz",
+          "integrity": "sha512-JiratNkqWceEsC8Y/IgSR5NvzUFjiUj7K489YU8CP6a9QyKNNFdCZv06tht2uJfAomuXOgXuXktNhD0VtH9v9A==",
           "dev": true
         },
         "async": {
@@ -9772,12 +9465,6 @@
             }
           }
         },
-        "browser-stdout": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
-          "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
-          "dev": true
-        },
         "chalk": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
@@ -9791,30 +9478,6 @@
             "supports-color": "^2.0.0"
           }
         },
-        "commander": {
-          "version": "2.9.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-          "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
-          "dev": true,
-          "requires": {
-            "graceful-readlink": ">= 1.0.0"
-          }
-        },
-        "debug": {
-          "version": "2.6.8",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "diff": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
-          "integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k=",
-          "dev": true
-        },
         "formatio": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.2.0.tgz",
@@ -9823,18 +9486,6 @@
           "requires": {
             "samsam": "1.x"
           }
-        },
-        "growl": {
-          "version": "1.9.2",
-          "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
-          "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=",
-          "dev": true
-        },
-        "has-flag": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-          "dev": true
         },
         "isarray": {
           "version": "0.0.1",
@@ -9853,51 +9504,6 @@
           "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.6.0.tgz",
           "integrity": "sha1-OpoCg0UqR9dDnnJzG54H1zhuSfY=",
           "dev": true
-        },
-        "mocha": {
-          "version": "3.5.3",
-          "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.5.3.tgz",
-          "integrity": "sha512-/6na001MJWEtYxHOV1WLfsmR4YIynkUEhBwzsb+fk2qmQ3iqsi258l/Q2MWHJMImAcNpZ8DEdYAK72NHoIQ9Eg==",
-          "dev": true,
-          "requires": {
-            "browser-stdout": "1.3.0",
-            "commander": "2.9.0",
-            "debug": "2.6.8",
-            "diff": "3.2.0",
-            "escape-string-regexp": "1.0.5",
-            "glob": "7.1.1",
-            "growl": "1.9.2",
-            "he": "1.1.1",
-            "json3": "3.3.2",
-            "lodash.create": "3.1.1",
-            "mkdirp": "0.5.1",
-            "supports-color": "3.1.2"
-          },
-          "dependencies": {
-            "glob": {
-              "version": "7.1.1",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
-              "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
-              "dev": true,
-              "requires": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^3.0.2",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
-              }
-            },
-            "supports-color": {
-              "version": "3.1.2",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
-              "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
-              "dev": true,
-              "requires": {
-                "has-flag": "^1.0.0"
-              }
-            }
-          }
         },
         "path-to-regexp": {
           "version": "1.7.0",
@@ -10009,15 +9615,13 @@
       "dev": true
     },
     "wordwrapjs": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-2.0.0.tgz",
-      "integrity": "sha1-q1X2leYRjak4WP3XDAU9HF4BrCA=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-3.0.0.tgz",
+      "integrity": "sha512-mO8XtqyPvykVCsrwj5MlOVWvSnCdT+C+QVbm6blradR7JExAhbkZ7hZ9A+9NUtwzSqrlUo9a67ws0EiILrvRpw==",
       "dev": true,
       "requires": {
-        "array-back": "^1.0.3",
-        "feature-detect-es6": "^1.3.1",
         "reduce-flatten": "^1.0.1",
-        "typical": "^2.6.0"
+        "typical": "^2.6.1"
       }
     },
     "wrappy": {
@@ -10100,9 +9704,9 @@
       }
     },
     "yauzl": {
-      "version": "2.9.2",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.9.2.tgz",
-      "integrity": "sha1-T7G8euH8L1cDe1SvasyP4QMcW3c=",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
       "dev": true,
       "optional": true,
       "requires": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "test": "npm run build && npm run lint && wct --npm",
     "quicktest": "wct -l chrome -p --npm",
     "checksize": "uglifyjs core.js -mc --toplevel | gzip -9 | wc -c",
+    "min": "uglifyjs core.js -mc --toplevel",
     "format": "find src test | grep '\\.js$\\|\\.ts$' | xargs clang-format --style=file -i",
     "lint": "tslint --project ./",
     "prepare": "npm run build"

--- a/package.json
+++ b/package.json
@@ -35,10 +35,7 @@
   "devDependencies": {
     "@types/chai": "^4.1.0",
     "@types/mocha": "^5.2.0",
-    "@webcomponents/shadycss": "^1.2.1",
-    "@webcomponents/template": "^1.3.1",
-    "@webcomponents/webcomponentsjs": "^2.0.2",
-    "babel-polyfill": "^6.26.0",
+    "@webcomponents/webcomponentsjs": "^2.0.4",
     "chai": "^4.1.2",
     "mocha": "^5.2.0",
     "tslint": "^5.9.1",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "typescript": "^2.8.3",
     "uglify-es": "^3.3.5",
     "wct-browser-legacy": "^1.0.1",
-    "web-component-tester": "^6.6.0"
+    "web-component-tester": "^6.8.0"
   },
   "typings": "lit-html.d.ts",
   "dependencies": {}

--- a/src/core.ts
+++ b/src/core.ts
@@ -478,6 +478,10 @@ export interface Part {
   commit(): void;
 }
 
+/**
+ * Sets attribute values for AttributeParts, so that the value is only set once
+ * even if there are multiple parts for an attribute.
+ */
 export class AttributeCommitter {
   element: Element;
   name: string;
@@ -491,8 +495,15 @@ export class AttributeCommitter {
     this.strings = strings;
     this.parts = [];
     for (let i = 0; i < strings.length - 1; i++) {
-      this.parts[i] = new AttributePart(this);
+      this.parts[i] = this._createPart();
     }
+  }
+
+  /**
+   * Creates a single part. Override this to create a differnt type of part.
+   */
+  protected _createPart(): AttributePart {
+    return new AttributePart(this);
   }
 
   protected _getValue(): any {

--- a/src/core.ts
+++ b/src/core.ts
@@ -429,12 +429,12 @@ export class Template {
  * with certain DOM APIs, like textContent.
  */
 export const getValue = (part: Part, value: any) => {
-  // `null` as the value of a Text node will render the string 'null'
-  // so we convert it to undefined
   if (isDirective(value)) {
     value = value(part);
     return noChange;
   }
+  // `null` as the value of a Text node will render the string 'null'
+  // so we convert it to undefined
   return value === null ? undefined : value;
 };
 
@@ -580,7 +580,15 @@ export class NodePart implements Part {
   }
 
   setValue(value: any): void {
-    value = getValue(this, value);
+    if (isDirective(value)) {
+      this._pendingValue = noChange;
+      value(this);
+      return;
+    }
+    if (value === noChange) {
+      return;
+    }
+    value = value === null ? undefined : value;
     if (_isPrimitiveValue(value) && value === this._value) {
       value = noChange;
     }

--- a/src/core.ts
+++ b/src/core.ts
@@ -69,8 +69,8 @@ export class TemplateResult {
       // "...>...": text position. open === -1, close > -1
       // "...<...": attribute position. open > -1
       // "...": no change. open === -1, close === -1
-      isTextBinding = (close > -1 || isTextBinding) &&
-          s.indexOf('<', close + 1) === -1;
+      isTextBinding =
+          (close > -1 || isTextBinding) && s.indexOf('<', close + 1) === -1;
       html += isTextBinding ? nodeMarker : marker;
     }
     html += this.strings[l];
@@ -542,26 +542,25 @@ export class AttributeCommitter {
 export class AttributePart implements Part {
   committer: AttributeCommitter;
   _value: any = undefined;
+  _pendingValue: any = undefined;
 
   constructor(comitter: AttributeCommitter) {
     this.committer = comitter;
   }
 
   setValue(value: any): void {
-    value = getValue(this, value);
-    if (value === noChange) {
-      return;
-    }
-    if (_isPrimitiveValue(value)) {
-      if (value === this._value) {
-        return;
-      }
-    }
-    this._value = value;
-    this.committer.dirty = true;
+    this._pendingValue = value;
   }
 
   commit() {
+    let value = getValue(this, this._pendingValue);
+    if (value === noChange) {
+      return;
+    }
+    if (!_isPrimitiveValue(value) || value !== this._value) {
+      this._value = value;
+      this.committer.dirty = true;
+    }
     this.committer.commit();
   }
 }

--- a/src/core.ts
+++ b/src/core.ts
@@ -476,10 +476,8 @@ export interface Part {
   /**
    * Sets the current part value, but does not write it to the DOM.
    * @param value The value that will be committed.
-   * @param keyValue A different value to use for comparing against previous
-   *     values to determine if a part has changed. Optional.
    */
-  setValue(value: any, keyValue?: any): void;
+  setValue(value: any): void;
 
   /**
    * Commits the current part value, cause it to actually be written to the DOM.
@@ -551,17 +549,15 @@ export class AttributeCommitter {
 export class AttributePart implements Part {
   committer: AttributeCommitter;
   _value: any = undefined;
-  _keyValue: any = undefined;
 
   constructor(comitter: AttributeCommitter) {
     this.committer = comitter;
   }
 
-  setValue(value: any, keyValue: any = noChange): void {
+  setValue(value: any): void {
     value = value === null ? undefined : value;
-    if (value !== noChange || (keyValue === noChange || keyValue !== this._keyValue) || !_isPrimitiveValue(value) || value !== this._value) {
+    if (value !== noChange || !_isPrimitiveValue(value) || value !== this._value) {
       this._value = value;
-      this._keyValue = keyValue;
       if (!isDirective(value)) {
         this.committer.dirty = true;
       }
@@ -588,7 +584,6 @@ export class NodePart implements Part {
   endNode: Node;
   _value: any = undefined;
   _pendingValue: any = undefined;
-  _pendingKeyValue: any = undefined;
 
   constructor(instance: TemplateInstance, startNode: Node, endNode: Node) {
     this.instance = instance;
@@ -596,9 +591,8 @@ export class NodePart implements Part {
     this.endNode = endNode;
   }
 
-  setValue(value: any, keyValue: any = noChange): void {
+  setValue(value: any): void {
     this._pendingValue = value;
-    this._pendingKeyValue = keyValue;
   }
 
   commit() {
@@ -607,7 +601,7 @@ export class NodePart implements Part {
       this._pendingValue = noChange;
       directive(this);
     }
-    let value = this._pendingValue === null ? undefined : this._pendingValue;
+    const value = this._pendingValue === null ? undefined : this._pendingValue;
     if (value === noChange) {
       return;
     }
@@ -626,10 +620,6 @@ export class NodePart implements Part {
     } else {
       // Fallback, will render the string representation
       this._setText(value);
-    }
-    if (this._pendingKeyValue !== noChange) {
-      this._value = this._pendingKeyValue;
-      this._pendingKeyValue = noChange;
     }
   }
 

--- a/src/core.ts
+++ b/src/core.ts
@@ -482,6 +482,7 @@ export class AttributeCommitter {
   name: string;
   strings: string[];
   parts: AttributePart[];
+  dirty = true;
 
   constructor(element: Element, name: string, strings: string[]) {
     this.element = element;
@@ -518,15 +519,16 @@ export class AttributeCommitter {
   }
 
   commit(): void {
-    // console.log('AttributeCommitter.commit');
-    this.element.setAttribute(this.name, this._getValue());
+    if (this.dirty) {
+      this.dirty = false;
+      this.element.setAttribute(this.name, this._getValue());
+    }
   }
 }
 
 export class AttributePart implements Part {
   committer: AttributeCommitter;
   _value: any = undefined;
-  private _dirty = true;
 
   constructor(comitter: AttributeCommitter) {
     this.committer = comitter;
@@ -535,7 +537,6 @@ export class AttributePart implements Part {
   setValue(value: any): void {
     value = getValue(this, value);
     if (value === noChange) {
-      this._dirty = false;
       return;
     }
     if (_isPrimitiveValue(value)) {
@@ -544,14 +545,11 @@ export class AttributePart implements Part {
       }
     }
     this._value = value;
-    this._dirty = true;
+    this.committer.dirty = true;
   }
 
   commit() {
-    if (this._dirty) {
-      this._dirty = false;
-      this.committer.commit();
-    }
+    this.committer.commit();
   }
 }
 

--- a/src/core.ts
+++ b/src/core.ts
@@ -462,8 +462,9 @@ export const noChange = {};
  */
 export {noChange as directiveValue};
 
-export const _isPrimitiveValue = (value: any) => (value === null ||
-    !(typeof value === 'object' || typeof value === 'function'));
+export const _isPrimitiveValue = (value: any) =>
+    (value === null ||
+     !(typeof value === 'object' || typeof value === 'function'));
 
 /**
  * The Part interface represents a dynamic part of a template instance rendered
@@ -471,7 +472,7 @@ export const _isPrimitiveValue = (value: any) => (value === null ||
  */
 export interface Part {
   _value: any;
-  
+
   setValue(value: any): void;
 
   commit(): void;
@@ -504,7 +505,8 @@ export class AttributeCommitter {
       const part = this.parts[i];
       if (part !== undefined) {
         const v = part._value;
-        if (v != null && (Array.isArray(v) || typeof v !== 'string' && v[Symbol.iterator])) {
+        if (v != null &&
+            (Array.isArray(v) || typeof v !== 'string' && v[Symbol.iterator])) {
           for (const t of v) {
             text += t;
           }
@@ -708,7 +710,6 @@ export class NodePart implements Part {
   commit() {
     // nothing for now...
   }
-
 }
 
 export type PartCallback =
@@ -716,17 +717,17 @@ export type PartCallback =
         Part[];
 
 export const defaultPartCallback =
-    (instance: TemplateInstance,
-     templatePart: TemplatePart,
-     node: Node): Part[] => {
-      if (templatePart.type === 'attribute') {
-        const comitter = new AttributeCommitter(node as Element, templatePart.name!, templatePart.strings!);
-        return comitter.parts;
-      } else if (templatePart.type === 'node') {
-        return [new NodePart(instance, node, node.nextSibling!)];
-      }
-      throw [new Error(`Unknown part type ${templatePart.type}`)];
-    };
+    (instance: TemplateInstance, templatePart: TemplatePart, node: Node):
+        Part[] => {
+          if (templatePart.type === 'attribute') {
+            const comitter = new AttributeCommitter(
+                node as Element, templatePart.name!, templatePart.strings!);
+            return comitter.parts;
+          } else if (templatePart.type === 'node') {
+            return [new NodePart(instance, node, node.nextSibling!)];
+          }
+          throw[new Error(`Unknown part type ${templatePart.type}`)];
+        };
 
 
 /**

--- a/src/core.ts
+++ b/src/core.ts
@@ -455,7 +455,7 @@ const isDirective = (o: any) =>
  * A sentinel value that signals that a value was handled by a directive and
  * should not be written to the DOM.
  */
-export const noChange = {'noChange': true};
+export const noChange = {};
 
 /**
  * @deprecated Use `noChange` instead.
@@ -469,12 +469,12 @@ export const _isPrimitiveValue = (value: any) => (value === null ||
  * The Part interface represents a dynamic part of a template instance rendered
  * by lit-html.
  */
-export abstract class Part {
-  _value: any = undefined;
-    
-  abstract setValue(value: any): void;
+export interface Part {
+  _value: any;
+  
+  setValue(value: any): void;
 
-  abstract commit(): void;
+  commit(): void;
 }
 
 export class AttributeCommitter {
@@ -493,7 +493,7 @@ export class AttributeCommitter {
     }
   }
 
-  commit(): void {
+  protected _getValue(): any {
     const strings = this.strings;
     const l = strings.length - 1;
     let text = '';
@@ -514,16 +514,21 @@ export class AttributeCommitter {
     }
 
     text += strings[l];
-    this.element.setAttribute(this.name, text);
+    return text;
+  }
+
+  commit(): void {
+    // console.log('AttributeCommitter.commit');
+    this.element.setAttribute(this.name, this._getValue());
   }
 }
 
-export class AttributePart extends Part {
+export class AttributePart implements Part {
   committer: AttributeCommitter;
+  _value: any = undefined;
   private _dirty = true;
 
   constructor(comitter: AttributeCommitter) {
-    super();
     this.committer = comitter;
   }
 
@@ -550,13 +555,13 @@ export class AttributePart extends Part {
   }
 }
 
-export class NodePart extends Part {
+export class NodePart implements Part {
   instance: TemplateInstance;
   startNode: Node;
   endNode: Node;
+  _value: any = undefined;
 
   constructor(instance: TemplateInstance, startNode: Node, endNode: Node) {
-    super();
     this.instance = instance;
     this.startNode = startNode;
     this.endNode = endNode;

--- a/src/lib/async-append.ts
+++ b/src/lib/async-append.ts
@@ -36,10 +36,10 @@ export const asyncAppend = <T>(
     DirectiveFn<NodePart> => directive(async (part: NodePart) => {
       // If we've already set up this particular iterable, we don't need
       // to do anything.
-      if (value === part._previousValue) {
+      if (value === part._value) {
         return;
       }
-      part._previousValue = value;
+      part._value = value;
 
       // We keep track of item Parts across iterations, so that we can
       // share marker nodes between consecutive Parts.
@@ -55,7 +55,7 @@ export const asyncAppend = <T>(
 
         // Check to make sure that value is the still the current value of
         // the part, and if not bail because a new value owns this part
-        if (part._previousValue !== value) {
+        if (part._value !== value) {
           break;
         }
 

--- a/src/lib/async-append.ts
+++ b/src/lib/async-append.ts
@@ -36,10 +36,10 @@ export const asyncAppend = <T>(
     DirectiveFn<NodePart> => directive(async (part: NodePart) => {
       // If we've already set up this particular iterable, we don't need
       // to do anything.
-      if (value === part._value) {
+      if (value === part.value) {
         return;
       }
-      part._value = value;
+      part.value = value;
 
       // We keep track of item Parts across iterations, so that we can
       // share marker nodes between consecutive Parts.
@@ -55,7 +55,7 @@ export const asyncAppend = <T>(
 
         // Check to make sure that value is the still the current value of
         // the part, and if not bail because a new value owns this part
-        if (part._value !== value) {
+        if (part.value !== value) {
           break;
         }
 

--- a/src/lib/async-append.ts
+++ b/src/lib/async-append.ts
@@ -88,6 +88,7 @@ export const asyncAppend = <T>(
         }
         itemPart = new NodePart(part.instance, itemStartNode, part.endNode);
         itemPart.setValue(v);
+        itemPart.commit();
         i++;
       }
     });

--- a/src/lib/async-replace.ts
+++ b/src/lib/async-replace.ts
@@ -37,7 +37,7 @@ export const asyncReplace =
         DirectiveFn<NodePart> => directive(async (part: NodePart) => {
           // If we've already set up this particular iterable, we don't need
           // to do anything.
-          if (value === part._previousValue) {
+          if (value === part._value) {
             return;
           }
 
@@ -46,7 +46,7 @@ export const asyncReplace =
           const itemPart =
               new NodePart(part.instance, part.startNode, part.endNode);
 
-          part._previousValue = itemPart;
+          part._value = itemPart;
 
           let i = 0;
 
@@ -59,7 +59,7 @@ export const asyncReplace =
 
             // Check to make sure that value is the still the current value of
             // the part, and if not bail because a new value owns this part
-            if (part._previousValue !== itemPart) {
+            if (part._value !== itemPart) {
               break;
             }
 

--- a/src/lib/async-replace.ts
+++ b/src/lib/async-replace.ts
@@ -37,7 +37,7 @@ export const asyncReplace =
         DirectiveFn<NodePart> => directive(async (part: NodePart) => {
           // If we've already set up this particular iterable, we don't need
           // to do anything.
-          if (value === part._value) {
+          if (value === part.value) {
             return;
           }
 
@@ -46,7 +46,7 @@ export const asyncReplace =
           const itemPart =
               new NodePart(part.instance, part.startNode, part.endNode);
 
-          part._value = itemPart;
+          part.value = itemPart;
 
           let i = 0;
 
@@ -59,7 +59,7 @@ export const asyncReplace =
 
             // Check to make sure that value is the still the current value of
             // the part, and if not bail because a new value owns this part
-            if (part._value !== itemPart) {
+            if (part.value !== itemPart) {
               break;
             }
 

--- a/src/lib/async-replace.ts
+++ b/src/lib/async-replace.ts
@@ -72,6 +72,7 @@ export const asyncReplace =
             }
 
             itemPart.setValue(v);
+            itemPart.commit();
             i++;
           }
         });

--- a/src/lib/lit-extended.ts
+++ b/src/lib/lit-extended.ts
@@ -12,11 +12,11 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {AttributePart, defaultPartCallback, Part, SVGTemplateResult, TemplateInstance, TemplatePart, TemplateResult} from '../core.js';
-import {BooleanAttributePart, EventPart, PropertyPart} from '../lit-html.js';
+import {defaultPartCallback, Part, SVGTemplateResult, TemplateInstance, TemplatePart, TemplateResult, AttributeCommitter} from '../core.js';
+import {BooleanAttributePart, EventPart, PropertyCommitter} from '../lit-html.js';
 
 export {render} from '../core.js';
-export {BooleanAttributePart, EventPart, PropertyPart} from '../lit-html.js';
+export {BooleanAttributePart, EventPart} from '../lit-html.js';
 
 /**
  * Interprets a template literal as a lit-extended HTML template.
@@ -59,29 +59,25 @@ export const svg = (strings: TemplateStringsArray, ...values: any[]) =>
  */
 export const extendedPartCallback =
     (instance: TemplateInstance, templatePart: TemplatePart, node: Node):
-        Part => {
+        Part[] => {
           if (templatePart.type === 'attribute') {
             if (templatePart.rawName!.substr(0, 3) === 'on-') {
               const eventName = templatePart.rawName!.slice(3);
-              return new EventPart(instance, node as Element, eventName);
+              return [new EventPart(node as Element, eventName)];
             }
             const lastChar =
                 templatePart.name!.substr(templatePart.name!.length - 1);
             if (lastChar === '$') {
               const name = templatePart.name!.slice(0, -1);
-              return new AttributePart(
-                  instance, node as Element, name, templatePart.strings!);
+              const comitter = new AttributeCommitter(node as Element, name, templatePart.strings!);
+              return comitter.parts;
             }
             if (lastChar === '?') {
               const name = templatePart.name!.slice(0, -1);
-              return new BooleanAttributePart(
-                  instance, node as Element, name, templatePart.strings!);
+              return [new BooleanAttributePart(node as Element, name, templatePart.strings!)];
             }
-            return new PropertyPart(
-                instance,
-                node as Element,
-                templatePart.rawName!,
-                templatePart.strings!);
+            const comitter = new PropertyCommitter(node as Element, templatePart.name!, templatePart.strings!);
+            return comitter.parts;
           }
           return defaultPartCallback(instance, templatePart, node);
         };

--- a/src/lib/lit-extended.ts
+++ b/src/lib/lit-extended.ts
@@ -12,7 +12,7 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {defaultPartCallback, Part, SVGTemplateResult, TemplateInstance, TemplatePart, TemplateResult, AttributeCommitter} from '../core.js';
+import {AttributeCommitter, defaultPartCallback, Part, SVGTemplateResult, TemplateInstance, TemplatePart, TemplateResult} from '../core.js';
 import {BooleanAttributePart, EventPart, PropertyCommitter} from '../lit-html.js';
 
 export {render} from '../core.js';
@@ -69,14 +69,17 @@ export const extendedPartCallback =
                 templatePart.name!.substr(templatePart.name!.length - 1);
             if (lastChar === '$') {
               const name = templatePart.name!.slice(0, -1);
-              const comitter = new AttributeCommitter(node as Element, name, templatePart.strings!);
+              const comitter = new AttributeCommitter(
+                  node as Element, name, templatePart.strings!);
               return comitter.parts;
             }
             if (lastChar === '?') {
               const name = templatePart.name!.slice(0, -1);
-              return [new BooleanAttributePart(node as Element, name, templatePart.strings!)];
+              return [new BooleanAttributePart(
+                  node as Element, name, templatePart.strings!)];
             }
-            const comitter = new PropertyCommitter(node as Element, templatePart.name!, templatePart.strings!);
+            const comitter = new PropertyCommitter(
+                node as Element, templatePart.name!, templatePart.strings!);
             return comitter.parts;
           }
           return defaultPartCallback(instance, templatePart, node);

--- a/src/lib/repeat.ts
+++ b/src/lib/repeat.ts
@@ -87,6 +87,7 @@ export function repeat<T>(
       }
 
       itemPart.setValue(result);
+      itemPart.commit();
     }
 
     // Cleanup

--- a/src/lib/unsafe-html.ts
+++ b/src/lib/unsafe-html.ts
@@ -31,10 +31,5 @@ export const unsafeHTML = (value: any): DirectiveFn<NodePart> =>
       // Use a <template> to parse HTML into Nodes
       const tmp = document.createElement('template');
       tmp.innerHTML = value;
-      part.setValue(document.importNode(tmp.content, true));
-      part.commit();
-
-      // Remember the actual value passed to unsafeHTML rather than the DOM
-      // Nodes we created
-      part._value = value;
+      part.setValue(document.importNode(tmp.content, true), value);
     });

--- a/src/lib/unsafe-html.ts
+++ b/src/lib/unsafe-html.ts
@@ -23,11 +23,18 @@ import {_isPrimitiveValue, directive, DirectiveFn, NodePart} from '../core.js';
  */
 export const unsafeHTML = (value: any): DirectiveFn<NodePart> =>
     directive((part: NodePart): void => {
-      if (part._previousValue === value && _isPrimitiveValue(value)) {
+
+      // Dirty check primitive values
+      if (part._value === value && _isPrimitiveValue(value)) {
         return;
       }
+
+      // Use a <template> to parse HTML into Nodes
       const tmp = document.createElement('template');
       tmp.innerHTML = value;
       part.setValue(document.importNode(tmp.content, true));
-      part._previousValue = value;
+
+      // Remember the actual value passed to unsafeHTML rather than the DOM
+      // Nodes we created
+      part._value = value;
     });

--- a/src/lib/unsafe-html.ts
+++ b/src/lib/unsafe-html.ts
@@ -23,7 +23,6 @@ import {_isPrimitiveValue, directive, DirectiveFn, NodePart} from '../core.js';
  */
 export const unsafeHTML = (value: any): DirectiveFn<NodePart> =>
     directive((part: NodePart): void => {
-
       // Dirty check primitive values
       if (part._value === value && _isPrimitiveValue(value)) {
         return;

--- a/src/lib/unsafe-html.ts
+++ b/src/lib/unsafe-html.ts
@@ -21,15 +21,20 @@ import {_isPrimitiveValue, directive, DirectiveFn, NodePart} from '../core.js';
  * sanitized or escaped, as it may lead to cross-site-scripting
  * vulnerabilities.
  */
+
+const previousValues = new WeakMap<NodePart, string>();
+
 export const unsafeHTML = (value: any): DirectiveFn<NodePart> =>
     directive((part: NodePart): void => {
       // Dirty check primitive values
-      if (part._value === value && _isPrimitiveValue(value)) {
+      const previousValue = previousValues.get(part);
+      if (previousValue === value && _isPrimitiveValue(value)) {
         return;
       }
 
       // Use a <template> to parse HTML into Nodes
       const tmp = document.createElement('template');
       tmp.innerHTML = value;
-      part.setValue(document.importNode(tmp.content, true), value);
+      part.setValue(document.importNode(tmp.content, true));
+      previousValues.set(part, value);
     });

--- a/src/lib/unsafe-html.ts
+++ b/src/lib/unsafe-html.ts
@@ -12,7 +12,7 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {_isPrimitiveValue, directive, DirectiveFn, NodePart} from '../core.js';
+import {isPrimitive, directive, DirectiveFn, NodePart} from '../core.js';
 
 /**
  * Renders the result as HTML, rather than text.
@@ -28,7 +28,7 @@ export const unsafeHTML = (value: any): DirectiveFn<NodePart> =>
     directive((part: NodePart): void => {
       // Dirty check primitive values
       const previousValue = previousValues.get(part);
-      if (previousValue === value && _isPrimitiveValue(value)) {
+      if (previousValue === value && isPrimitive(value)) {
         return;
       }
 

--- a/src/lib/unsafe-html.ts
+++ b/src/lib/unsafe-html.ts
@@ -32,6 +32,7 @@ export const unsafeHTML = (value: any): DirectiveFn<NodePart> =>
       const tmp = document.createElement('template');
       tmp.innerHTML = value;
       part.setValue(document.importNode(tmp.content, true));
+      part.commit();
 
       // Remember the actual value passed to unsafeHTML rather than the DOM
       // Nodes we created

--- a/src/lib/unsafe-html.ts
+++ b/src/lib/unsafe-html.ts
@@ -12,7 +12,7 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {isPrimitive, directive, DirectiveFn, NodePart} from '../core.js';
+import {directive, DirectiveFn, isPrimitive, NodePart} from '../core.js';
 
 /**
  * Renders the result as HTML, rather than text.

--- a/src/lib/until.ts
+++ b/src/lib/until.ts
@@ -19,9 +19,8 @@ import {directive, DirectiveFn, NodePart} from '../core.js';
  */
 export const until =
     (promise: Promise<any>, defaultContent: any): DirectiveFn<NodePart> =>
-        directive((part: NodePart): void => {
+        directive((part: NodePart) => {
           part.setValue(defaultContent);
           part.commit();
           part.setValue(promise);
-          part.commit();
         });

--- a/src/lib/until.ts
+++ b/src/lib/until.ts
@@ -21,5 +21,7 @@ export const until =
     (promise: Promise<any>, defaultContent: any): DirectiveFn<NodePart> =>
         directive((part: NodePart): void => {
           part.setValue(defaultContent);
+          part.commit();
           part.setValue(promise);
+          part.commit();
         });

--- a/src/lit-html.ts
+++ b/src/lit-html.ts
@@ -128,6 +128,20 @@ export class BooleanAttributePart implements Part {
 }
 
 export class PropertyCommitter extends AttributeCommitter {
+  single: boolean;
+
+  constructor(element: Element, name: string, strings: string[]) {
+    super(element, name, strings);
+    this.single = (strings.length === 2 && strings[0] === '' && strings[1] === '');
+  }
+
+  _getValue() {
+    if (this.single) {
+      return this.parts[0]._value;
+    }
+    return super._getValue();
+  }
+
   commit(): void {
     if (this.dirty) {
       this.dirty = false;

--- a/src/lit-html.ts
+++ b/src/lit-html.ts
@@ -59,20 +59,23 @@ export const svg = (strings: TemplateStringsArray, ...values: any[]) =>
 export const partCallback =
     (instance: TemplateInstance,
      templatePart: TemplatePart,
-     node: Node): Part => {
+     node: Node): Part[] => {
       if (templatePart.type === 'attribute') {
         const name = templatePart.name!;
         const prefix = name[0];
         if (prefix === '.') {
-          return new PropertyPart(
-              instance, node as Element, name.slice(1), templatePart.strings!);
+          return [new PropertyPart(
+              instance, node as Element, name.slice(1), templatePart.strings!)];
         }
         if (prefix === '@') {
-          return new EventPart(instance, node as Element, name.slice(1));
+          return [new EventPart(instance, node as Element, name.slice(1))];
         }
         if (prefix === '?') {
-          return new BooleanAttributePart(
-              instance, node as Element, name.slice(1), templatePart.strings!);
+          return [new BooleanAttributePart(
+              instance,
+              node as Element,
+              name.slice(1),
+              templatePart.strings!)];
         }
       }
       return defaultPartCallback(instance, templatePart, node);
@@ -128,7 +131,7 @@ export class PropertyPart extends AttributePart {
   }
 }
 
-export class EventPart implements Part {
+export class EventPart extends Part {
   instance: TemplateInstance;
   element: Element;
   eventName: string;

--- a/src/lit-html.ts
+++ b/src/lit-html.ts
@@ -129,7 +129,10 @@ export class BooleanAttributePart implements Part {
 
 export class PropertyCommitter extends AttributeCommitter {
   commit(): void {
-    (this.element as any)[this.name] = this._getValue();
+    if (this.dirty) {
+      this.dirty = false;
+      (this.element as any)[this.name] = this._getValue();
+    }
   }
 }
 

--- a/src/lit-html.ts
+++ b/src/lit-html.ts
@@ -12,7 +12,7 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {AttributeCommitter, AttributePart, defaultPartCallback, getValue, noChange, Part, SVGTemplateResult, TemplateInstance, TemplatePart, TemplateResult} from './core.js';
+import {AttributeCommitter, defaultPartCallback, getValue, noChange, Part, SVGTemplateResult, TemplateInstance, TemplatePart, TemplateResult} from './core.js';
 
 export {render} from './core.js';
 

--- a/src/lit-html.ts
+++ b/src/lit-html.ts
@@ -12,7 +12,7 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {AttributePart, defaultPartCallback, getValue, noChange, Part, SVGTemplateResult, TemplateInstance, TemplatePart, TemplateResult, AttributeCommitter} from './core.js';
+import {AttributeCommitter, AttributePart, defaultPartCallback, getValue, noChange, Part, SVGTemplateResult, TemplateInstance, TemplatePart, TemplateResult} from './core.js';
 
 export {render} from './core.js';
 
@@ -57,28 +57,28 @@ export const svg = (strings: TemplateStringsArray, ...values: any[]) =>
  *     html`<input type="checkbox" ?checked=${value}>`
  */
 export const partCallback =
-    (instance: TemplateInstance,
-     templatePart: TemplatePart,
-     node: Node): Part[] => {
-      if (templatePart.type === 'attribute') {
-        const name = templatePart.name!;
-        const prefix = name[0];
-        if (prefix === '.') {
-          const comitter = new PropertyCommitter(node as Element, templatePart.name!.slice(1), templatePart.strings!);
-          return comitter.parts;
-        }
-        if (prefix === '@') {
-          return [new EventPart(node as Element, name.slice(1))];
-        }
-        if (prefix === '?') {
-          return [new BooleanAttributePart(
-              node as Element,
-              name.slice(1),
-              templatePart.strings!)];
-        }
-      }
-      return defaultPartCallback(instance, templatePart, node);
-    };
+    (instance: TemplateInstance, templatePart: TemplatePart, node: Node):
+        Part[] => {
+          if (templatePart.type === 'attribute') {
+            const name = templatePart.name!;
+            const prefix = name[0];
+            if (prefix === '.') {
+              const comitter = new PropertyCommitter(
+                  node as Element,
+                  templatePart.name!.slice(1),
+                  templatePart.strings!);
+              return comitter.parts;
+            }
+            if (prefix === '@') {
+              return [new EventPart(node as Element, name.slice(1))];
+            }
+            if (prefix === '?') {
+              return [new BooleanAttributePart(
+                  node as Element, name.slice(1), templatePart.strings!)];
+            }
+          }
+          return defaultPartCallback(instance, templatePart, node);
+        };
 
 /**
  * Implements a boolean attribute, roughly as defined in the HTML
@@ -132,7 +132,8 @@ export class PropertyCommitter extends AttributeCommitter {
 
   constructor(element: Element, name: string, strings: string[]) {
     super(element, name, strings);
-    this.single = (strings.length === 2 && strings[0] === '' && strings[1] === '');
+    this.single =
+        (strings.length === 2 && strings[0] === '' && strings[1] === '');
   }
 
   _getValue() {

--- a/src/lit-html.ts
+++ b/src/lit-html.ts
@@ -164,8 +164,10 @@ export class EventPart implements Part {
 
   setValue(value: any): void {
     value = getValue(this, value);
-    if (value !== noChange && (value == null) !== (this._value == null)) {
-      this._dirty = true;
+    if (value !== noChange) {
+      if ((value == null) !== (this._value == null)) {
+        this._dirty = true;
+      }
       this._value = value;
     }
   }

--- a/src/lit-html.ts
+++ b/src/lit-html.ts
@@ -12,7 +12,7 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {AttributeCommitter, defaultPartCallback, getValue, noChange, Part, SVGTemplateResult, TemplateInstance, TemplatePart, TemplateResult} from './core.js';
+import {AttributeCommitter, defaultPartCallback, getValue, noChange, Part, SVGTemplateResult, TemplateInstance, TemplatePart, TemplateResult, AttributePart} from './core.js';
 
 export {render} from './core.js';
 
@@ -127,6 +127,15 @@ export class BooleanAttributePart implements Part {
   }
 }
 
+/**
+ * Sets attribute values for PropertyParts, so that the value is only set once
+ * even if there are multiple parts for a property.
+ * 
+ * If an expression controls the whole property value, then the value is simply
+ * assigned to the property under control. If there are string literals or
+ * multiple expressions, then the strings are expressions are interpolated into
+ * a string first.
+ */
 export class PropertyCommitter extends AttributeCommitter {
   single: boolean;
 
@@ -134,6 +143,10 @@ export class PropertyCommitter extends AttributeCommitter {
     super(element, name, strings);
     this.single =
         (strings.length === 2 && strings[0] === '' && strings[1] === '');
+  }
+
+  protected _createPart(): PropertyPart {
+    return new PropertyPart(this);
   }
 
   _getValue() {
@@ -150,6 +163,8 @@ export class PropertyCommitter extends AttributeCommitter {
     }
   }
 }
+
+export class PropertyPart extends AttributePart {}
 
 export class EventPart implements Part {
   element: Element;

--- a/src/lit-html.ts
+++ b/src/lit-html.ts
@@ -207,7 +207,7 @@ export class EventPart implements Part {
   }
 
   setValue(value: any, keyValue: any = noChange): void {
-    value = !!value;
+    console.log('setValue', {value, keyValue});
     if (value !== noChange || (keyValue === noChange || keyValue !== this._keyValue) || value !== this._value) {
       this._value = value;
       this._keyValue = keyValue;
@@ -255,6 +255,7 @@ export class EventPart implements Part {
   // }
 
   handleEvent(event: Event) {
+    console.log('A', this._value);
     if (typeof this._value === 'function') {
       this._value.call(this.element, event);
     } else if (typeof this._value.handleEvent === 'function') {

--- a/src/lit-html.ts
+++ b/src/lit-html.ts
@@ -106,13 +106,6 @@ export class BooleanAttributePart implements Part {
 
   setValue(value: any): void {
     this._pendingValue = value;
-    // value = !!value;
-    // if (value !== noChange || value !== this._value) {
-    //   this._value = value;
-    //   if (!isDirective(value)) {
-    //     this._dirty = true;
-    //   }
-    // }
   }
 
   commit() {

--- a/src/lit-html.ts
+++ b/src/lit-html.ts
@@ -12,7 +12,7 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {AttributeCommitter, defaultPartCallback, getValue, noChange, Part, SVGTemplateResult, TemplateInstance, TemplatePart, TemplateResult, AttributePart} from './core.js';
+import {AttributeCommitter, AttributePart, defaultPartCallback, getValue, noChange, Part, SVGTemplateResult, TemplateInstance, TemplatePart, TemplateResult} from './core.js';
 
 export {render} from './core.js';
 
@@ -130,7 +130,7 @@ export class BooleanAttributePart implements Part {
 /**
  * Sets attribute values for PropertyParts, so that the value is only set once
  * even if there are multiple parts for a property.
- * 
+ *
  * If an expression controls the whole property value, then the value is simply
  * assigned to the property under control. If there are string literals or
  * multiple expressions, then the strings are expressions are interpolated into

--- a/src/lit-html.ts
+++ b/src/lit-html.ts
@@ -12,7 +12,7 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {isDirective, AttributeCommitter, AttributePart, defaultPartCallback, noChange, Part, SVGTemplateResult, TemplateInstance, TemplatePart, TemplateResult} from './core.js';
+import {AttributeCommitter, AttributePart, defaultPartCallback, isDirective, noChange, Part, SVGTemplateResult, TemplateInstance, TemplatePart, TemplateResult} from './core.js';
 
 export * from './core.js';
 

--- a/src/lit-html.ts
+++ b/src/lit-html.ts
@@ -91,7 +91,7 @@ export class BooleanAttributePart implements Part {
   element: Element;
   name: string;
   strings: string[];
-  _value: any = undefined;
+  value: any = undefined;
   _pendingValue: any = undefined;
 
   constructor(element: Element, name: string, strings: string[]) {
@@ -118,14 +118,14 @@ export class BooleanAttributePart implements Part {
       return;
     }
     const value = !!this._pendingValue;
-    if (this._value !== value) {
+    if (this.value !== value) {
       if (value) {
         this.element.setAttribute(this.name, '');
       } else {
         this.element.removeAttribute(this.name);
       }
     }
-    this._value = value;
+    this.value = value;
     this._pendingValue = noChange;
   }
 }
@@ -154,7 +154,7 @@ export class PropertyCommitter extends AttributeCommitter {
 
   _getValue() {
     if (this.single) {
-      return this.parts[0]._value;
+      return this.parts[0].value;
     }
     return super._getValue();
   }
@@ -172,7 +172,7 @@ export class PropertyPart extends AttributePart {}
 export class EventPart implements Part {
   element: Element;
   eventName: string;
-  _value: any = undefined;
+  value: any = undefined;
   _pendingValue: any = undefined;
 
   constructor(element: Element, eventName: string) {
@@ -193,22 +193,22 @@ export class EventPart implements Part {
     if (this._pendingValue === noChange) {
       return;
     }
-    if ((this._pendingValue == null) !== (this._value == null)) {
+    if ((this._pendingValue == null) !== (this.value == null)) {
       if (this._pendingValue == null) {
         this.element.removeEventListener(this.eventName, this);
       } else {
         this.element.addEventListener(this.eventName, this);
       }
     }
-    this._value = this._pendingValue;
+    this.value = this._pendingValue;
     this._pendingValue = noChange;
   }
 
   handleEvent(event: Event) {
-    if (typeof this._value === 'function') {
-      this._value.call(this.element, event);
-    } else if (typeof this._value.handleEvent === 'function') {
-      this._value.handleEvent(event);
+    if (typeof this.value === 'function') {
+      this.value.call(this.element, event);
+    } else if (typeof this.value.handleEvent === 'function') {
+      this.value.handleEvent(event);
     }
   }
 }

--- a/src/test/core_test.ts
+++ b/src/test/core_test.ts
@@ -359,6 +359,24 @@ suite('Core', () => {
             '<div foo="bar"></div>');
       });
 
+      test('renders multiple bindings in an attribute', () => {
+
+        let mutationRecords: MutationRecord[] = [];
+        const mutationObserver = new MutationObserver((records) => {
+          mutationRecords = records;
+        });
+        mutationObserver.observe(container, {attributes: true, subtree: true});
+
+        render(html`<div foo="a${'b'}c${'d'}e"></div>`, container);
+
+        mutationRecords = mutationObserver.takeRecords();
+
+        assert.equal(
+            stripExpressionDelimeters(container.innerHTML),
+            '<div foo="abcde"></div>');
+        assert.equal(mutationRecords.length, 1);
+      });
+
       test('renders a case-sensitive attribute', () => {
         const size = 100;
         render(html`<svg viewBox="0 0 ${size} ${size}"></svg>`, container);
@@ -663,8 +681,11 @@ suite('Core', () => {
         // This test is sensitive to the exact binding in the style tag.
         // Make sure the binding takes up the whole element with no text
         // on either side of it
+
+        // Work around a false positive lit-html pluging lint error:
+        const h = html;
         render(
-            html`
+            h`
             <style>${'bar'}</style>
             <a href="/buy/${'foo'}"></a>
           `,
@@ -700,8 +721,7 @@ suite('Core', () => {
 
       test('renders directives on AttributeParts', () => {
         const fooDirective = directive((part: AttributePart) => {
-          console.log('fooDirective', part.committer.name);
-          part.committer.element.setAttribute(part.committer.name, 'foo');
+          part.setValue('foo');
         });
 
         render(html`<div foo="${fooDirective}"></div>`, container);

--- a/src/test/core_test.ts
+++ b/src/test/core_test.ts
@@ -642,18 +642,18 @@ suite('Core', () => {
           </div>`);
       });
 
-      test('render style tags with expressions correctly', () => {
+      test('renders style tags with expressions correctly', () => {
         const color = 'red';
         const t = html`
           <style>
-            h1: {
+            h1 {
               color: ${color};
             }
           </style>`;
         render(t, container);
         assert.equal(stripExpressionDelimeters(container.innerHTML), `
           <style>
-            h1: {
+            h1 {
               color: red;
             }
           </style>`);
@@ -700,7 +700,8 @@ suite('Core', () => {
 
       test('renders directives on AttributeParts', () => {
         const fooDirective = directive((part: AttributePart) => {
-          part.element.setAttribute(part.name, 'foo');
+          console.log('fooDirective', part.committer.name);
+          part.committer.element.setAttribute(part.committer.name, 'foo');
         });
 
         render(html`<div foo="${fooDirective}"></div>`, container);
@@ -979,70 +980,70 @@ suite('Core', () => {
           });
     });
 
-    suite('extensibility', () => {
-      // These tests demonstrate how a flavored layer on top of lit-html could
-      // modify the parsed Template to implement different behavior, like
-      // setting properties instead of attributes.
+    // suite('extensibility', () => {
+    //   // These tests demonstrate how a flavored layer on top of lit-html could
+    //   // modify the parsed Template to implement different behavior, like
+    //   // setting properties instead of attributes.
 
-      // Note that because the template parse phase captures the pre-parsed
-      // attribute names from the template strings, we can retreive the original
-      // case of the names!
+    //   // Note that because the template parse phase captures the pre-parsed
+    //   // attribute names from the template strings, we can retreive the original
+    //   // case of the names!
 
-      const partCallback =
-          (instance: TemplateInstance, templatePart: TemplatePart, node: Node):
-              Part => {
-                if (templatePart.type === 'attribute') {
-                  return new PropertyPart(
-                      instance,
-                      node as Element,
-                      templatePart.rawName!,
-                      templatePart.strings!);
-                }
-                return defaultPartCallback(instance, templatePart, node);
-              };
+    //   const partCallback =
+    //       (instance: TemplateInstance, templatePart: TemplatePart, node: Node):
+    //           Part[] => {
+    //             if (templatePart.type === 'attribute') {
+    //               return [new PropertyPart(
+    //                   instance,
+    //                   node as Element,
+    //                   templatePart.rawName!,
+    //                   templatePart.strings!)];
+    //             }
+    //             return defaultPartCallback(instance, templatePart, node);
+    //           };
 
-      class PropertyPart extends AttributePart {
-        setValue(values: any[]): void {
-          const s = this.strings;
-          if (s.length === 2 && s[0] === '' && s[s.length - 1] === '') {
-            // An expression that occupies the whole attribute value will leave
-            // leading and trailing empty strings.
-            (this.element as any)[this.name] = values[0];
-          } else {
-            // Interpolation, so interpolate
-            let text = '';
-            for (let i = 0; i < s.length; i++) {
-              text += s[i];
-              if (i < s.length - 1) {
-                text += values[i];
-              }
-            }
-            (this.element as any)[this.name] = text;
-          }
-        }
-      }
+    //   class PropertyPart extends AttributePart {
+    //     setValue(values: any[]): void {
+    //       const s = this.strings;
+    //       if (s.length === 2 && s[0] === '' && s[s.length - 1] === '') {
+    //         // An expression that occupies the whole attribute value will leave
+    //         // leading and trailing empty strings.
+    //         (this.element as any)[this.name] = values[0];
+    //       } else {
+    //         // Interpolation, so interpolate
+    //         let text = '';
+    //         for (let i = 0; i < s.length; i++) {
+    //           text += s[i];
+    //           if (i < s.length - 1) {
+    //             text += values[i];
+    //           }
+    //         }
+    //         (this.element as any)[this.name] = text;
+    //       }
+    //     }
+    //   }
 
-      const testHtml = (strings: TemplateStringsArray, ...values: any[]) =>
-          new TemplateResult(strings, values, 'html', partCallback);
+    //   const testHtml = (strings: TemplateStringsArray, ...values: any[]) =>
+    //       new TemplateResult(strings, values, 'html', partCallback);
 
-      test('can replace parts with custom types', () => {
-        const container = document.createElement('div');
-        const t = testHtml`<div someProp="${123}"></div>`;
-        render(t, container);
-        assert.equal(
-            stripExpressionDelimeters(container.innerHTML), '<div></div>');
-        assert.strictEqual((container.firstElementChild as any).someProp, 123);
-      });
+    //   test('can replace parts with custom types', () => {
+    //     const container = document.createElement('div');
+    //     const t = testHtml`<div someProp="${123}"></div>`;
+    //     render(t, container);
+    //     assert.equal(
+    //         stripExpressionDelimeters(container.innerHTML), '<div></div>');
+    //     assert.strictEqual((container.firstElementChild as any).someProp, 123);
+    //   });
 
-      test('works with nested templates', () => {
-        const container = document.createElement('div');
-        const t = testHtml`${html`<div someProp="${123}"></div>`}`;
-        render(t, container);
-        assert.equal(
-            stripExpressionDelimeters(container.innerHTML), '<div></div>');
-        assert.strictEqual((container.firstElementChild as any).someProp, 123);
-      });
-    });
+    //   test('works with nested templates', () => {
+    //     const container = document.createElement('div');
+    //     const t = testHtml`${html`<div someProp="${123}"></div>`}`;
+    //     render(t, container);
+    //     assert.equal(
+    //         stripExpressionDelimeters(container.innerHTML), '<div></div>');
+    //     assert.strictEqual((container.firstElementChild as any).someProp, 123);
+    //   });
+    // });
   });
 
   suite('NodePart', () => {

--- a/src/test/core_test.ts
+++ b/src/test/core_test.ts
@@ -360,7 +360,6 @@ suite('Core', () => {
       });
 
       test('renders multiple bindings in an attribute', () => {
-
         let mutationRecords: MutationRecord[] = [];
         const mutationObserver = new MutationObserver((records) => {
           mutationRecords = records;
@@ -1000,70 +999,6 @@ suite('Core', () => {
           });
     });
 
-    // suite('extensibility', () => {
-    //   // These tests demonstrate how a flavored layer on top of lit-html could
-    //   // modify the parsed Template to implement different behavior, like
-    //   // setting properties instead of attributes.
-
-    //   // Note that because the template parse phase captures the pre-parsed
-    //   // attribute names from the template strings, we can retreive the original
-    //   // case of the names!
-
-    //   const partCallback =
-    //       (instance: TemplateInstance, templatePart: TemplatePart, node: Node):
-    //           Part[] => {
-    //             if (templatePart.type === 'attribute') {
-    //               return [new PropertyPart(
-    //                   instance,
-    //                   node as Element,
-    //                   templatePart.rawName!,
-    //                   templatePart.strings!)];
-    //             }
-    //             return defaultPartCallback(instance, templatePart, node);
-    //           };
-
-    //   class PropertyPart extends AttributePart {
-    //     setValue(values: any[]): void {
-    //       const s = this.strings;
-    //       if (s.length === 2 && s[0] === '' && s[s.length - 1] === '') {
-    //         // An expression that occupies the whole attribute value will leave
-    //         // leading and trailing empty strings.
-    //         (this.element as any)[this.name] = values[0];
-    //       } else {
-    //         // Interpolation, so interpolate
-    //         let text = '';
-    //         for (let i = 0; i < s.length; i++) {
-    //           text += s[i];
-    //           if (i < s.length - 1) {
-    //             text += values[i];
-    //           }
-    //         }
-    //         (this.element as any)[this.name] = text;
-    //       }
-    //     }
-    //   }
-
-    //   const testHtml = (strings: TemplateStringsArray, ...values: any[]) =>
-    //       new TemplateResult(strings, values, 'html', partCallback);
-
-    //   test('can replace parts with custom types', () => {
-    //     const container = document.createElement('div');
-    //     const t = testHtml`<div someProp="${123}"></div>`;
-    //     render(t, container);
-    //     assert.equal(
-    //         stripExpressionDelimeters(container.innerHTML), '<div></div>');
-    //     assert.strictEqual((container.firstElementChild as any).someProp, 123);
-    //   });
-
-    //   test('works with nested templates', () => {
-    //     const container = document.createElement('div');
-    //     const t = testHtml`${html`<div someProp="${123}"></div>`}`;
-    //     render(t, container);
-    //     assert.equal(
-    //         stripExpressionDelimeters(container.innerHTML), '<div></div>');
-    //     assert.strictEqual((container.firstElementChild as any).someProp, 123);
-    //   });
-    // });
   });
 
   suite('NodePart', () => {

--- a/src/test/core_test.ts
+++ b/src/test/core_test.ts
@@ -713,7 +713,6 @@ suite('Core', () => {
       test('renders directives on NodeParts', () => {
         const fooDirective = directive((part: NodePart) => {
           part.setValue('foo');
-          part.commit();
         });
 
         render(html`<div>${fooDirective}</div>`, container);

--- a/src/test/core_test.ts
+++ b/src/test/core_test.ts
@@ -15,7 +15,7 @@
 /// <reference path="../../node_modules/@types/mocha/index.d.ts" />
 /// <reference path="../../node_modules/@types/chai/index.d.ts" />
 
-import {AttributePart, defaultPartCallback, defaultTemplateFactory, directive, html, NodePart, Part, render, svg, TemplateInstance, TemplatePart, TemplateResult} from '../core.js';
+import {AttributePart, defaultPartCallback, defaultTemplateFactory, directive, html, NodePart, render, svg, TemplateInstance, TemplatePart, TemplateResult} from '../core.js';
 
 import {stripExpressionDelimeters} from './test-helpers.js';
 

--- a/src/test/core_test.ts
+++ b/src/test/core_test.ts
@@ -251,7 +251,9 @@ suite('Core', () => {
 
         render(html`${form}`, container);
 
-        assert.equal(stripExpressionDelimeters(container.innerHTML), '<form><input name="one"><input name="two"></form>');
+        assert.equal(
+            stripExpressionDelimeters(container.innerHTML),
+            '<form><input name="one"><input name="two"></form>');
       });
 
       const testSkipForTemplatePolyfill =
@@ -711,6 +713,7 @@ suite('Core', () => {
       test('renders directives on NodeParts', () => {
         const fooDirective = directive((part: NodePart) => {
           part.setValue('foo');
+          part.commit();
         });
 
         render(html`<div>${fooDirective}</div>`, container);
@@ -998,7 +1001,6 @@ suite('Core', () => {
             assert.notEqual(fooDiv, barDiv);
           });
     });
-
   });
 
   suite('NodePart', () => {
@@ -1023,21 +1025,25 @@ suite('Core', () => {
     suite('setValue', () => {
       test('accepts a string', () => {
         part.setValue('foo');
+        part.commit();
         assert.equal(stripExpressionDelimeters(container.innerHTML), 'foo');
       });
 
       test('accepts a number', () => {
         part.setValue(123);
+        part.commit();
         assert.equal(stripExpressionDelimeters(container.innerHTML), '123');
       });
 
       test('accepts undefined', () => {
         part.setValue(undefined);
+        part.commit();
         assert.equal(stripExpressionDelimeters(container.innerHTML), '');
       });
 
       test('accepts null', () => {
         part.setValue(null);
+        part.commit();
         assert.equal(stripExpressionDelimeters(container.innerHTML), '');
       });
 
@@ -1046,15 +1052,18 @@ suite('Core', () => {
           throw new Error();
         };
         part.setValue(f);
+        part.commit();
       });
 
       test('accepts an element', () => {
         part.setValue(document.createElement('p'));
+        part.commit();
         assert.equal(stripExpressionDelimeters(container.innerHTML), '<p></p>');
       });
 
       test('accepts arrays', () => {
         part.setValue([1, 2, 3]);
+        part.commit();
         assert.equal(stripExpressionDelimeters(container.innerHTML), '123');
         assert.strictEqual(container.firstChild, startNode);
         assert.strictEqual(container.lastChild, endNode);
@@ -1062,6 +1071,7 @@ suite('Core', () => {
 
       test('accepts an empty array', () => {
         part.setValue([]);
+        part.commit();
         assert.equal(stripExpressionDelimeters(container.innerHTML), '');
         assert.strictEqual(container.firstChild, startNode);
         assert.strictEqual(container.lastChild, endNode);
@@ -1069,6 +1079,7 @@ suite('Core', () => {
 
       test('accepts nested arrays', () => {
         part.setValue([1, [2], 3]);
+        part.commit();
         assert.equal(stripExpressionDelimeters(container.innerHTML), '123');
         assert.deepEqual(
             ['', '1', '', '2', '', '3', ''],
@@ -1079,12 +1090,14 @@ suite('Core', () => {
 
       test('accepts nested templates', () => {
         part.setValue(html`<h1>${'foo'}</h1>`);
+        part.commit();
         assert.equal(
             stripExpressionDelimeters(container.innerHTML), '<h1>foo</h1>');
       });
 
       test('accepts arrays of nested templates', () => {
         part.setValue([1, 2, 3].map((i) => html`${i}`));
+        part.commit();
         assert.equal(stripExpressionDelimeters(container.innerHTML), '123');
       });
 
@@ -1095,6 +1108,7 @@ suite('Core', () => {
           document.createElement('span')
         ];
         part.setValue(children);
+        part.commit();
         assert.equal(
             stripExpressionDelimeters(container.innerHTML),
             '<p></p><a></a><span></span>');
@@ -1130,13 +1144,16 @@ suite('Core', () => {
 
       test('updates when called multiple times with simple values', () => {
         part.setValue('abc');
+        part.commit();
         assert.equal(stripExpressionDelimeters(container.innerHTML), 'abc');
         part.setValue('def');
+        part.commit();
         assert.equal(stripExpressionDelimeters(container.innerHTML), 'def');
       });
 
       test('updates when called multiple times with arrays', () => {
         part.setValue([1, 2, 3]);
+        part.commit();
         assert.equal(stripExpressionDelimeters(container.innerHTML), '123');
         assert.deepEqual(
             ['', '1', '', '2', '', '3', ''],
@@ -1145,6 +1162,7 @@ suite('Core', () => {
         assert.strictEqual(container.lastChild, endNode);
 
         part.setValue([]);
+        part.commit();
         assert.equal(stripExpressionDelimeters(container.innerHTML), '');
         assert.deepEqual(
             ['', ''], Array.from(container.childNodes).map((n) => n.nodeValue));
@@ -1154,6 +1172,7 @@ suite('Core', () => {
 
       test('updates when called multiple times with arrays 2', () => {
         part.setValue([1, 2, 3]);
+        part.commit();
         assert.equal(stripExpressionDelimeters(container.innerHTML), '123');
         assert.deepEqual(
             ['', '1', '', '2', '', '3', ''],
@@ -1162,6 +1181,7 @@ suite('Core', () => {
         assert.strictEqual(container.lastChild, endNode);
 
         part.setValue([4, 5]);
+        part.commit();
         assert.equal(stripExpressionDelimeters(container.innerHTML), '45');
         assert.deepEqual(
             ['', '4', '', '5', ''],
@@ -1170,6 +1190,7 @@ suite('Core', () => {
         assert.strictEqual(container.lastChild, endNode);
 
         part.setValue([]);
+        part.commit();
         assert.equal(stripExpressionDelimeters(container.innerHTML), '');
         assert.deepEqual(
             ['', ''], Array.from(container.childNodes).map((n) => n.nodeValue));
@@ -1177,6 +1198,7 @@ suite('Core', () => {
         assert.strictEqual(container.lastChild, endNode);
 
         part.setValue([4, 5]);
+        part.commit();
         assert.equal(stripExpressionDelimeters(container.innerHTML), '45');
         assert.deepEqual(
             ['', '4', '', '5', ''],
@@ -1187,6 +1209,7 @@ suite('Core', () => {
 
       test('updates nested arrays', () => {
         part.setValue([1, [2], 3]);
+        part.commit();
         assert.equal(stripExpressionDelimeters(container.innerHTML), '123');
         assert.deepEqual(
             ['', '1', '', '2', '', '3', ''],
@@ -1195,6 +1218,7 @@ suite('Core', () => {
         assert.strictEqual(container.lastChild, endNode);
 
         part.setValue([[1], 2, 3]);
+        part.commit();
         assert.equal(stripExpressionDelimeters(container.innerHTML), '123');
         assert.deepEqual(
             ['', '1', '', '2', '', '3', ''],
@@ -1225,12 +1249,14 @@ suite('Core', () => {
             let value = 'foo';
             const r = () => html`<h1>${value}</h1>`;
             part.setValue(r());
+            part.commit();
             assert.equal(
                 stripExpressionDelimeters(container.innerHTML), '<h1>foo</h1>');
             const originalH1 = container.querySelector('h1');
 
             value = 'bar';
             part.setValue(r());
+            part.commit();
             assert.equal(
                 stripExpressionDelimeters(container.innerHTML), '<h1>bar</h1>');
             const newH1 = container.querySelector('h1');
@@ -1243,6 +1269,7 @@ suite('Core', () => {
             let items = [1, 2, 3];
             const r = () => items.map((i) => html`<li>${i}</li>`);
             part.setValue(r());
+            part.commit();
             assert.equal(
                 stripExpressionDelimeters(container.innerHTML),
                 '<li>1</li><li>2</li><li>3</li>');
@@ -1250,6 +1277,7 @@ suite('Core', () => {
 
             items = [3, 2, 1];
             part.setValue(r());
+            part.commit();
             assert.equal(
                 stripExpressionDelimeters(container.innerHTML),
                 '<li>3</li><li>2</li><li>1</li>');

--- a/src/test/lib/lit-extended_test.ts
+++ b/src/test/lib/lit-extended_test.ts
@@ -15,7 +15,7 @@
 /// <reference path="../../../node_modules/@types/mocha/index.d.ts" />
 /// <reference path="../../../node_modules/@types/chai/index.d.ts" />
 
-import {directive, html as htmlPlain, AttributePart} from '../../core.js';
+import {AttributePart, directive, html as htmlPlain} from '../../core.js';
 import {html, render} from '../../lib/lit-extended.js';
 import {stripExpressionDelimeters} from '../test-helpers.js';
 

--- a/src/test/lib/lit-extended_test.ts
+++ b/src/test/lib/lit-extended_test.ts
@@ -276,7 +276,7 @@ suite('lit-extended', () => {
 
     test('renders directives on PropertyParts', () => {
       const fooDirective = directive((part: AttributePart) => {
-        (part.committer.element as any)[part.committer.name] = 1234;
+        part.setValue(1234);
       });
 
       render(html`<div foo="${fooDirective}"></div>`, container);

--- a/src/test/lib/lit-extended_test.ts
+++ b/src/test/lib/lit-extended_test.ts
@@ -32,8 +32,8 @@ suite('lit-extended', () => {
     test('sets properties', () => {
       render(html`<div foo=${123} bar=${456}></div>`, container);
       const div = container.firstChild!;
-      assert.equal((div as any).foo, 123);
-      assert.equal((div as any).bar, 456);
+      assert.strictEqual((div as any).foo, 123);
+      assert.strictEqual((div as any).bar, 456);
     });
 
     test('renders to an attribute', () => {

--- a/src/test/lib/lit-extended_test.ts
+++ b/src/test/lib/lit-extended_test.ts
@@ -15,8 +15,8 @@
 /// <reference path="../../../node_modules/@types/mocha/index.d.ts" />
 /// <reference path="../../../node_modules/@types/chai/index.d.ts" />
 
-import {directive, html as htmlPlain} from '../../core.js';
-import {html, PropertyPart, render} from '../../lib/lit-extended.js';
+import {directive, html as htmlPlain, AttributePart} from '../../core.js';
+import {html, render} from '../../lib/lit-extended.js';
 import {stripExpressionDelimeters} from '../test-helpers.js';
 
 const assert = chai.assert;
@@ -275,8 +275,8 @@ suite('lit-extended', () => {
     });
 
     test('renders directives on PropertyParts', () => {
-      const fooDirective = directive((part: PropertyPart) => {
-        (part.element as any)[part.name] = 1234;
+      const fooDirective = directive((part: AttributePart) => {
+        (part.committer.element as any)[part.committer.name] = 1234;
       });
 
       render(html`<div foo="${fooDirective}"></div>`, container);

--- a/src/test/lib/modify-template_test.ts
+++ b/src/test/lib/modify-template_test.ts
@@ -77,8 +77,11 @@ suite('add/remove nodes from template', () => {
         </div><div name="remove"><span name="remove"><span name="remove">remove</span></span></div>`;
         const result = getResult('bar', 'baz', 'qux');
         const template = templateFactory(result);
-        const nodeSet = new Set(Array.from(
-            template.element.content.querySelectorAll('[name="remove"]')));
+        const nodeSet = new Set();
+        const nodesToRemove = template.element.content.querySelectorAll('[name="remove"]');
+        for (const node of Array.from(nodesToRemove)) {
+          nodeSet.add(node);
+        }
         removeNodesFromTemplate(template, nodeSet);
         render(result, container);
         assert.equal(stripExpressionDelimeters(container.innerHTML), `
@@ -105,8 +108,11 @@ suite('add/remove nodes from template', () => {
         </div><div name="remove"><span name="remove"><span name="remove">remove</span></span></div>`;
         const result = getResult('bar', 'baz', 'qux', 'r1', 'r2', 'r3');
         const template = templateFactory(result);
-        const nodeSet = new Set(Array.from(
-            template.element.content.querySelectorAll('[name="remove"]')));
+        const nodeSet = new Set();
+        const nodesToRemove = template.element.content.querySelectorAll('[name="remove"]');
+        for (const node of Array.from(nodesToRemove)) {
+          nodeSet.add(node);
+        }
         removeNodesFromTemplate(template, nodeSet);
         render(result, container);
         assert.equal(stripExpressionDelimeters(container.innerHTML), `

--- a/src/test/lib/modify-template_test.ts
+++ b/src/test/lib/modify-template_test.ts
@@ -78,7 +78,8 @@ suite('add/remove nodes from template', () => {
         const result = getResult('bar', 'baz', 'qux');
         const template = templateFactory(result);
         const nodeSet = new Set();
-        const nodesToRemove = template.element.content.querySelectorAll('[name="remove"]');
+        const nodesToRemove =
+            template.element.content.querySelectorAll('[name="remove"]');
         for (const node of Array.from(nodesToRemove)) {
           nodeSet.add(node);
         }
@@ -109,7 +110,8 @@ suite('add/remove nodes from template', () => {
         const result = getResult('bar', 'baz', 'qux', 'r1', 'r2', 'r3');
         const template = templateFactory(result);
         const nodeSet = new Set();
-        const nodesToRemove = template.element.content.querySelectorAll('[name="remove"]');
+        const nodesToRemove =
+            template.element.content.querySelectorAll('[name="remove"]');
         for (const node of Array.from(nodesToRemove)) {
           nodeSet.add(node);
         }

--- a/src/test/lit-html_test.ts
+++ b/src/test/lit-html_test.ts
@@ -32,8 +32,8 @@ suite('lit-html', () => {
     test('sets properties', () => {
       render(html`<div .foo=${123} .bar=${456}></div>`, container);
       const div = container.firstChild!;
-      assert.equal((div as any).foo, 123);
-      assert.equal((div as any).bar, 456);
+      assert.strictEqual((div as any).foo, 123);
+      assert.strictEqual((div as any).bar, 456);
     });
 
     test('renders to an attribute', () => {
@@ -282,7 +282,7 @@ suite('lit-html', () => {
       render(html`<div .foo="${fooDirective}"></div>`, container);
       assert.equal(
           stripExpressionDelimeters(container.innerHTML), '<div></div>');
-      assert.equal((container.firstElementChild as any).foo, 1234);
+      assert.strictEqual((container.firstElementChild as any).foo, 1234);
     });
 
     const suiteIfCustomElementsAreSupported =

--- a/src/test/lit-html_test.ts
+++ b/src/test/lit-html_test.ts
@@ -15,8 +15,9 @@
 /// <reference path="../../node_modules/@types/mocha/index.d.ts" />
 /// <reference path="../../node_modules/@types/chai/index.d.ts" />
 
-import {directive, html as htmlPlain, AttributePart} from '../core.js';
+import {AttributePart, directive, html as htmlPlain} from '../core.js';
 import {html, render} from '../lit-html.js';
+
 import {stripExpressionDelimeters} from './test-helpers.js';
 
 const assert = chai.assert;

--- a/src/test/lit-html_test.ts
+++ b/src/test/lit-html_test.ts
@@ -15,13 +15,13 @@
 /// <reference path="../../node_modules/@types/mocha/index.d.ts" />
 /// <reference path="../../node_modules/@types/chai/index.d.ts" />
 
-import {directive, html as htmlPlain} from '../core.js';
-import {html, PropertyPart, render} from '../lit-html.js';
+import {directive, html as htmlPlain, AttributePart} from '../core.js';
+import {html, render} from '../lit-html.js';
 import {stripExpressionDelimeters} from './test-helpers.js';
 
 const assert = chai.assert;
 
-suite('lit-extended', () => {
+suite('lit-html', () => {
   suite('render', () => {
     let container: HTMLElement;
 
@@ -275,8 +275,8 @@ suite('lit-extended', () => {
     });
 
     test('renders directives on PropertyParts', () => {
-      const fooDirective = directive((part: PropertyPart) => {
-        (part.element as any)[part.name] = 1234;
+      const fooDirective = directive((part: AttributePart) => {
+        (part.committer.element as any)[part.committer.name] = 1234;
       });
 
       render(html`<div .foo="${fooDirective}"></div>`, container);

--- a/src/test/lit-html_test.ts
+++ b/src/test/lit-html_test.ts
@@ -276,7 +276,7 @@ suite('lit-html', () => {
 
     test('renders directives on PropertyParts', () => {
       const fooDirective = directive((part: AttributePart) => {
-        (part.committer.element as any)[part.committer.name] = 1234;
+        part.setValue(1234);
       });
 
       render(html`<div .foo="${fooDirective}"></div>`, container);

--- a/src/test/lit-html_test.ts
+++ b/src/test/lit-html_test.ts
@@ -218,8 +218,11 @@ suite('lit-html', () => {
       const listener2 = () => {
         count2++;
       };
-      render(html`<div @click=${listener1}></div>`, container);
-      render(html`<div @click=${listener2}></div>`, container);
+      const t = (listener: () => void) => html`<div @click=${listener}></div>`;
+      render(t(listener1), container);
+      render(t(listener2), container);
+
+      console.log(container.innerHTML);
 
       const div = container.firstChild as HTMLElement;
       div.click();

--- a/src/test/lit-html_test.ts
+++ b/src/test/lit-html_test.ts
@@ -228,32 +228,38 @@ suite('lit-html', () => {
       assert.equal(count2, 1);
     });
 
-    test(
+    test.only(
         'allows updating event listener without extra calls to remove/addEventListener',
         () => {
           let listener: Function|null;
           const t = () => html`<div @click=${listener}></div>`;
           render(t(), container);
           const div = container.firstChild as HTMLElement;
+
           let addCount = 0;
           let removeCount = 0;
           div.addEventListener = () => addCount++;
           div.removeEventListener = () => removeCount++;
+
           listener = () => {};
           render(t(), container);
           assert.equal(addCount, 1);
           assert.equal(removeCount, 0);
+
           listener = () => {};
           assert.equal(addCount, 1);
           assert.equal(removeCount, 0);
+
           listener = null;
           render(t(), container);
           assert.equal(addCount, 1);
           assert.equal(removeCount, 1);
+
           listener = () => {};
           render(t(), container);
           assert.equal(addCount, 2);
           assert.equal(removeCount, 1);
+
           listener = () => {};
           render(t(), container);
           assert.equal(addCount, 2);

--- a/src/test/lit-html_test.ts
+++ b/src/test/lit-html_test.ts
@@ -277,13 +277,13 @@ suite('lit-html', () => {
     });
 
     test('event listeners can see events fired by dynamic children', () => {
+      // This tests that node directives are called in the commit phase, not
+      // the setValue phase
       let event: Event|undefined = undefined;
       document.body.appendChild(container);
       render(
           html`
-        <div @test-event=${(e: Event) => {
-            event = e;
-          }}>
+        <div @test-event=${(e: Event) => { event = e; }}>
           ${directive((part: NodePart) => {
             // This emulates a custom element that fires an event in its
             // connectedCallback
@@ -294,6 +294,20 @@ suite('lit-html', () => {
         </div>`,
           container);
       document.body.removeChild(container);
+      assert.isOk(event);
+    });
+
+    test('event listeners can see events fired directives in AttributeParts', () => {
+      // This tests that attribute directives are called in the commit phase, not
+      // the setValue phase
+      let event = undefined;
+      const fire = directive((part: AttributePart) => {
+        part.committer.element.dispatchEvent(new CustomEvent('test-event', {
+          bubbles: true,
+        }));
+      });
+
+      render(html`<div @test-event=${(e: Event) => { event = e; }} b=${fire}></div>`, container);
       assert.isOk(event);
     });
 

--- a/src/test/lit-html_test.ts
+++ b/src/test/lit-html_test.ts
@@ -15,7 +15,7 @@
 /// <reference path="../../node_modules/@types/mocha/index.d.ts" />
 /// <reference path="../../node_modules/@types/chai/index.d.ts" />
 
-import {AttributePart, directive, html as htmlPlain} from '../core.js';
+import {AttributePart, directive, html as htmlPlain, NodePart} from '../core.js';
 import {html, render} from '../lit-html.js';
 
 import {stripExpressionDelimeters} from './test-helpers.js';
@@ -277,14 +277,6 @@ suite('lit-html', () => {
     });
 
     test('event listeners can see events fired by dynamic children', () => {
-      class FiresEvent extends HTMLElement {
-        connectedCallback() {
-          this.dispatchEvent(new CustomEvent('test-event', {
-            bubbles: true,
-          }));
-        }
-      }
-      customElements.define('x-fires-event', FiresEvent);
       let event: Event|undefined = undefined;
       document.body.appendChild(container);
       render(
@@ -292,7 +284,13 @@ suite('lit-html', () => {
         <div @test-event=${(e: Event) => {
             event = e;
           }}>
-          ${html`<x-fires-event></x-fires-event>`}
+          ${directive((part: NodePart) => {
+            // This emulates a custom element that fires an event in its
+            // connectedCallback
+            part.startNode.dispatchEvent(new CustomEvent('test-event', {
+              bubbles: true,
+            }));
+          })}
         </div>`,
           container);
       document.body.removeChild(container);

--- a/src/test/lit-html_test.ts
+++ b/src/test/lit-html_test.ts
@@ -222,8 +222,6 @@ suite('lit-html', () => {
       render(t(listener1), container);
       render(t(listener2), container);
 
-      console.log(container.innerHTML);
-
       const div = container.firstChild as HTMLElement;
       div.click();
       assert.equal(count1, 0);
@@ -276,6 +274,29 @@ suite('lit-html', () => {
       render(t(), container);
       div.click();
       assert.equal(target, undefined);
+    });
+
+    test('event listeners can see events fired by dynamic children', () => {
+      class FiresEvent extends HTMLElement {
+        connectedCallback() {
+          this.dispatchEvent(new CustomEvent('test-event', {
+            bubbles: true,
+          }));
+        }
+      }
+      customElements.define('x-fires-event', FiresEvent);
+      let event: Event|undefined = undefined;
+      document.body.appendChild(container);
+      render(
+          html`
+        <div @test-event=${(e: Event) => {
+            event = e;
+          }}>
+          ${html`<x-fires-event></x-fires-event>`}
+        </div>`,
+          container);
+      document.body.removeChild(container);
+      assert.isOk(event);
     });
 
     test('renders directives on PropertyParts', () => {

--- a/src/test/lit-html_test.ts
+++ b/src/test/lit-html_test.ts
@@ -290,7 +290,9 @@ suite('lit-html', () => {
       document.body.appendChild(container);
       render(
           html`
-        <div @test-event=${(e: Event) => { event = e; }}>
+        <div @test-event=${(e: Event) => {
+            event = e;
+          }}>
           ${directive((part: NodePart) => {
             // This emulates a custom element that fires an event in its
             // connectedCallback
@@ -304,19 +306,25 @@ suite('lit-html', () => {
       assert.isOk(event);
     });
 
-    test('event listeners can see events fired directives in AttributeParts', () => {
-      // This tests that attribute directives are called in the commit phase, not
-      // the setValue phase
-      let event = undefined;
-      const fire = directive((part: AttributePart) => {
-        part.committer.element.dispatchEvent(new CustomEvent('test-event', {
-          bubbles: true,
-        }));
-      });
+    test(
+        'event listeners can see events fired directives in AttributeParts',
+        () => {
+          // This tests that attribute directives are called in the commit
+          // phase, not the setValue phase
+          let event = undefined;
+          const fire = directive((part: AttributePart) => {
+            part.committer.element.dispatchEvent(new CustomEvent('test-event', {
+              bubbles: true,
+            }));
+          });
 
-      render(html`<div @test-event=${(e: Event) => { event = e; }} b=${fire}></div>`, container);
-      assert.isOk(event);
-    });
+          render(
+              html`<div @test-event=${(e: Event) => {
+                event = e;
+              }} b=${fire}></div>`,
+              container);
+          assert.isOk(event);
+        });
 
     test('renders directives on PropertyParts', () => {
       const fooDirective = directive((part: AttributePart) => {

--- a/src/test/lit-html_test.ts
+++ b/src/test/lit-html_test.ts
@@ -228,7 +228,7 @@ suite('lit-html', () => {
       assert.equal(count2, 1);
     });
 
-    test.only(
+    test(
         'allows updating event listener without extra calls to remove/addEventListener',
         () => {
           let listener: Function|null;
@@ -247,6 +247,7 @@ suite('lit-html', () => {
           assert.equal(removeCount, 0);
 
           listener = () => {};
+          render(t(), container);
           assert.equal(addCount, 1);
           assert.equal(removeCount, 0);
 

--- a/test/index-polyserve.html
+++ b/test/index-polyserve.html
@@ -13,11 +13,15 @@
   </head>
   <body>
     <div id="mocha"></div>
+    <script type="module" src="./core_test.js"></script>
     <script type="module" src="./lit-html_test.js"></script>
     <script type="module" src="./lib/repeat_test.js"></script>
     <script type="module" src="./lib/until_test.js"></script>
     <script type="module" src="./lib/lit-extended_test.js"></script>
     <script type="module" src="./lib/unsafe-html_test.js"></script>
+    <script type="module" src="./lib/async-append_test.js"></script>
+    <script type="module" src="./lib/async-replace_test.js"></script>
+    <script type="module" src="./lib/modify-template_test.js"></script>
     <script type="module">
       mocha.run();
     </script>

--- a/test/index.html
+++ b/test/index.html
@@ -10,7 +10,7 @@
     <script type="module" src="./lit-html_test.js"></script>
     <script type="module" src="./lib/repeat_test.js"></script>
     <script type="module" src="./lib/until_test.js"></script>
-    <script type="module" src="./lib/lit-extended_test.js"></script>
+    <!-- <script type="module" src="./lib/lit-extended_test.js"></script> -->
     <script type="module" src="./lib/unsafe-html_test.js"></script>
     <script type="module" src="./lib/async-append_test.js"></script>
     <script type="module" src="./lib/async-replace_test.js"></script>

--- a/test/index.html
+++ b/test/index.html
@@ -15,7 +15,7 @@
     <script type="module" src="./lib/async-append_test.js"></script>
     <script type="module" src="./lib/async-replace_test.js"></script>
     <script type="module" src="./lib/modify-template_test.js"></script>
-    <!-- <script type="module">
+    <script type="module">
       WCT.loadSuites([
         'shady.html',
         'shady.html?shadydom=true',
@@ -24,6 +24,6 @@
         'shady-apply.html?shadydom=true',
         'shady-apply.html?shadydom=true&shimscssproperties=true',
       ]);
-    </script> -->
+    </script>
   </body>
 </html>

--- a/test/index.html
+++ b/test/index.html
@@ -15,7 +15,7 @@
     <script type="module" src="./lib/async-append_test.js"></script>
     <script type="module" src="./lib/async-replace_test.js"></script>
     <script type="module" src="./lib/modify-template_test.js"></script>
-    <script type="module">
+    <!-- <script type="module">
       WCT.loadSuites([
         'shady.html',
         'shady.html?shadydom=true',
@@ -24,6 +24,6 @@
         'shady-apply.html?shadydom=true',
         'shady-apply.html?shadydom=true&shimscssproperties=true',
       ]);
-    </script>
+    </script> -->
   </body>
 </html>

--- a/test/index.html
+++ b/test/index.html
@@ -10,7 +10,7 @@
     <script type="module" src="./lit-html_test.js"></script>
     <script type="module" src="./lib/repeat_test.js"></script>
     <script type="module" src="./lib/until_test.js"></script>
-    <!-- <script type="module" src="./lib/lit-extended_test.js"></script> -->
+    <script type="module" src="./lib/lit-extended_test.js"></script>
     <script type="module" src="./lib/unsafe-html_test.js"></script>
     <script type="module" src="./lib/async-append_test.js"></script>
     <script type="module" src="./lib/async-replace_test.js"></script>

--- a/test/index.html
+++ b/test/index.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <script src="../node_modules/wct-browser-legacy/browser.js"></script>
-    <script src="../node_modules/@webcomponents/template/template.js"></script>
+    <script src="../node_modules/@webcomponents/webcomponentsjs/webcomponents-bundle.js"></script>
     <script src="../node_modules/babel-polyfill/dist/polyfill.min.js"></script>
   </head>
   <body>

--- a/test/index.html
+++ b/test/index.html
@@ -3,7 +3,6 @@
   <head>
     <script src="../node_modules/wct-browser-legacy/browser.js"></script>
     <script src="../node_modules/@webcomponents/webcomponentsjs/webcomponents-bundle.js"></script>
-    <script src="../node_modules/babel-polyfill/dist/polyfill.min.js"></script>
   </head>
   <body>
     <script type="module" src="./core_test.js"></script>

--- a/test/index.html
+++ b/test/index.html
@@ -2,9 +2,6 @@
 <html>
   <head>
     <script src="../node_modules/wct-browser-legacy/browser.js"></script>
-    <script>
-      window.setImmediate = undefined;
-    </script>
     <script src="../node_modules/@webcomponents/webcomponentsjs/webcomponents-bundle.js"></script>
   </head>
   <body>

--- a/test/index.html
+++ b/test/index.html
@@ -2,6 +2,9 @@
 <html>
   <head>
     <script src="../node_modules/wct-browser-legacy/browser.js"></script>
+    <script>
+      window.setImmediate = undefined;
+    </script>
     <script src="../node_modules/@webcomponents/webcomponentsjs/webcomponents-bundle.js"></script>
   </head>
   <body>


### PR DESCRIPTION
This PR removes the SinglePart/MultiPart distinction. AttributeParts now only have a single value, but are associated with an AttributeCommitter that commits multiple values to an attribute.

This PR is based on #398.

The attribute handling code is a bit simpler in this factoring, though the "fast" path for attribute with a single value isn't implemented here, but it is implemented for PropertyCommitter. Not sure if this matters much.