### PR TITLE
Avoid IE 11's bad Set constructor

### DIFF
--- a/src/lib/shady-render.ts
+++ b/src/lib/shady-render.ts
@@ -79,8 +79,12 @@ function removeStylesFromLitTemplates(scopeName: string) {
     if (templates !== undefined) {
       templates.forEach((template) => {
         const {element: {content}} = template;
-        const styles = content.querySelectorAll('style');
-        removeNodesFromTemplate(template, new Set(Array.from(styles)));
+        // IE 11 doesn't support the iterable param Set constructor
+        const styles = new Set<Element>();
+        Array.from(content.querySelectorAll('style')).forEach((s: Element) => {
+          styles.add(s);
+        });
+        removeNodesFromTemplate(template, styles);
       });
     }
   });


### PR DESCRIPTION
IE 11 doesn't support the `iterable` param to the `Set` constructor.

Fixes https://github.com/Polymer/lit-html/issues/368.