### PR TITLE
WIP:  Work with Attr nodes to fix invalid attr names

### DIFF
--- a/src/lib/lit-extended.ts
+++ b/src/lib/lit-extended.ts
@@ -64,18 +64,22 @@ export const extendedPartCallback =
             const element = node as Element;
             const lastChar =
                 templatePart.name!.substr(templatePart.name!.length - 1);
+            const attr = getAttributeNode(element, templatePart.rawName!);
+            element.removeAttributeNode(attr);
             if (lastChar === '$') {
               const name = templatePart.name!.slice(0, -1);
+              // Hope the name's valid XML now...
+              element.setAttribute(name, '');
               return new AttributePart(
                   instance, element, name, templatePart.strings!);
             }
             if (lastChar === '?') {
               const name = templatePart.name!.slice(0, -1);
+              // Hope the name's valid XML now...
+              element.setAttribute(name, '');
               return new BooleanAttributePart(
                   instance, element, name, templatePart.strings!);
             }
-            const attr = getAttributeNode(element, templatePart.rawName!);
-            element.removeAttributeNode(attr);
             return new PropertyPart(
                 instance,
                 element,


### PR DESCRIPTION
This is an attempt to fix getting/setting attributes with invalid XML names, eg `class$` or `.test`.

Needs more work and manual testing... But IE seems to be fine parsing these attrs and then allowing manipulation through the `Attr` node.

Fixes https://github.com/Polymer/lit-html/issues/295.