### PR TITLE
Add NodePart attachment methods

### DIFF
--- a/src/lib/async-append.ts
+++ b/src/lib/async-append.ts
@@ -79,15 +79,15 @@ export const asyncAppend = <T>(
         // Check to see if we have a previous item and Part
         if (itemPart !== undefined) {
           // Create a new node to separate the previous and next Parts
-          itemStartNode = document.createTextNode('');
+          itemStartNode = document.createComment('');
           // itemPart is currently the Part for the previous item. Set
           // it's endNode to the node we'll use for the next Part's
           // startNode.
           itemPart.endNode = itemStartNode;
           part.endNode.parentNode!.insertBefore(itemStartNode, part.endNode);
         }
-        itemPart =
-            new NodePart(itemStartNode, part.endNode, part.templateFactory);
+        itemPart = new NodePart(part.templateFactory);
+        itemPart.insertAfterNode(itemStartNode);
         itemPart.setValue(v);
         itemPart.commit();
         i++;

--- a/src/lib/async-replace.ts
+++ b/src/lib/async-replace.ts
@@ -43,9 +43,7 @@ export const asyncReplace =
 
           // We nest a new part to keep track of previous item values separately
           // of the iterable as a value itself.
-          const itemPart =
-              new NodePart(part.startNode, part.endNode, part.templateFactory);
-
+          const itemPart = new NodePart(part.templateFactory);
           part.value = itemPart;
 
           let i = 0;
@@ -55,6 +53,7 @@ export const asyncReplace =
             // previous value display until we can replace it.
             if (i === 0) {
               part.clear();
+              itemPart.appendIntoPart(part);
             }
 
             // Check to make sure that value is the still the current value of

--- a/src/lib/repeat.ts
+++ b/src/lib/repeat.ts
@@ -67,11 +67,19 @@ export function repeat<T>(
       // Try to reuse a part
       let itemPart = keyMap.get(key);
       if (itemPart === undefined) {
-        const marker = document.createTextNode('');
-        const endNode = document.createTextNode('');
+        // TODO(justinfagnani): We really want to avoid manual marker creation
+        // here and instead use something like part.insertBeforePart(). This
+        // requires a little refactoring, like iterating through values and
+        // existing parts like NodePart#_setIterable does. We can also remove
+        // keyMapCache and use part._value instead.
+        // But... repeat() is badly in need of rewriting, so we'll do this for
+        // now and revisit soon.
+        const marker = document.createComment('');
+        const endNode = document.createComment('');
         container.insertBefore(marker, currentMarker);
         container.insertBefore(endNode, currentMarker);
-        itemPart = new NodePart(marker, endNode, part.templateFactory);
+        itemPart = new NodePart(part.templateFactory);
+        itemPart.insertAfterNode(marker);
         if (key !== undefined) {
           keyMap.set(key, itemPart);
         }

--- a/src/test/core_test.ts
+++ b/src/test/core_test.ts
@@ -1009,11 +1009,13 @@ suite('Core', () => {
 
     setup(() => {
       container = document.createElement('div');
-      startNode = document.createTextNode('');
-      endNode = document.createTextNode('');
+      startNode = document.createComment('');
+      endNode = document.createComment('');
       container.appendChild(startNode);
       container.appendChild(endNode);
-      part = new NodePart(startNode, endNode, defaultTemplateFactory);
+      part = new NodePart(defaultTemplateFactory);
+      part.startNode = startNode;
+      part.endNode = endNode;
     });
 
     suite('setValue', () => {
@@ -1076,8 +1078,8 @@ suite('Core', () => {
         part.commit();
         assert.equal(stripExpressionDelimeters(container.innerHTML), '123');
         assert.deepEqual(
-            ['', '1', '', '2', '', '3', ''],
-            Array.from(container.childNodes).map((n) => n.nodeValue));
+            Array.from(container.childNodes).map((n) => n.nodeValue),
+            ['', '', '1', '', '', '2', '', '', '3', '', '']);
         assert.strictEqual(container.firstChild, startNode);
         assert.strictEqual(container.lastChild, endNode);
       });
@@ -1150,8 +1152,8 @@ suite('Core', () => {
         part.commit();
         assert.equal(stripExpressionDelimeters(container.innerHTML), '123');
         assert.deepEqual(
-            ['', '1', '', '2', '', '3', ''],
-            Array.from(container.childNodes).map((n) => n.nodeValue));
+            Array.from(container.childNodes).map((n) => n.nodeValue),
+            ['', '', '1', '', '2', '', '3', '', '']);
         assert.strictEqual(container.firstChild, startNode);
         assert.strictEqual(container.lastChild, endNode);
 
@@ -1159,7 +1161,7 @@ suite('Core', () => {
         part.commit();
         assert.equal(stripExpressionDelimeters(container.innerHTML), '');
         assert.deepEqual(
-            ['', ''], Array.from(container.childNodes).map((n) => n.nodeValue));
+            Array.from(container.childNodes).map((n) => n.nodeValue), ['', '']);
         assert.strictEqual(container.firstChild, startNode);
         assert.strictEqual(container.lastChild, endNode);
       });
@@ -1169,8 +1171,8 @@ suite('Core', () => {
         part.commit();
         assert.equal(stripExpressionDelimeters(container.innerHTML), '123');
         assert.deepEqual(
-            ['', '1', '', '2', '', '3', ''],
-            Array.from(container.childNodes).map((n) => n.nodeValue));
+            Array.from(container.childNodes).map((n) => n.nodeValue),
+            ['', '', '1', '', '2', '', '3', '', '']);
         assert.strictEqual(container.firstChild, startNode);
         assert.strictEqual(container.lastChild, endNode);
 
@@ -1178,8 +1180,8 @@ suite('Core', () => {
         part.commit();
         assert.equal(stripExpressionDelimeters(container.innerHTML), '45');
         assert.deepEqual(
-            ['', '4', '', '5', ''],
-            Array.from(container.childNodes).map((n) => n.nodeValue));
+            Array.from(container.childNodes).map((n) => n.nodeValue),
+            ['', '', '4', '', '5', '', '']);
         assert.strictEqual(container.firstChild, startNode);
         assert.strictEqual(container.lastChild, endNode);
 
@@ -1187,7 +1189,7 @@ suite('Core', () => {
         part.commit();
         assert.equal(stripExpressionDelimeters(container.innerHTML), '');
         assert.deepEqual(
-            ['', ''], Array.from(container.childNodes).map((n) => n.nodeValue));
+            Array.from(container.childNodes).map((n) => n.nodeValue), ['', '']);
         assert.strictEqual(container.firstChild, startNode);
         assert.strictEqual(container.lastChild, endNode);
 
@@ -1195,8 +1197,8 @@ suite('Core', () => {
         part.commit();
         assert.equal(stripExpressionDelimeters(container.innerHTML), '45');
         assert.deepEqual(
-            ['', '4', '', '5', ''],
-            Array.from(container.childNodes).map((n) => n.nodeValue));
+            Array.from(container.childNodes).map((n) => n.nodeValue),
+            ['', '', '4', '', '5', '', '']);
         assert.strictEqual(container.firstChild, startNode);
         assert.strictEqual(container.lastChild, endNode);
       });
@@ -1206,8 +1208,8 @@ suite('Core', () => {
         part.commit();
         assert.equal(stripExpressionDelimeters(container.innerHTML), '123');
         assert.deepEqual(
-            ['', '1', '', '2', '', '3', ''],
-            Array.from(container.childNodes).map((n) => n.nodeValue));
+            Array.from(container.childNodes).map((n) => n.nodeValue),
+            ['', '', '1', '', '', '2', '', '', '3', '', '']);
         assert.strictEqual(container.firstChild, startNode);
         assert.strictEqual(container.lastChild, endNode);
 
@@ -1215,8 +1217,8 @@ suite('Core', () => {
         part.commit();
         assert.equal(stripExpressionDelimeters(container.innerHTML), '123');
         assert.deepEqual(
-            ['', '1', '', '2', '', '3', ''],
-            Array.from(container.childNodes).map((n) => n.nodeValue));
+            Array.from(container.childNodes).map((n) => n.nodeValue),
+            ['', '', '', '1', '', '', '2', '', '3', '', '']);
         assert.strictEqual(container.firstChild, startNode);
         assert.strictEqual(container.lastChild, endNode);
       });
@@ -1278,6 +1280,77 @@ suite('Core', () => {
             const newLIs = Array.from(container.querySelectorAll('li'));
             assert.deepEqual(newLIs, originalLIs);
           });
+    });
+
+    suite('insertAfterNode', () => {
+      test(
+          'inserts part and sets values between ref node and its next sibling',
+          () => {
+            const testEndNode = document.createComment('');
+            container.appendChild(testEndNode);
+            const testPart = new NodePart(defaultTemplateFactory);
+            testPart.insertAfterNode(endNode);
+            assert.equal(testPart.startNode, endNode);
+            assert.equal(testPart.endNode, testEndNode);
+            const text = document.createTextNode('');
+            testPart.setValue(text);
+            testPart.commit();
+            assert.deepEqual(
+                Array.from(container.childNodes),
+                [startNode, endNode, text, testEndNode]);
+          });
+    });
+
+    suite('appendIntoPart', () => {
+      test(
+          'inserts part and sets values between ref node and its next sibling',
+          () => {
+            const testPart = new NodePart(defaultTemplateFactory);
+            testPart.appendIntoPart(part);
+            assert.instanceOf(testPart.startNode, Comment);
+            assert.instanceOf(testPart.endNode, Comment);
+            const text = document.createTextNode('');
+            testPart.setValue(text);
+            testPart.commit();
+            assert.deepEqual(Array.from(container.childNodes), [
+              startNode,
+              testPart.startNode,
+              text,
+              testPart.endNode,
+              endNode,
+            ]);
+
+            const parentText = document.createTextNode('');
+            part.setValue(parentText);
+            part.commit();
+            assert.deepEqual(Array.from(container.childNodes), [
+              startNode,
+              parentText,
+              endNode,
+            ]);
+          });
+    });
+
+    suite('insertAfterPart', () => {
+      test('inserts part and sets values after another part', () => {
+        const testPart = new NodePart(defaultTemplateFactory);
+        testPart.insertAfterPart(part);
+        assert.instanceOf(testPart.startNode, Comment);
+        assert.equal(testPart.endNode, endNode);
+        const text = document.createTextNode('');
+        testPart.setValue(text);
+        testPart.commit();
+        assert.deepEqual(
+            Array.from(container.childNodes),
+            [startNode, testPart.startNode, text, endNode]);
+
+        const previousText = document.createTextNode('');
+        part.setValue(previousText);
+        part.commit();
+        assert.deepEqual(
+            Array.from(container.childNodes),
+            [startNode, previousText, testPart.startNode, text, endNode]);
+      });
     });
 
     suite('clear', () => {


### PR DESCRIPTION
Adds `NodePart#insertAfterNode`, `NodePart#appendIntoPart`, `NodePart#insertAfterPart` to abstract away a little of the marker node management. Cleans up some of the code in `NodePart#_setIterable`.

This brings the size of core.js to just under 2.5k

Note that I didn't put much work into cleaning up repeat(), but left a comment explaining why.