### PR TITLE
Add guard directive

### DIFF
--- a/src/directives/guard.ts
+++ b/src/directives/guard.ts
@@ -1,0 +1,46 @@
+/**
+ * @license
+ * Copyright (c) 2018 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+import {directive, Directive, NodePart} from '../lit-html.js';
+
+const previousExpressions = new WeakMap<NodePart, any>();
+
+/**
+ * Creates a guard directive. Prevents any re-render until the identity of the expression
+ * changes, for example when a primitive changes value or when an object reference changes.
+ *
+ * This useful with immutable data patterns, by preventing expensive work until data updates.
+ * Example:
+ *
+ * html`
+ *   <div>
+ *     ${guard(items, () => items.map(item => html`${item}`))}
+ *   </div>
+ * `
+ *
+ * In this case, items are mapped over only when the array reference changes.
+ *
+ * @param expression the expression to check before re-rendering
+ * @param valueFn function which returns the render value
+ */
+export const guard = (expression: any, valueFn: () => any): Directive<NodePart> =>
+    directive((part: NodePart): void => {
+      // Dirty check previous expression
+      if (previousExpressions.get(part) === expression) {
+        return;
+      }
+
+      part.setValue(valueFn());
+      previousExpressions.set(part, expression);
+    });

--- a/src/test/directives/guard_test.ts
+++ b/src/test/directives/guard_test.ts
@@ -1,0 +1,94 @@
+/**
+ * @license
+ * Copyright (c) 2018 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+/// <reference path="../../../node_modules/@types/mocha/index.d.ts" />
+/// <reference path="../../../node_modules/@types/chai/index.d.ts" />
+
+import {render} from '../../lib/render.js';
+import {html} from '../../lit-html.js';
+import {guard} from '../../directives/guard.js';
+import {stripExpressionMarkers} from '../test-utils/strip-markers.js';
+
+const assert = chai.assert;
+
+suite('guard', () => {
+  let container: HTMLDivElement;
+
+  function renderGuarded(expression: any, value: () => any) {
+    render(html`<div>${guard(expression, value)}</div>`, container);
+  }
+
+  setup(() => {
+    container = document.createElement('div');
+  });
+
+  test('re-renders only on identity changes', () => {
+    let callCount = 0;
+    let renderCount = 0;
+
+    const guardedTemplate = () => {
+      callCount += 1;
+      return html`Template ${renderCount}`;
+    };
+
+    renderCount += 1;
+    renderGuarded('foo', guardedTemplate);
+    assert.equal(
+      stripExpressionMarkers(container.innerHTML),
+      '<div>Template 1</div>');
+
+    renderCount += 1;
+    renderGuarded('foo', guardedTemplate);
+    assert.equal(
+      stripExpressionMarkers(container.innerHTML),
+       '<div>Template 1</div>');
+
+    renderCount += 1;
+    renderGuarded('bar', guardedTemplate);
+    assert.equal(
+      stripExpressionMarkers(container.innerHTML),
+      '<div>Template 3</div>' );
+
+    assert.equal(callCount, 2);
+  });
+
+  test('dirty checks non-primitive values', () => {
+    let callCount = 0;
+    let items = ['foo', 'bar'];
+
+    const guardedTemplate = () => {
+      callCount += 1;
+      return html`<ul>${items.map((i) => html`<li>${i}</li>`)}`;
+    };
+
+    renderGuarded(items, guardedTemplate);
+    assert.equal(
+      stripExpressionMarkers(container.innerHTML),
+      '<div><ul><li>foo</li><li>bar</li></ul></div>');
+    items.push('baz');
+
+    renderGuarded(items, guardedTemplate);
+    assert.equal(
+      stripExpressionMarkers(container.innerHTML),
+      '<div><ul><li>foo</li><li>bar</li></ul></div>');
+
+    items = [...items];
+    renderGuarded(items, guardedTemplate);
+    assert.equal(
+      stripExpressionMarkers(container.innerHTML),
+      '<div><ul><li>foo</li><li>bar</li><li>baz</li></ul></div>');
+
+    assert.equal(callCount, 2);
+  });
+});


### PR DESCRIPTION
This adds a guard directive. I know there is a lot of refactoring going on in https://github.com/Polymer/lit-html/pull/436, but with this PR this can already be reviewed. I can rebase later.

The implementation is really simple, it just dirty checks the expression and if it changed since the previous render it sets the value. 

Dirty checking for objects is done on identity/pointer, so immutable data patterns need to be used for updating. Unlike the polymer data system, there is no 'escape' like doing `this.set('foo.bar')` or `notifyPath()`. We could add a 'force' parameter, but maybe see if we can get away without that first.