### PR TITLE
Fix bug in AttributePart setValue

### DIFF
--- a/src/lib/parts.ts
+++ b/src/lib/parts.ts
@@ -118,7 +118,7 @@ export class AttributePart implements Part {
   }
 
   setValue(value: any): void {
-    if (value !== noChange || !isPrimitive(value) || value !== this.value) {
+    if (value !== noChange && (!isPrimitive(value) || value !== this.value)) {
       this.value = value;
       // If the value is a not a directive, dirty the committer so that it'll
       // call setAttribute. If the value is a directive, it'll dirty the

--- a/src/test/lib/parts_test.ts
+++ b/src/test/lib/parts_test.ts
@@ -13,12 +13,34 @@
  */
 
 import {TemplateProcessor} from '../../lib/template-processor.js';
-import {html, NodePart, render, templateFactory, TemplateResult} from '../../lit-html.js';
+import {AttributeCommitter, AttributePart, html, NodePart, render, templateFactory, TemplateResult} from '../../lit-html.js';
 import {stripExpressionMarkers} from '../test-utils/strip-markers.js';
 
 const assert = chai.assert;
 
 suite('Parts', () => {
+  suite('AttributePart', () => {
+    let element: HTMLElement;
+    let committer: AttributeCommitter;
+    let part: AttributePart;
+
+    setup(() => {
+      element = document.createElement('div');
+      committer = new AttributeCommitter(element, 'foo', ['', '']);
+      part = committer.parts[0];
+    });
+
+    suite('setValue', () => {
+      test('does not dirty the committer when setting the same value twice', () => {
+        part.setValue('bar');
+        part.commit();
+        assert.equal(element.getAttribute('foo'), 'bar');
+        part.setValue('bar');
+        assert.equal(committer.dirty, false)
+      });
+    });
+  });
+
   suite('NodePart', () => {
     let container: HTMLElement;
     let startNode: Node;


### PR DESCRIPTION
There's a bug in your `setValue()` function in `AttributePart`

This statement always evaluates to true, which made the conditional always evaluate the true branch:

```
value !== noChange || !isPrimitive(value)
```

Clearly the intent is to do nothing if `value === noChange` (or if ` isPrimitive(value) && value === this.value`)