### PR TITLE
Upgrade disconnected custom elements before setting properties on them.

### DIFF
--- a/src/lib/dom.ts
+++ b/src/lib/dom.ts
@@ -12,6 +12,9 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
+export const isCEPolyfill = window.customElements !== undefined &&
+    (window.customElements as any).polyfillWrapFlushCallback !== undefined;
+
 /**
  * Reparents nodes, starting from `startNode` (inclusive) to `endNode`
  * (exclusive), into another container (could be the same container), before

--- a/src/lib/parts.ts
+++ b/src/lib/parts.ts
@@ -13,7 +13,7 @@
  */
 
 import {isDirective} from './directive.js';
-import {removeNodes} from './dom.js';
+import {isCEPolyfill, removeNodes} from './dom.js';
 import {TemplateFactory} from './template-factory.js';
 import {TemplateInstance} from './template-instance.js';
 import {TemplateResult} from './template-result.js';
@@ -257,7 +257,13 @@ export class NodePart implements Part {
       // from the render function so that it can control caching.
       instance =
           new TemplateInstance(template, value.processor, this.templateFactory);
-      this._commitNode(instance._clone());
+      const fragment = instance._clone();
+      // Since we cloned in the polyfill case, now force an upgrade
+      if (isCEPolyfill && !this.endNode.isConnected) {
+        document.adoptNode(fragment);
+        customElements.upgrade(fragment);
+      }
+      this._commitNode(fragment);
       this.value = instance;
     }
     instance.update(value.values);

--- a/src/lib/render.ts
+++ b/src/lib/render.ts
@@ -12,7 +12,7 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {removeNodes} from './dom.js';
+import {isCEPolyfill, removeNodes} from './dom.js';
 import {templateFactory as defaultTemplateFactory, TemplateFactory} from './template-factory.js';
 import {TemplateInstance} from './template-instance.js';
 import {TemplateResult} from './template-result.js';
@@ -52,6 +52,11 @@ export function render(
   (container as TemplateContainer).__templateInstance = instance;
   const fragment = instance._clone();
   removeNodes(container, container.firstChild);
+  // Since we cloned in the polyfill case, now force an upgrade
+  if (isCEPolyfill && !container.isConnected) {
+    document.adoptNode(fragment);
+    customElements.upgrade(fragment);
+  }
   container.appendChild(fragment);
   instance.update(result.values);
 }

--- a/src/lib/template-instance.ts
+++ b/src/lib/template-instance.ts
@@ -13,13 +13,11 @@
  */
 
 
+import {isCEPolyfill} from './dom.js';
 import {Part} from './parts.js';
 import {TemplateFactory} from './template-factory.js';
 import {TemplateProcessor} from './template-processor.js';
 import {isTemplatePartActive, Template} from './template.js';
-
-const isCEPolyfill = window.customElements !== undefined &&
-    (window.customElements as any).polyfillWrapFlushCallback !== undefined;
 
 /**
  * An instance of a `Template` that can be attached to the DOM and updated
@@ -108,12 +106,6 @@ export class TemplateInstance {
       }
     };
     _prepareInstance(fragment);
-
-    // Since we cloned in the polyfill case, now force an upgrade
-    if (isCEPolyfill) {
-      document.adoptNode(fragment);
-      customElements.upgrade(fragment);
-    }
     return fragment;
   }
 }

--- a/src/lib/template-instance.ts
+++ b/src/lib/template-instance.ts
@@ -18,6 +18,9 @@ import {TemplateFactory} from './template-factory.js';
 import {TemplateProcessor} from './template-processor.js';
 import {isTemplatePartActive, Template} from './template.js';
 
+const isCEPolyfill = window.customElements !== undefined &&
+    (window.customElements as any).polyfillWrapFlushCallback !== undefined;
+
 /**
  * An instance of a `Template` that can be attached to the DOM and updated
  * with new values.
@@ -52,11 +55,15 @@ export class TemplateInstance {
   }
 
   _clone(): DocumentFragment {
-    // Clone the node, rather than importing it, to keep the fragment in the
-    // template's document. This leaves the fragment inert so custom elements
-    // won't upgrade until after the main document adopts the node.
-    const fragment =
-        this.template.element.content.cloneNode(true) as DocumentFragment;
+    // When using the Custom Elements polyfill, clone the node, rather than
+    // importing it, to keep the fragment in the template's document. This
+    // leaves the fragment inert so custom elements won't upgrade and
+    // potentially modify their contents by creating a polyfilled ShadowRoot
+    // while we traverse the tree.
+    const fragment = isCEPolyfill ?
+        this.template.element.content.cloneNode(true) as DocumentFragment :
+        document.importNode(this.template.element.content, true);
+
     const parts = this.template.parts;
     let partIndex = 0;
     let nodeIndex = 0;
@@ -65,9 +72,7 @@ export class TemplateInstance {
       // null
       const walker = document.createTreeWalker(
           fragment,
-          133 /* NodeFilter.SHOW_ELEMENT | NodeFilter.SHOW_COMMENT |
-NodeFilter.SHOW_TEXT */
-          ,
+          133 /* NodeFilter.SHOW_{ELEMENT|COMMENT|TEXT} */,
           null as any,
           false);
       let node = walker.nextNode();
@@ -103,6 +108,18 @@ NodeFilter.SHOW_TEXT */
       }
     };
     _prepareInstance(fragment);
+
+    // Since we cloned in the polyfill case, now force an upgrade
+    if (isCEPolyfill) {
+      document.adoptNode(fragment);
+      customElements.upgrade(fragment);
+    }
     return fragment;
+  }
+}
+
+declare global {
+  class CustomElementRegistry {
+    upgrade(node: Node): void;
   }
 }


### PR DESCRIPTION
This keeps us from creating instance properties that alias assessors on disconnected elements.

This technique only works if `customElements.upgrade` is implemented. It's in Chrome, the polyfill, and Safari TP, and Firefox nightly.

There's two other ways we could solve this. First we either:
1. Patch TreeWalker properly in ShadyDOM
2. Don't use TreeWalker to traverse, so that we don't traverse ShadyDOM ShadowRoots created synchronously in constructors.

Then we go back to `document.importNode(template.content, true)` to clone & upgrade in one step.