### PR TITLE
Rewrite render() to use a NodePart

### DIFF
--- a/src/directives/async-append.ts
+++ b/src/directives/async-append.ts
@@ -12,7 +12,7 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {directive, Directive, NodePart} from '../lit-html.js';
+import {createMarker, directive, Directive, NodePart} from '../lit-html.js';
 
 /**
  * A directive that renders the items of an async iterable[1], appending new
@@ -79,7 +79,7 @@ export const asyncAppend = <T>(
         // Check to see if we have a previous item and Part
         if (itemPart !== undefined) {
           // Create a new node to separate the previous and next Parts
-          itemStartNode = document.createComment('');
+          itemStartNode = createMarker();
           // itemPart is currently the Part for the previous item. Set
           // it's endNode to the node we'll use for the next Part's
           // startNode.

--- a/src/directives/repeat.ts
+++ b/src/directives/repeat.ts
@@ -12,7 +12,7 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {directive, Directive, NodePart, removeNodes, reparentNodes} from '../lit-html.js';
+import {createMarker, directive, Directive, NodePart, removeNodes, reparentNodes} from '../lit-html.js';
 
 export type KeyFn<T> = (item: T) => any;
 export type ItemTemplate<T> = (item: T, index: number) => any;
@@ -74,8 +74,8 @@ export function repeat<T>(
         // keyMapCache and use part._value instead.
         // But... repeat() is badly in need of rewriting, so we'll do this for
         // now and revisit soon.
-        const marker = document.createComment('');
-        const endNode = document.createComment('');
+        const marker = createMarker();
+        const endNode = createMarker();
         container.insertBefore(marker, currentMarker);
         container.insertBefore(endNode, currentMarker);
         itemPart = new NodePart(part.templateFactory);

--- a/src/lib/render.ts
+++ b/src/lib/render.ts
@@ -12,14 +12,13 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {isCEPolyfill, removeNodes} from './dom.js';
+import {removeNodes} from './dom.js';
+import {NodePart} from './parts.js';
 import {templateFactory as defaultTemplateFactory, TemplateFactory} from './template-factory.js';
-import {TemplateInstance} from './template-instance.js';
 import {TemplateResult} from './template-result.js';
+import {createMarker} from './template.js';
 
-export type TemplateContainer = (Element|DocumentFragment)&{
-  __templateInstance?: TemplateInstance;
-};
+const parts = new WeakMap<Node, NodePart>();
 
 /**
  * Renders a template to a container.
@@ -39,24 +38,17 @@ export function render(
     result: TemplateResult,
     container: Element|DocumentFragment,
     templateFactory: TemplateFactory = defaultTemplateFactory) {
-  const template = templateFactory(result);
-  let instance = (container as TemplateContainer).__templateInstance;
-  // Repeat render, just call update()
-  if (instance !== undefined && instance.template === template &&
-      instance.processor === result.processor) {
-    instance.update(result.values);
-    return;
+  let part = parts.get(container);
+  if (part === undefined) {
+    removeNodes(container, container.firstChild);
+    part = new NodePart(templateFactory);
+    const startNode = createMarker();
+    const endNode = createMarker();
+    container.appendChild(startNode);
+    container.appendChild(endNode);
+    part.insertAfterNode(startNode);
+    parts.set(container, part);
   }
-  // First render, create a new TemplateInstance and append it
-  instance = new TemplateInstance(template, result.processor, templateFactory);
-  (container as TemplateContainer).__templateInstance = instance;
-  const fragment = instance._clone();
-  removeNodes(container, container.firstChild);
-  // Since we cloned in the polyfill case, now force an upgrade
-  if (isCEPolyfill && !container.isConnected) {
-    document.adoptNode(fragment);
-    customElements.upgrade(fragment);
-  }
-  container.appendChild(fragment);
-  instance.update(result.values);
+  part.setValue(result);
+  part.commit();
 }

--- a/src/test/directives/unsafe-html_test.ts
+++ b/src/test/directives/unsafe-html_test.ts
@@ -46,7 +46,7 @@ suite('unsafeHTML', () => {
     // Modify instance directly. Since lit-html doesn't dirty check against
     // actual DOM, but again previous part values, this modification should
     // persist through the next render if dirty checking works.
-    const text = container.firstChild!.childNodes[1] as Text;
+    const text = container.querySelector('div')!.childNodes[1] as Text;
     text.textContent = 'bbb';
     assert.equal(stripExpressionMarkers(container.innerHTML), '<div>bbb</div>');
 
@@ -54,7 +54,7 @@ suite('unsafeHTML', () => {
     render(t(), container);
 
     assert.equal(stripExpressionMarkers(container.innerHTML), '<div>bbb</div>');
-    const text2 = container.firstChild!.childNodes[1] as Text;
+    const text2 = container.querySelector('div')!.childNodes[1] as Text;
     assert.strictEqual(text, text2);
   });
 

--- a/src/test/lib/parts_test.ts
+++ b/src/test/lib/parts_test.ts
@@ -13,7 +13,7 @@
  */
 
 import {TemplateProcessor} from '../../lib/template-processor.js';
-import {html, NodePart, render, templateFactory, TemplateResult} from '../../lit-html.js';
+import {createMarker, html, NodePart, render, templateFactory, TemplateResult} from '../../lit-html.js';
 import {stripExpressionMarkers} from '../test-utils/strip-markers.js';
 
 const assert = chai.assert;
@@ -27,8 +27,8 @@ suite('Parts', () => {
 
     setup(() => {
       container = document.createElement('div');
-      startNode = document.createComment('');
-      endNode = document.createComment('');
+      startNode = createMarker();
+      endNode = createMarker();
       container.appendChild(startNode);
       container.appendChild(endNode);
       part = new NodePart(templateFactory);
@@ -325,7 +325,7 @@ suite('Parts', () => {
       test(
           'inserts part and sets values between ref node and its next sibling',
           () => {
-            const testEndNode = document.createComment('');
+            const testEndNode = createMarker();
             container.appendChild(testEndNode);
             const testPart = new NodePart(templateFactory);
             testPart.insertAfterNode(endNode);

--- a/src/test/lib/render_test.ts
+++ b/src/test/lib/render_test.ts
@@ -433,7 +433,7 @@ suite('render()', () => {
   suite('properties', () => {
     test('sets properties', () => {
       render(html`<div .foo=${123} .bar=${456}></div>`, container);
-      const div = container.firstChild!;
+      const div = container.querySelector('div')!;
       assert.strictEqual((div as any).foo, 123);
       assert.strictEqual((div as any).bar, 456);
     });
@@ -482,7 +482,7 @@ suite('render()', () => {
         thisValue = this;
       };
       render(html`<div @click=${listener}></div>`, container);
-      const div = container.firstChild as HTMLElement;
+      const div = container.querySelector('div')!;
       div.click();
       assert.equal(thisValue, div);
 
@@ -503,7 +503,7 @@ suite('render()', () => {
         }
       };
       render(html`<div @click=${listener}></div>`, container);
-      const div = container.firstChild as HTMLElement;
+      const div = container.querySelector('div')!;
       div.click();
       assert.equal(thisValue, listener);
     });
@@ -516,7 +516,7 @@ suite('render()', () => {
       render(html`<div @click=${listener}></div>`, container);
       render(html`<div @click=${listener}></div>`, container);
 
-      const div = container.firstChild as HTMLElement;
+      const div = container.querySelector('div')!;
       div.click();
       assert.equal(count, 1);
     });
@@ -534,7 +534,7 @@ suite('render()', () => {
       render(t(listener1), container);
       render(t(listener2), container);
 
-      const div = container.firstChild as HTMLElement;
+      const div = container.querySelector('div')!;
       div.click();
       assert.equal(count1, 0);
       assert.equal(count2, 1);
@@ -546,7 +546,7 @@ suite('render()', () => {
           let listener: Function|null;
           const t = () => html`<div @click=${listener}></div>`;
           render(t(), container);
-          const div = container.firstChild as HTMLElement;
+          const div = container.querySelector('div')!;
 
           let addCount = 0;
           let removeCount = 0;
@@ -584,7 +584,7 @@ suite('render()', () => {
       let listener: any = (e: any) => target = e.target;
       const t = () => html`<div @click=${listener}></div>`;
       render(t(), container);
-      const div = container.firstChild as HTMLElement;
+      const div = container.querySelector('div')!;
       div.click();
       assert.equal(target, div);
 
@@ -957,22 +957,6 @@ suite('render()', () => {
           '<ul><li>x</li><li>y</li></ul>');
     });
 
-    test('sanity check one', () => {
-      // bump line numbers
-      const foo = 'aaa';
-
-      const t = () => html`<div>${foo}</div>`;
-
-      render(t(), container);
-      assert.equal(
-          stripExpressionMarkers(container.innerHTML), '<div>aaa</div>');
-      const text = container.firstChild!.childNodes[1] as Text;
-      text.textContent = 'bbb';
-      render(t(), container);
-      assert.equal(
-          stripExpressionMarkers(container.innerHTML), '<div>bbb</div>');
-    });
-
     test('dirty checks simple values', () => {
       const foo = 'aaa';
 
@@ -981,7 +965,7 @@ suite('render()', () => {
       render(t(), container);
       assert.equal(
           stripExpressionMarkers(container.innerHTML), '<div>aaa</div>');
-      const text = container.firstChild!.childNodes[1] as Text;
+      const text = container.querySelector('div')!;
       assert.equal(text.textContent, 'aaa');
 
       // Set textContent manually. Since lit-html doesn't dirty check against
@@ -996,7 +980,7 @@ suite('render()', () => {
       render(t(), container);
       assert.equal(
           stripExpressionMarkers(container.innerHTML), '<div>bbb</div>');
-      const text2 = container.firstChild!.childNodes[1] as Text;
+      const text2 = container.querySelector('div')!;
 
       // The next node should be the same too
       assert.strictEqual(text, text2);
@@ -1041,14 +1025,14 @@ suite('render()', () => {
       render(t(), container);
       assert.equal(
           stripExpressionMarkers(container.innerHTML), '<div>aaa</div>');
-      const div = container.firstChild as HTMLDivElement;
+      const div = container.querySelector('div')!;
       assert.equal(div.tagName, 'DIV');
 
       foo = 'bbb';
       render(t(), container);
       assert.equal(
           stripExpressionMarkers(container.innerHTML), '<div>bbb</div>');
-      const div2 = container.firstChild as HTMLDivElement;
+      const div2 = container.querySelector('div')!;
       // check that only the part changed
       assert.equal(div, div2);
     });


### PR DESCRIPTION
This is mostly just to reuse some logic and try to not repeat ourselves in render() and NodePart#_commitTemplateResult.

This has the side-effect of allowing more value types to render(), which I'm so-so on as it doesn't seem like a huge use case, though it does solve #422.

shady-render is tricky as usual. I included a commit that rewrites it, but it has to patch a NodePart :/ I didn't bother making all the shady tests pass because of how ugly that is. An option there would be to let NodePart#_insert be overridable and subclass it with a ShadyNodePart.