### PR TITLE
Small directive optimization

### DIFF
--- a/src/lib/directive.ts
+++ b/src/lib/directive.ts
@@ -14,15 +14,15 @@
 
 import {Part} from './parts.js';
 
+const directives = new WeakMap<any, Boolean>();
+
 export interface Directive<P = Part> {
   (part: P): void;
-  __litDirective?: true;
 }
 
 export const directive = <P = Part>(f: Directive<P>): Directive<P> => {
-  f.__litDirective = true;
+  directives.set(f, true);
   return f;
 };
 
-export const isDirective = (o: any) =>
-    typeof o === 'function' && o.__litDirective === true;
+export const isDirective = (o: any) => directives.has(o);


### PR DESCRIPTION
Just a small change, I think this variant is a little cleaner since it doesn't use 'private' properties on objects.

This saves 21 bytes in the library size (before minification and compression). It increases runtime memory consumption by a few bytes: it adds one `WeakMap` instance to the memory pool.

I found no measurable performance difference.

Someone who understands TypeScript should probably check the `any` type on the WeakMap key. I'm sure it's not correct, but I couldn't find anything else that would compile. I can update the PR with the correct type.

----

An alternative option is to use Set or WeakSet instead of a WeakMap, but I believe WeakMap performance is slightly better than Set, and WeakSet would require another polyfill for IE11.

The odds of a directive ever leaving memory once created is pretty much zero, so Set is probably the most appropriate to use here. It would probably also save additional bytes. I can benchmark again with Set to verify that there is no impact.