### PR TITLE
Don’t use WeakMap with primitive value keys.

### DIFF
--- a/src/lib/directive.ts
+++ b/src/lib/directive.ts
@@ -25,4 +25,5 @@ export const directive = <P = Part>(f: Directive<P>): Directive<P> => {
   return f;
 };
 
-export const isDirective = (o: any) => directives.has(o);
+export const isDirective = (o: any) =>
+    typeof o === 'function' && directives.has(o);


### PR DESCRIPTION
Fixes #462