### PR TITLE
Break cycle in dependency graph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 <!-- ## Unreleased -->
 
+### Changed
+* Eliminated a cycle in the module import graph (#472)
+* Remove the default value for the templateProcessor parameter in TemplateResult#constuctor, making it a required paremeter (#472)
+
 ## [0.11.0] - 2018-08-28
 
 ### Added

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -21,11 +21,6 @@ export default {
     file: 'lit-html.bundled.js',
     format: 'esm',
   },
-  onwarn(warning) {
-    if (warning.code !== 'CIRCULAR_DEPENDENCY') {
-      console.error(`(!) ${warning.message}`);
-    }
-  },
   plugins: [
     terser({
       warnings: true,

--- a/src/lib/default-template-processor.ts
+++ b/src/lib/default-template-processor.ts
@@ -12,11 +12,15 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {Part} from './part.js';
-import {NodePart} from './parts.js';
-import {TemplateFactory} from './template-factory.js';
+import {TemplateFactory} from '../lit-html.js';
 
-export interface TemplateProcessor {
+import {Part} from './part.js';
+import {AttributeCommitter, BooleanAttributePart, EventPart, NodePart, PropertyCommitter} from './parts.js';
+
+/**
+ * Creates Parts when a template is instantiated.
+ */
+export class DefaultTemplateProcessor {
   /**
    * Create parts for an attribute-position binding, given the event, attribute
    * name, and string literals.
@@ -27,11 +31,28 @@ export interface TemplateProcessor {
    *   event for fully-controlled bindings with a single expression.
    */
   handleAttributeExpressions(element: Element, name: string, strings: string[]):
-      Part[];
-
+      Part[] {
+    const prefix = name[0];
+    if (prefix === '.') {
+      const comitter = new PropertyCommitter(element, name.slice(1), strings);
+      return comitter.parts;
+    }
+    if (prefix === '@') {
+      return [new EventPart(element, name.slice(1))];
+    }
+    if (prefix === '?') {
+      return [new BooleanAttributePart(element, name.slice(1), strings)];
+    }
+    const comitter = new AttributeCommitter(element, name, strings);
+    return comitter.parts;
+  }
   /**
    * Create parts for a text-position binding.
    * @param templateFactory
    */
-  handleTextExpression(templateFactory: TemplateFactory): NodePart;
+  handleTextExpression(templateFactory: TemplateFactory) {
+    return new NodePart(templateFactory);
+  }
 }
+
+export const defaultTemplateProcessor = new DefaultTemplateProcessor();

--- a/src/lib/directive.ts
+++ b/src/lib/directive.ts
@@ -12,7 +12,7 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {Part} from './parts.js';
+import {Part} from './part.js';
 
 const directives = new WeakMap<any, Boolean>();
 

--- a/src/lib/part.ts
+++ b/src/lib/part.ts
@@ -1,0 +1,24 @@
+/**
+ * The Part interface represents a dynamic part of a template instance rendered
+ * by lit-html.
+ */
+export interface Part {
+  value: any;
+
+  /**
+   * Sets the current part value, but does not write it to the DOM.
+   * @param value The value that will be committed.
+   */
+  setValue(value: any): void;
+
+  /**
+   * Commits the current part value, cause it to actually be written to the DOM.
+   */
+  commit(): void;
+}
+
+/**
+ * A sentinel value that signals that a value was handled by a directive and
+ * should not be written to the DOM.
+ */
+export const noChange = {};

--- a/src/lib/parts.ts
+++ b/src/lib/parts.ts
@@ -14,35 +14,11 @@
 
 import {isDirective} from './directive.js';
 import {isCEPolyfill, removeNodes} from './dom.js';
+import {noChange, Part} from './part.js';
 import {TemplateFactory} from './template-factory.js';
 import {TemplateInstance} from './template-instance.js';
 import {TemplateResult} from './template-result.js';
 import {createMarker} from './template.js';
-
-/**
- * The Part interface represents a dynamic part of a template instance rendered
- * by lit-html.
- */
-export interface Part {
-  value: any;
-
-  /**
-   * Sets the current part value, but does not write it to the DOM.
-   * @param value The value that will be committed.
-   */
-  setValue(value: any): void;
-
-  /**
-   * Commits the current part value, cause it to actually be written to the DOM.
-   */
-  commit(): void;
-}
-
-/**
- * A sentinel value that signals that a value was handled by a directive and
- * should not be written to the DOM.
- */
-export const noChange = {};
 
 export const isPrimitive = (value: any) =>
     (value === null ||

--- a/src/lib/template-instance.ts
+++ b/src/lib/template-instance.ts
@@ -14,7 +14,7 @@
 
 
 import {isCEPolyfill} from './dom.js';
-import {Part} from './parts.js';
+import {Part} from './part.js';
 import {TemplateFactory} from './template-factory.js';
 import {TemplateProcessor} from './template-processor.js';
 import {isTemplatePartActive, Template} from './template.js';

--- a/src/lib/template-result.ts
+++ b/src/lib/template-result.ts
@@ -13,7 +13,7 @@
  */
 
 import {reparentNodes} from './dom.js';
-import {defaultTemplateProcessor, TemplateProcessor} from './template-processor.js';
+import {TemplateProcessor} from './template-processor.js';
 import {lastAttributeNameRegex, marker, nodeMarker, rewritesStyleAttribute} from './template.js';
 
 /**
@@ -28,7 +28,7 @@ export class TemplateResult {
 
   constructor(
       strings: TemplateStringsArray, values: any[], type: string,
-      processor: TemplateProcessor = defaultTemplateProcessor) {
+      processor: TemplateProcessor) {
     this.strings = strings;
     this.values = values;
     this.type = type;

--- a/src/lit-html.ts
+++ b/src/lit-html.ts
@@ -12,12 +12,15 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
+import {defaultTemplateProcessor} from './lib/default-template-processor.js';
 import {SVGTemplateResult, TemplateResult} from './lib/template-result.js';
 
 export * from './lib/template-result.js';
 export * from './lib/template.js';
 export * from './lib/template-processor.js';
+export * from './lib/default-template-processor.js';
 export * from './lib/template-instance.js';
+export * from './lib/part.js';
 export * from './lib/parts.js';
 export * from './lib/dom.js';
 export * from './lib/directive.js';
@@ -29,11 +32,11 @@ export * from './lib/template-factory.js';
  * render to and update a container.
  */
 export const html = (strings: TemplateStringsArray, ...values: any[]) =>
-    new TemplateResult(strings, values, 'html');
+    new TemplateResult(strings, values, 'html', defaultTemplateProcessor);
 
 /**
  * Interprets a template literal as an SVG template that can efficiently
  * render to and update a container.
  */
 export const svg = (strings: TemplateStringsArray, ...values: any[]) =>
-    new SVGTemplateResult(strings, values, 'svg');
+    new SVGTemplateResult(strings, values, 'svg', defaultTemplateProcessor);

--- a/src/test/lib/parts_test.ts
+++ b/src/test/lib/parts_test.ts
@@ -12,8 +12,7 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {TemplateProcessor} from '../../lib/template-processor.js';
-import {AttributeCommitter, AttributePart, html, NodePart, render, templateFactory, TemplateResult} from '../../lit-html.js';
+import {AttributeCommitter, AttributePart, DefaultTemplateProcessor, html, NodePart, render, templateFactory, TemplateResult} from '../../lit-html.js';
 import {stripExpressionMarkers} from '../test-utils/strip-markers.js';
 
 const assert = chai.assert;
@@ -155,7 +154,7 @@ suite('Parts', () => {
       test('nested TemplateResults use their own processor', () => {
         // TODO (justinfagnani): rewrite to not use render(), but use NodePart
         // directly like the other tests here
-        class TestTemplateProcessor extends TemplateProcessor {
+        class TestTemplateProcessor extends DefaultTemplateProcessor {
           handleAttributeExpressions(
               element: Element, name: string, strings: string[]) {
             if (name[0] === '&') {


### PR DESCRIPTION
For compatibility with tools that don't handle cycles.

Note: I broke out more interfaces than strictly necessary (splitting TemplateProcessor would have been enough), but I didn't yet create an interface for NodePart, which would be nice to do soon.