### PR TITLE
Fixed link to CONTRIBUTING.md from within README.md (Fixes #474)

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,4 +48,4 @@ internal API may still change somewhat. The `html` and `render` API is stable.
 
 ## Contributing
 
-Please see [CONTRIBUTING.md]().
+Please see [CONTRIBUTING.md](https://github.com/Polymer/lit-html/blob/master/CONTRIBUTING.md).


### PR DESCRIPTION
At the bottom of the README.md file the link to the CONTRIBUTING.md file is broken as the url is not provided. 