### PR TITLE
Make TemplateInstance clone return upgraded fragments

### DIFF
--- a/src/lib/parts.ts
+++ b/src/lib/parts.ts
@@ -13,7 +13,7 @@
  */
 
 import {isDirective} from './directive.js';
-import {isCEPolyfill, removeNodes} from './dom.js';
+import {removeNodes} from './dom.js';
 import {noChange, Part} from './part.js';
 import {TemplateFactory} from './template-factory.js';
 import {TemplateInstance} from './template-instance.js';
@@ -234,11 +234,6 @@ export class NodePart implements Part {
       const instance =
           new TemplateInstance(template, value.processor, this.templateFactory);
       const fragment = instance._clone();
-      // Since we cloned in the polyfill case, now force an upgrade
-      if (isCEPolyfill) {
-        document.adoptNode(fragment);
-        customElements.upgrade(fragment);
-      }
       instance.update(value.values);
       this._commitNode(fragment);
       this.value = instance;

--- a/src/lib/render.ts
+++ b/src/lib/render.ts
@@ -12,7 +12,7 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {isCEPolyfill, removeNodes} from './dom.js';
+import {removeNodes} from './dom.js';
 import {templateFactory as defaultTemplateFactory, TemplateFactory} from './template-factory.js';
 import {TemplateInstance} from './template-instance.js';
 import {TemplateResult} from './template-result.js';
@@ -50,11 +50,6 @@ export function render(
   templateInstances.set(container, instance);
   const fragment = instance._clone();
   removeNodes(container, container.firstChild);
-  // Since we cloned in the polyfill case, now force an upgrade
-  if (isCEPolyfill && !container.isConnected) {
-    document.adoptNode(fragment);
-    customElements.upgrade(fragment);
-  }
   container.appendChild(fragment);
   instance.update(result.values);
 }

--- a/src/lib/template-instance.ts
+++ b/src/lib/template-instance.ts
@@ -106,6 +106,10 @@ export class TemplateInstance {
       }
     };
     _prepareInstance(fragment);
+    if (isCEPolyfill) {
+      document.adoptNode(fragment);
+      customElements.upgrade(fragment);
+    }
     return fragment;
   }
 }


### PR DESCRIPTION
As discussed in #455 

For some reason ShadyRender did not have the necessary code to upgrade the elements, so this possibly fixes a bug there. If this commit does not cause any tests to break then there's clearly some testing surface missing there, because it definitely changes behaviour.