### PR TITLE
Fix issues with shady-render introduced in 0.11.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 <!-- ### Removed -->
 <!-- ### Fixed -->
 
+## Unreleased
+* Fixed issues with `shady-render` introduced in 0.11.3 ([#504](https://github.com/Polymer/lit-html/issues/504) and [#505](https://github.com/Polymer/lit-html/issues/505).
+
+### Fixed
+
 ## [0.11.3] - 2018-09-13
 ### Changed
 * Moved upgrading of custom elements in template fragments to a common location in TemplateInstance ([#489](https://github.com/Polymer/lit-html/pull/489))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 <!-- ### Fixed -->
 
 ## Unreleased
-* Fixed issues with `shady-render` introduced in 0.11.3 ([#504](https://github.com/Polymer/lit-html/issues/504) and [#505](https://github.com/Polymer/lit-html/issues/505).
 
 ### Fixed
+* Fixed issues with `shady-render` introduced in 0.11.3 ([#504](https://github.com/Polymer/lit-html/issues/504) and [#505](https://github.com/Polymer/lit-html/issues/505).
 
 ## [0.11.3] - 2018-09-13
 ### Changed

--- a/src/lib/modify-template.ts
+++ b/src/lib/modify-template.ts
@@ -38,8 +38,8 @@ export function removeNodesFromTemplate(
   const {element: {content}, parts} = template;
   const walker =
       document.createTreeWalker(content, walkerNodeFilter, null as any, false);
-  let partIndex = 0;
-  let part = parts[0];
+  let partIndex = nextActiveIndexInTemplateParts(parts);
+  let part = parts[partIndex];
   let nodeIndex = -1;
   let removeCount = 0;
   const nodesToRemoveInTemplate = [];
@@ -67,7 +67,9 @@ export function removeNodesFromTemplate(
       // If part is in a removed node deactivate it by setting index to -1 or
       // adjust the index as needed.
       part.index = currentRemovingNode !== null ? -1 : part.index - removeCount;
-      part = parts[++partIndex];
+      // go to the next active part.
+      partIndex = nextActiveIndexInTemplateParts(parts, partIndex);
+      part = parts[partIndex];
     }
   }
   nodesToRemoveInTemplate.forEach((n) => n.parentNode!.removeChild(n));

--- a/src/lib/modify-template.ts
+++ b/src/lib/modify-template.ts
@@ -74,7 +74,7 @@ export function removeNodesFromTemplate(
 }
 
 const countNodes = (node: Node) => {
-  let count = 1;
+  let count = (node.nodeType === Node.DOCUMENT_FRAGMENT_NODE) ? 0 : 1;
   const walker =
       document.createTreeWalker(node, walkerNodeFilter, null as any, false);
   while (walker.nextNode()) {
@@ -117,8 +117,8 @@ export function insertNodeIntoTemplate(
     walkerIndex++;
     const walkerNode = walker.currentNode as Element;
     if (walkerNode === refNode) {
-      refNode.parentNode!.insertBefore(node, refNode);
       insertCount = countNodes(node);
+      refNode.parentNode!.insertBefore(node, refNode);
     }
     while (partIndex !== -1 && parts[partIndex].index === walkerIndex) {
       // If we've inserted the node, simply adjust all subsequent parts

--- a/src/lib/shady-render.ts
+++ b/src/lib/shady-render.ts
@@ -137,18 +137,18 @@ const prepareTemplateStyles =
       // will actually render so that it can update the style inside when
       // needed (e.g. @apply native Shadow DOM case).
       window.ShadyCSS.prepareTemplateStyles(template.element, scopeName);
-      // When in native Shadow DOM, re-add styling to rendered content using the
-      // style ShadyCSS produced.
       if (window.ShadyCSS.nativeShadow) {
+        // When in native Shadow DOM, re-add styling to rendered content using
+        // the style ShadyCSS produced.
         const style = template.element.content.querySelector('style')!;
         renderedDOM.insertBefore(style.cloneNode(true), renderedDOM.firstChild);
+      } else {
         // When not in native Shadow DOM, at this point ShadyCSS will have
         // removed the style from the lit template and parts will be broken as a
         // result. To fix this, we put back the style node ShadyCSS removed
         // and then tell lit to remove that node from the template.
         // NOTE, ShadyCSS creates its own style so we can safely add/remove
         // `condensedStyle` here.
-      } else {
         template.element.content.insertBefore(
             condensedStyle, template.element.content.firstChild);
         const removes = new Set();

--- a/src/lib/shady-render.ts
+++ b/src/lib/shady-render.ts
@@ -112,26 +112,50 @@ const styleTemplatesForScope =
       shadyRenderSet.add(scopeName);
       // Move styles out of rendered DOM and store.
       const styles = fragment.querySelectorAll('style');
-      const styleFragment = document.createDocumentFragment();
+      let condensedStyle;
+      // Collect styles into a single style. This helps us make sure ShadyCSS
+      // manipulations will not prevent us from being able to fix up template
+      // part indices.
+      // NOTE: collecting styles is inefficient for browsers but ShadyCSS
+      // currently does this anyway. When it does not, this should be changed.
       for (let i = 0; i < styles.length; i++) {
-        styleFragment.appendChild(styles[i]);
+        const style = styles[i];
+        style.parentNode!.removeChild(style);
+        if (condensedStyle === undefined) {
+          condensedStyle = document.createElement('style');
+        }
+        condensedStyle.textContent! += style.textContent;
       }
       // Remove styles from nested templates in this scope.
       removeStylesFromLitTemplates(scopeName);
-      // And then put them into the "root" template passed in as `template`.
-      insertNodeIntoTemplate(
-          template, styleFragment, template.element.content.firstChild);
+      // And then put the condensed style into the "root" template passed in as
+      // `template`.
+      if (condensedStyle !== undefined) {
+        insertNodeIntoTemplate(
+            template, condensedStyle, template.element.content.firstChild);
+      }
       // Note, it's important that ShadyCSS gets the template that `lit-html`
       // will actually render so that it can update the style inside when
-      // needed.
+      // needed (e.g. @apply native Shadow DOM case).
       window.ShadyCSS.prepareTemplateStyles(template.element, scopeName);
-      // When using native Shadow DOM, replace the style in the rendered
-      // fragment.
+      // When in native Shadow DOM, re-add styling to rendered content using the
+      // style ShadyCSS produced.
       if (window.ShadyCSS.nativeShadow) {
         const style = template.element.content.querySelector('style');
         if (style !== null) {
           fragment.insertBefore(style.cloneNode(true), fragment.firstChild);
         }
+        // When not in native Shadow DOM, at this point ShadyCSS will have
+        // removed the style from the lit template and parts will be broken as a
+        // result. To fix this, we put back the style node ShadyCSS removed
+        // (which is no longer in use) and then tell lit to remove that node
+        // from the template.
+      } else if (condensedStyle !== undefined) {
+        template.element.content.insertBefore(
+            condensedStyle, template.element.content.firstChild);
+        const removes = new Set();
+        removes.add(condensedStyle);
+        removeNodesFromTemplate(template, removes);
       }
     };
 

--- a/src/test/lib/modify-template_test.ts
+++ b/src/test/lib/modify-template_test.ts
@@ -66,11 +66,8 @@ suite('add/remove nodes from template', () => {
       });
 
   test('inserting documentFragment into template', () => {
-    const getResult = (a: any, b: any, c: any) => html`
-        <div foo="${a}">
-          ${b}
-          <p>${c}</p>
-        </div>`;
+    const getResult = (a: any, b: any, c: any) =>
+        html`<div foo="${a}">${b}<p>${c}</p></div>`;
     const result = getResult('bar', 'baz', 'qux');
     const template = templateFactory(result);
     const fragment1 = document.createDocumentFragment();
@@ -83,18 +80,12 @@ suite('add/remove nodes from template', () => {
         template, fragment2, template.element.content.querySelector('p'));
     render(result, container);
     assert.equal(
-        stripExpressionMarkers(container.innerHTML), `<div><span>1</span></div>
-        <div foo="bar">
-          baz
-          <p>qux</p>
-        </div>`);
+        stripExpressionMarkers(container.innerHTML),
+        `<div><span>1</span></div><div foo="bar">baz<p>qux</p></div>`);
     render(getResult('a', 'b', 'c'), container);
     assert.equal(
-        stripExpressionMarkers(container.innerHTML), `<div><span>1</span></div>
-        <div foo="a">
-          b
-          <p>c</p>
-        </div>`);
+        stripExpressionMarkers(container.innerHTML),
+        `<div><span>1</span></div><div foo="a">b<p>c</p></div>`);
   });
 
   test(

--- a/src/test/lib/modify-template_test.ts
+++ b/src/test/lib/modify-template_test.ts
@@ -72,7 +72,7 @@ suite('add/remove nodes from template', () => {
     const template = templateFactory(result);
     const fragment1 = document.createDocumentFragment();
     fragment1.appendChild(document.createElement('div'));
-    fragment1.firstElementChild!.innerHTML = '<span>1</span>';
+    (fragment1.firstChild as HTMLElement)!.innerHTML = '<span>1</span>';
     insertNodeIntoTemplate(
         template, fragment1, template.element.content.firstChild);
     const fragment2 = document.createDocumentFragment();

--- a/src/test/lib/modify-template_test.ts
+++ b/src/test/lib/modify-template_test.ts
@@ -163,7 +163,8 @@ suite('add/remove nodes from template', () => {
         const result = getResult('bar', 'baz', 'qux', 'r1', 'r2', 'r3');
         const template = templateFactory(result);
         let node;
-        while (node = template.element.content.querySelector('[name="remove"]')) {
+        while (node =
+                   template.element.content.querySelector('[name="remove"]')) {
           const nodeSet = new Set();
           nodeSet.add(node);
           removeNodesFromTemplate(template, nodeSet);

--- a/src/test/lib/modify-template_test.ts
+++ b/src/test/lib/modify-template_test.ts
@@ -65,41 +65,37 @@ suite('add/remove nodes from template', () => {
         </div><div><span>3</span></div>`);
       });
 
-  test(
-      'inserting documentFragment into template',
-      () => {
-        const getResult = (a: any, b: any, c: any) => html`
+  test('inserting documentFragment into template', () => {
+    const getResult = (a: any, b: any, c: any) => html`
         <div foo="${a}">
           ${b}
           <p>${c}</p>
         </div>`;
-        const result = getResult('bar', 'baz', 'qux');
-        const template = templateFactory(result);
-        const fragment1 = document.createDocumentFragment();
-        fragment1.appendChild(document.createElement('div'));
-        fragment1.firstElementChild!.innerHTML = '<span>1</span>';
-        insertNodeIntoTemplate(
-            template, fragment1, template.element.content.firstChild);
-        const fragment2 = document.createDocumentFragment();
-        insertNodeIntoTemplate(
-            template, fragment2, template.element.content.querySelector('p'));
-        render(result, container);
-        assert.equal(
-            stripExpressionMarkers(container.innerHTML),
-            `<div><span>1</span></div>
+    const result = getResult('bar', 'baz', 'qux');
+    const template = templateFactory(result);
+    const fragment1 = document.createDocumentFragment();
+    fragment1.appendChild(document.createElement('div'));
+    fragment1.firstElementChild!.innerHTML = '<span>1</span>';
+    insertNodeIntoTemplate(
+        template, fragment1, template.element.content.firstChild);
+    const fragment2 = document.createDocumentFragment();
+    insertNodeIntoTemplate(
+        template, fragment2, template.element.content.querySelector('p'));
+    render(result, container);
+    assert.equal(
+        stripExpressionMarkers(container.innerHTML), `<div><span>1</span></div>
         <div foo="bar">
           baz
           <p>qux</p>
         </div>`);
-        render(getResult('a', 'b', 'c'), container);
-        assert.equal(
-            stripExpressionMarkers(container.innerHTML),
-            `<div><span>1</span></div>
+    render(getResult('a', 'b', 'c'), container);
+    assert.equal(
+        stripExpressionMarkers(container.innerHTML), `<div><span>1</span></div>
         <div foo="a">
           b
           <p>c</p>
         </div>`);
-      });
+  });
 
   test(
       'removing nodes in template between parts renders/updates result', () => {

--- a/src/test/lib/modify-template_test.ts
+++ b/src/test/lib/modify-template_test.ts
@@ -150,4 +150,35 @@ suite('add/remove nodes from template', () => {
           <p>c</p>
         </div>`);
       });
+
+  test(
+      'removing nodes in template containing parts with in-active parts renders/updates result',
+      () => {
+        const getResult = (a: any, b: any, c: any, r1: any, r2: any, r3: any) =>
+            html`<div name="remove"><span>${r1}</span></div>
+        <div foo="${a}"><div name="remove"><span>${r2}</span></div>
+          ${b}
+          <div name="remove"><span name="remove">${r3}</span></div><p>${c}</p>
+        </div><div name="remove"><span name="remove"><span name="remove">remove</span></span></div>`;
+        const result = getResult('bar', 'baz', 'qux', 'r1', 'r2', 'r3');
+        const template = templateFactory(result);
+        let node;
+        while (node = template.element.content.querySelector('[name="remove"]')) {
+          const nodeSet = new Set();
+          nodeSet.add(node);
+          removeNodesFromTemplate(template, nodeSet);
+        }
+        render(result, container);
+        assert.equal(stripExpressionMarkers(container.innerHTML), `
+        <div foo="bar">
+          baz
+          <p>qux</p>
+        </div>`);
+        render(getResult('a', 'b', 'c', 'rr1', 'rr2', 'rr3'), container);
+        assert.equal(stripExpressionMarkers(container.innerHTML), `
+        <div foo="a">
+          b
+          <p>c</p>
+        </div>`);
+      });
 });

--- a/src/test/lib/modify-template_test.ts
+++ b/src/test/lib/modify-template_test.ts
@@ -66,6 +66,42 @@ suite('add/remove nodes from template', () => {
       });
 
   test(
+      'inserting documentFragment into template',
+      () => {
+        const getResult = (a: any, b: any, c: any) => html`
+        <div foo="${a}">
+          ${b}
+          <p>${c}</p>
+        </div>`;
+        const result = getResult('bar', 'baz', 'qux');
+        const template = templateFactory(result);
+        const fragment1 = document.createDocumentFragment();
+        fragment1.appendChild(document.createElement('div'));
+        fragment1.firstElementChild!.innerHTML = '<span>1</span>';
+        insertNodeIntoTemplate(
+            template, fragment1, template.element.content.firstChild);
+        const fragment2 = document.createDocumentFragment();
+        insertNodeIntoTemplate(
+            template, fragment2, template.element.content.querySelector('p'));
+        render(result, container);
+        assert.equal(
+            stripExpressionMarkers(container.innerHTML),
+            `<div><span>1</span></div>
+        <div foo="bar">
+          baz
+          <p>qux</p>
+        </div>`);
+        render(getResult('a', 'b', 'c'), container);
+        assert.equal(
+            stripExpressionMarkers(container.innerHTML),
+            `<div><span>1</span></div>
+        <div foo="a">
+          b
+          <p>c</p>
+        </div>`);
+      });
+
+  test(
       'removing nodes in template between parts renders/updates result', () => {
         const getResult = (a: any, b: any, c: any) =>
             html`<div name="remove"><span>remove</span></div>

--- a/src/test/lib/shady-render-apply_test.ts
+++ b/src/test/lib/shady-render-apply_test.ts
@@ -14,8 +14,8 @@
 
 // Rename the html tag so that CSS linting doesn't warn on the non-standard
 // @apply syntax
-import {until} from '../../directives/until.js';
 import {html as htmlWithApply, render} from '../../lib/shady-render.js';
+import {renderShadowRoot} from '../test-utils/shadow-root.js';
 
 const assert = chai.assert;
 
@@ -23,7 +23,6 @@ suite('shady-render @apply', () => {
   test('styles with css custom properties using @apply render', function() {
     const container = document.createElement('scope-5');
     document.body.appendChild(container);
-    container.attachShadow({mode: 'open'});
     const result = htmlWithApply`
       <style>
         :host {
@@ -38,7 +37,7 @@ suite('shady-render @apply', () => {
       </style>
       <div>Testing...</div>
     `;
-    render(result, container.shadowRoot!, 'scope-5');
+    renderShadowRoot(result, container);
     const div = (container.shadowRoot!).querySelector('div');
     const computedStyle = getComputedStyle(div!);
     assert.equal(
@@ -50,10 +49,7 @@ suite('shady-render @apply', () => {
   test(
       'styles with css custom properties using @apply render in different contexts',
       async () => {
-        const createApplyUser = () => {
-          const container = document.createElement('apply-user');
-          container.attachShadow({mode: 'open'});
-          const result = htmlWithApply`
+        const applyUserContent = htmlWithApply`
         <style>
           div {
             border-top: 2px solid black;
@@ -63,11 +59,9 @@ suite('shady-render @apply', () => {
         </style>
         <div>Testing...</div>
       `;
-          render(result, container.shadowRoot!, 'apply-user');
-          return container;
-        };
-        const applyUser = createApplyUser();
+        const applyUser = document.createElement('apply-user');
         document.body.appendChild(applyUser);
+        renderShadowRoot(applyUserContent, applyUser);
         const applyUserDiv = (applyUser.shadowRoot!).querySelector('div');
         const applyUserStyle = getComputedStyle(applyUserDiv!);
         assert.equal(
@@ -76,8 +70,7 @@ suite('shady-render @apply', () => {
             applyUserStyle.getPropertyValue('margin-top').trim(), '4px');
         // Render sub-element with a promise to ensure it's rendered after the
         // containing scope.
-        const applyUserPromise = Promise.resolve().then(createApplyUser);
-        const producerResult = htmlWithApply`
+        const producerContent = htmlWithApply`
       <style>
         :host {
           --stuff: {
@@ -86,16 +79,16 @@ suite('shady-render @apply', () => {
           };
         }
       </style>
-      ${until(applyUserPromise, 'loading')}
+      <apply-user></apply-user>
     `;
         const applyProducer = document.createElement('apply-producer');
-        applyProducer.attachShadow({mode: 'open'});
         document.body.appendChild(applyProducer);
-        render(producerResult, applyProducer.shadowRoot!, 'apply-producer');
-        await applyUserPromise;
+        renderShadowRoot(producerContent, applyProducer);
+        const userInProducer =
+            applyProducer.shadowRoot!.querySelector('apply-user')!;
+        renderShadowRoot(applyUserContent, userInProducer);
         const applyProducerDiv =
-            applyProducer.shadowRoot!.querySelector('apply-user')!.shadowRoot!
-                .querySelector('div')!;
+            userInProducer!.shadowRoot!.querySelector('div')!;
         const applyProducerStyle = getComputedStyle(applyProducerDiv!);
         assert.equal(
             applyProducerStyle.getPropertyValue('border-top-width').trim(),

--- a/src/test/lib/shady-render-apply_test.ts
+++ b/src/test/lib/shady-render-apply_test.ts
@@ -14,7 +14,7 @@
 
 // Rename the html tag so that CSS linting doesn't warn on the non-standard
 // @apply syntax
-import {html as htmlWithApply, render} from '../../lib/shady-render.js';
+import {html as htmlWithApply} from '../../lib/shady-render.js';
 import {renderShadowRoot} from '../test-utils/shadow-root.js';
 
 const assert = chai.assert;

--- a/src/test/lib/shady-render_test.ts
+++ b/src/test/lib/shady-render_test.ts
@@ -44,7 +44,7 @@ suite('shady-render', () => {
     document.body.removeChild(container);
   });
 
-  test('style elements apply in  shadowRoots in nested templates', () => {
+  test('style elements apply in shadowRoots in nested templates', () => {
     const container = document.createElement('div');
     document.body.appendChild(container);
     container.attachShadow({mode: 'open'});
@@ -74,6 +74,27 @@ suite('shady-render', () => {
         getComputedStyle(span!).getPropertyValue('border-top-width').trim(),
         '5px');
     document.body.removeChild(container);
+  });
+
+  test('results render to multiple containers', () => {
+    const container1 = document.createElement('div');
+    container1.attachShadow({mode: 'open'});
+    const container2 = document.createElement('div');
+    container2.attachShadow({mode: 'open'});
+    document.body.appendChild(container1);
+    document.body.appendChild(container2);
+    const renderTo = (data: any, container: Element) => render(
+      html`${data.a}-${data.b}-${data.c}`, container.shadowRoot!, 'a');
+    renderTo({a: 1, b: 2, c: 3}, container1);
+    renderTo({a: 4, b: 5, c: 6}, container2);
+    assert.equal(container1.shadowRoot!.textContent, '1-2-3');
+    assert.equal(container2.shadowRoot!.textContent, '4-5-6');
+    renderTo({a: 11, b: 22, c: 33}, container1);
+    renderTo({a: 44, b: 55, c: 66}, container2);
+    assert.equal(container1.shadowRoot!.textContent, '11-22-33');
+    assert.equal(container2.shadowRoot!.textContent, '44-55-66');
+    document.body.removeChild(container1);
+    document.body.removeChild(container2);
   });
 
   test('styles with css custom properties render', () => {

--- a/src/test/lib/shady-render_test.ts
+++ b/src/test/lib/shady-render_test.ts
@@ -83,8 +83,8 @@ suite('shady-render', () => {
     container2.attachShadow({mode: 'open'});
     document.body.appendChild(container1);
     document.body.appendChild(container2);
-    const renderTo = (data: any, container: Element) => render(
-      html`${data.a}-${data.b}-${data.c}`, container.shadowRoot!, 'a');
+    const renderTo = (data: any, container: Element) =>
+        render(html`${data.a}-${data.b}-${data.c}`, container.shadowRoot!, 'a');
     renderTo({a: 1, b: 2, c: 3}, container1);
     renderTo({a: 4, b: 5, c: 6}, container2);
     assert.equal(container1.shadowRoot!.textContent, '1-2-3');

--- a/src/test/test-utils/shadow-root.ts
+++ b/src/test/test-utils/shadow-root.ts
@@ -1,0 +1,26 @@
+/**
+ * @license
+ * Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+/**
+ * A helper for creating a shadowRoot on an element.
+ */
+import {render} from '../../lib/shady-render.js';
+import {TemplateResult} from '../../lit-html.js';
+
+export const renderShadowRoot = (result: TemplateResult, element: Element) => {
+  if (!element.shadowRoot) {
+    element.attachShadow({mode: 'open'});
+  }
+  render(result, element.shadowRoot!, element.localName!);
+};

--- a/src/test/test-utils/shadow-root.ts
+++ b/src/test/test-utils/shadow-root.ts
@@ -11,13 +11,12 @@
  * subject to an additional IP rights grant found at
  * http://polymer.github.io/PATENTS.txt
  */
+import {render} from '../../lib/shady-render.js';
+import {TemplateResult} from '../../lit-html.js';
 
 /**
  * A helper for creating a shadowRoot on an element.
  */
-import {render} from '../../lib/shady-render.js';
-import {TemplateResult} from '../../lit-html.js';
-
 export const renderShadowRoot = (result: TemplateResult, element: Element) => {
   if (!element.shadowRoot) {
     element.attachShadow({mode: 'open'});

--- a/test/index.html
+++ b/test/index.html
@@ -26,10 +26,10 @@
       WCT.loadSuites([
         'shady.html',
         'shady.html?shadydom=true',
-        'shady.html?shadydom=true&shimscssproperties=true',
+        'shady.html?shadydom=true&shimcssproperties=true',
         'shady-apply.html',
         'shady-apply.html?shadydom=true',
-        'shady-apply.html?shadydom=true&shimscssproperties=true',
+        'shady-apply.html?shadydom=true&shimcssproperties=true',
       ]);
     </script>
   </body>

--- a/test/index.html
+++ b/test/index.html
@@ -22,7 +22,7 @@
     <script type="module" src="./directives/when_test.js"></script>
     <script type="module" src="./directives/classMap_test.js"></script>
     <script type="module" src="./directives/styleMap_test.js"></script>
-    <script type="module">
+    <script>
       WCT.loadSuites([
         'shady.html',
         'shady.html?shadydom=true',

--- a/test/shady-apply.html
+++ b/test/shady-apply.html
@@ -10,7 +10,7 @@
       }
     </script>
     <script src="../node_modules/wct-browser-legacy/browser.js"></script>
-    <script src="../node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
+    <script src="../node_modules/@webcomponents/webcomponentsjs/webcomponents-bundle.js"></script>
     <script src="../node_modules/@webcomponents/shadycss/apply-shim.min.js"></script>
   </head>
   <body>

--- a/test/shady.html
+++ b/test/shady.html
@@ -10,7 +10,7 @@
       }
     </script>
     <script src="../node_modules/wct-browser-legacy/browser.js"></script>
-    <script src="../node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
+    <script src="../node_modules/@webcomponents/webcomponentsjs/webcomponents-bundle.js"></script>
   </head>
   <body>
     <script type="module" src="./lib/shady-render_test.js"></script>


### PR DESCRIPTION
* Correctly tests shimmed css custom properties (by fixing a typo).
* Ensures `shady` and `shady-apply` tests have a working version of ShadyCSS so that styling is tested.
* Fixes #505 by adding support for adding document fragments to templates.
* Fixes #506 by ensuring `ShadyCSS.styleElement` is called once per rendering to a given container.
* Ensures lit-html adapts to the template manipulations done by ShadyCSS so parts remain intact.
* Adds additional tests