### PR TITLE
Cache templates in NodePart

### DIFF
--- a/src/directives/when.ts
+++ b/src/directives/when.ts
@@ -12,16 +12,7 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {directive, Directive, NodePart, reparentNodes} from '../lit-html.js';
-
-interface PartCache {
-  truePart: NodePart;
-  falsePart: NodePart;
-  prevCondition?: boolean;
-  cacheContainer: DocumentFragment;
-}
-
-const partCaches = new WeakMap<NodePart, PartCache>();
+import { directive, Directive, NodePart } from '../lit-html.js';
 
 /**
  * Efficiently switches between two templates based on the given condition. The
@@ -45,56 +36,13 @@ const partCaches = new WeakMap<NodePart, PartCache>();
  * @param trueValue the value to render given a true condition
  * @param falseValue the value to render given a false condition
  */
-export const when =
-    (condition: any, trueValue: () => any, falseValue: () => any):
-        Directive<NodePart> => directive((parentPart: NodePart) => {
-          let cache = partCaches.get(parentPart);
-
-          // Create a new cache if this is the first render
-          if (cache === undefined) {
-            // Cache consists of two parts, one for each condition, and a
-            // docment fragment which we cache the nodes of the condition that's
-            // not currently rendered.
-            cache = {
-              truePart: new NodePart(parentPart.templateFactory),
-              falsePart: new NodePart(parentPart.templateFactory),
-              cacheContainer: document.createDocumentFragment(),
-            };
-            partCaches.set(parentPart, cache);
-
-            cache.truePart.appendIntoPart(parentPart);
-            cache.falsePart.appendIntoPart(parentPart);
-          }
-
-          // Based on the condition, select which part to render and which value
-          // to set on that part.
-          const nextPart = condition ? cache.truePart : cache.falsePart;
-          const nextValue = condition ? trueValue() : falseValue();
-
-          // If we switched condition, swap nodes to/from the cache.
-          if (!!condition !== cache.prevCondition) {
-            // Get the part which was rendered for the opposite condition. This
-            // should be added to the cache.
-            const prevPart = condition ? cache.falsePart : cache.truePart;
-
-            // If the next part was rendered, take it from the cache
-            if (nextPart.value) {
-              parentPart.startNode.parentNode!.appendChild(
-                  cache.cacheContainer);
-            }
-
-            // If the prev part was rendered, move it to the cache
-            if (prevPart.value) {
-              reparentNodes(
-                  cache.cacheContainer,
-                  prevPart.startNode,
-                  prevPart.endNode.nextSibling);
-            }
-          }
-
-          // Set the next part's value
-          nextPart.setValue(nextValue);
-          nextPart.commit();
-
-          cache.prevCondition = !!condition;
-        });
+export const when = (condition: any, trueValue: () => any, falseValue?: () => any): Directive<NodePart> =>
+  directive((parentPart: NodePart) => {
+    if (condition) {
+      parentPart.setValue(trueValue());
+    } else if (falseValue !== undefined) {
+      parentPart.setValue(falseValue());
+    } else {
+      parentPart.clear();
+    }
+  });


### PR DESCRIPTION
By caching templates in NodePart, we obviate the need for directives like `when`, since switching templates will be efficient by default. It works by creating a cache for rendered TemplateInstances when committing a TemplateResult, and re-using the TemplateInstances when we render the same Template.

Fixes #511

The code is not clean, it's just a prototype/idea to start off a discussion. Do not merge!