### PR TITLE
fixed a typo in guide / writing-templates section

### DIFF
--- a/docs-src/guide/02-writing-templates.md
+++ b/docs-src/guide/02-writing-templates.md
@@ -56,7 +56,7 @@ There are a few types of bindings:
     ```
   * Attribute:
     ```js
-    html`<div id=${id}></div`
+    html`<div id=${id}></div>`
     ```
   * Boolean Attribute:
     ```js


### PR DESCRIPTION
Fixed a typo in docs-src /guide / writing-templates section