### PR TITLE
Allow render() to pass an event listener context to be used as the this value for all event listener calls.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 <!-- ## Unreleased -->
 <!-- ### Added -->
+## Unreleased
 ### Changed
 * Re-implemented repeat directive for better performance ([#501](https://github.com/Polymer/lit-html/pull/501))
+* [Breaking] `render()` now takes an options object as the third argument. ([#523](https://github.com/Polymer/lit-html/pull/523))
+### Added
+* Event listeners are called with a configurable `this` reference, which is set via the `eventContext` option to `render()`. ([#523](https://github.com/Polymer/lit-html/pull/523))
+
 <!-- ### Removed -->
 <!-- ### Fixed -->
 

--- a/docs-src/guide/01-getting-started.md
+++ b/docs-src/guide/01-getting-started.md
@@ -41,6 +41,25 @@ If you use a tool that converts package names into paths, then you can import by
 import {html, render} from 'lit-html';
 ```
 
+## Rendering a Template
+
+lit-html has two main APIs:
+
+* The `html` template tag used to write templates
+* The `render()` function used to render a template to a DOM container.
+
+```ts
+// Import lit-html
+import {html, render} from 'lit-html';
+
+// Define a template
+const myTemplate = (name) => html`<p>Hello ${name}</p>`;
+
+// Render the template to the document
+render(myTemplate('World'), document.body);
+```
+
+To learn more about templates, see [Writing Templates](./writing-templates.html).
 
 ### Why is lit-html distributed as JavaScript modules, not as UMD/CJS/AMD?
 

--- a/docs-src/guide/02-writing-templates.md
+++ b/docs-src/guide/02-writing-templates.md
@@ -16,6 +16,26 @@ html`<h1>Hello World</h1>`
 html`<h1>Hello ${name}</h1>`
 ```
 
+## Rendering Templates
+
+A lit-html template expresion does not cause any DOM to be created or updated. It's only a description of DOM, called a TemplateResult. To actually create or update DOM, you need to pass the TemplateResult to the `render()` function, along with a container to render to:
+
+```ts
+import {html, render} from 'lit-html';
+
+const sayHi = (name) => html`<h1>Hello ${name}</h1>`;
+render(sayHi('Amy'), document.body);
+
+// subsequent renders wiill update the DOM
+render(sayHi('Zoe'), document.body);
+```
+
+### Render Options
+
+`render()` also takes an options argument that allows you to specify:
+* `eventContext`: The `this` value to use when invoking event listeners registered with the `@eventName` syntax.
+* `templateFactory`: The TemplateFactory to use. A TemplateFactory creates a Template from a TemplateResult, typically caching Templates based on their static content. Users won't usually supply their own TemplateFactory, but possible use ShadyCSS-integrated when using `/lib/shady-render.js`.
+
 ## Thinking Functionally
 
 lit-html is ideal for use in a functional approach to describing UIs. If you think of UI as a function of data, commonly expressed as `UI = f(data)`, you can write lit-html templates that mirror this exactly:
@@ -71,7 +91,7 @@ There are a few types of bindings:
     html`<button @click=${(e) => console.log('clicked')}>Click Me</button>`
     ```
 
-## Supported Types
+## Supported Data Types
 
 Each binding type supports different types of values:
 

--- a/src/directives/async-append.ts
+++ b/src/directives/async-append.ts
@@ -86,7 +86,7 @@ export const asyncAppend = <T>(
           itemPart.endNode = itemStartNode;
           part.endNode.parentNode!.insertBefore(itemStartNode, part.endNode);
         }
-        itemPart = new NodePart(part.templateFactory);
+        itemPart = new NodePart(part.options);
         itemPart.insertAfterNode(itemStartNode);
         itemPart.setValue(v);
         itemPart.commit();

--- a/src/directives/async-replace.ts
+++ b/src/directives/async-replace.ts
@@ -43,7 +43,7 @@ export const asyncReplace =
 
           // We nest a new part to keep track of previous item values separately
           // of the iterable as a value itself.
-          const itemPart = new NodePart(part.templateFactory);
+          const itemPart = new NodePart(part.options);
           part.value = value;
 
           let i = 0;

--- a/src/directives/repeat.ts
+++ b/src/directives/repeat.ts
@@ -26,7 +26,7 @@ const createAndInsertPart =
                                                     beforePart.startNode;
       const startNode = container.insertBefore(createMarker(), beforeNode);
       container.insertBefore(createMarker(), beforeNode);
-      const newPart = new NodePart(containerPart.templateFactory);
+      const newPart = new NodePart(containerPart.options);
       newPart.insertAfterNode(startNode);
       return newPart;
     };
@@ -361,7 +361,7 @@ export function repeat<T>(
           const oldPart = oldIndex !== undefined ? oldParts[oldIndex] : null;
           if (oldPart === null) {
             // No old part for this value; create a new one and insert it
-            let newPart =
+            const newPart =
                 createAndInsertPart(containerPart, oldParts[oldHead]!);
             updatePart(newPart, newValues[newHead]);
             newParts[newHead] = newPart;

--- a/src/directives/when.ts
+++ b/src/directives/when.ts
@@ -56,8 +56,8 @@ export const when =
             // docment fragment which we cache the nodes of the condition that's
             // not currently rendered.
             cache = {
-              truePart: new NodePart(parentPart.templateFactory),
-              falsePart: new NodePart(parentPart.templateFactory),
+              truePart: new NodePart(parentPart.options),
+              falsePart: new NodePart(parentPart.options),
               cacheContainer: document.createDocumentFragment(),
             };
             partCaches.set(parentPart, cache);

--- a/src/lib/default-template-processor.ts
+++ b/src/lib/default-template-processor.ts
@@ -12,15 +12,15 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {TemplateFactory} from '../lit-html.js';
-
 import {Part} from './part.js';
 import {AttributeCommitter, BooleanAttributePart, EventPart, NodePart, PropertyCommitter} from './parts.js';
+import {RenderOptions} from './render-options.js';
+import {TemplateProcessor} from './template-processor.js';
 
 /**
  * Creates Parts when a template is instantiated.
  */
-export class DefaultTemplateProcessor {
+export class DefaultTemplateProcessor implements TemplateProcessor {
   /**
    * Create parts for an attribute-position binding, given the event, attribute
    * name, and string literals.
@@ -30,15 +30,16 @@ export class DefaultTemplateProcessor {
    * @param strings The string literals. There are always at least two strings,
    *   event for fully-controlled bindings with a single expression.
    */
-  handleAttributeExpressions(element: Element, name: string, strings: string[]):
-      Part[] {
+  handleAttributeExpressions(
+      element: Element, name: string, strings: string[],
+      options: RenderOptions): Part[] {
     const prefix = name[0];
     if (prefix === '.') {
       const comitter = new PropertyCommitter(element, name.slice(1), strings);
       return comitter.parts;
     }
     if (prefix === '@') {
-      return [new EventPart(element, name.slice(1))];
+      return [new EventPart(element, name.slice(1), options.eventContext)];
     }
     if (prefix === '?') {
       return [new BooleanAttributePart(element, name.slice(1), strings)];
@@ -50,8 +51,8 @@ export class DefaultTemplateProcessor {
    * Create parts for a text-position binding.
    * @param templateFactory
    */
-  handleTextExpression(templateFactory: TemplateFactory) {
-    return new NodePart(templateFactory);
+  handleTextExpression(options: RenderOptions) {
+    return new NodePart(options);
   }
 }
 

--- a/src/lib/parts.ts
+++ b/src/lib/parts.ts
@@ -242,8 +242,9 @@ export class NodePart implements Part {
       this.value.update(value.values);
     } else {
       // Make sure we propagate the template processor from the TemplateResult
-      // so that we use it's syntax extension, etc. The template factory comes
-      // from the render function options so that it can control caching.
+      // so that we use its syntax extension, etc. The template factory comes
+      // from the render function options so that it can control template
+      // caching and preprocessing.
       const instance =
           new TemplateInstance(template, value.processor, this.options);
       const fragment = instance._clone();

--- a/src/lib/parts.ts
+++ b/src/lib/parts.ts
@@ -15,7 +15,7 @@
 import {isDirective} from './directive.js';
 import {removeNodes} from './dom.js';
 import {noChange, Part} from './part.js';
-import {TemplateFactory} from './template-factory.js';
+import {RenderOptions} from './render-options.js';
 import {TemplateInstance} from './template-instance.js';
 import {TemplateResult} from './template-result.js';
 import {createMarker} from './template.js';
@@ -119,14 +119,17 @@ export class AttributePart implements Part {
 }
 
 export class NodePart implements Part {
-  templateFactory: TemplateFactory;
+  // templateFactory: TemplateFactory;
+  options: RenderOptions;
   startNode!: Node;
   endNode!: Node;
   value: any = undefined;
   _pendingValue: any = undefined;
 
-  constructor(templateFactory: TemplateFactory) {
-    this.templateFactory = templateFactory;
+  constructor(options: RenderOptions) {
+    this.options = options;
+    // this.templateFactory = options && options.templateFactory ||
+    // defaultTemplateFactory;
   }
 
   /**
@@ -234,15 +237,15 @@ export class NodePart implements Part {
   }
 
   private _commitTemplateResult(value: TemplateResult): void {
-    const template = this.templateFactory(value);
+    const template = this.options.templateFactory(value);
     if (this.value && this.value.template === template) {
       this.value.update(value.values);
     } else {
       // Make sure we propagate the template processor from the TemplateResult
       // so that we use it's syntax extension, etc. The template factory comes
-      // from the render function so that it can control caching.
+      // from the render function options so that it can control caching.
       const instance =
-          new TemplateInstance(template, value.processor, this.templateFactory);
+          new TemplateInstance(template, value.processor, this.options);
       const fragment = instance._clone();
       instance.update(value.values);
       this._commitNode(fragment);
@@ -278,7 +281,7 @@ export class NodePart implements Part {
 
       // If no existing part, create a new one
       if (itemPart === undefined) {
-        itemPart = new NodePart(this.templateFactory);
+        itemPart = new NodePart(this.options);
         itemParts.push(itemPart);
         if (partIndex === 0) {
           itemPart.appendIntoPart(this);
@@ -406,12 +409,14 @@ export class PropertyPart extends AttributePart {}
 export class EventPart implements Part {
   element: Element;
   eventName: string;
+  eventContext?: EventTarget;
   value: any = undefined;
   _pendingValue: any = undefined;
 
-  constructor(element: Element, eventName: string) {
+  constructor(element: Element, eventName: string, eventContext?: EventTarget) {
     this.element = element;
     this.eventName = eventName;
+    this.eventContext = eventContext;
   }
 
   setValue(value: any): void {
@@ -439,10 +444,11 @@ export class EventPart implements Part {
   }
 
   handleEvent(event: Event) {
-    if (typeof this.value === 'function') {
-      this.value.call(this.element, event);
-    } else if (typeof this.value.handleEvent === 'function') {
-      this.value.handleEvent(event);
-    }
+    const listener = (typeof this.value === 'function') ?
+        this.value :
+        (typeof this.value.handleEvent === 'function') ?
+        this.value.handleEvent :
+        () => null;
+    listener.call(this.eventContext || this.element, event);
   }
 }

--- a/src/lib/parts.ts
+++ b/src/lib/parts.ts
@@ -119,7 +119,6 @@ export class AttributePart implements Part {
 }
 
 export class NodePart implements Part {
-  // templateFactory: TemplateFactory;
   options: RenderOptions;
   startNode!: Node;
   endNode!: Node;
@@ -128,8 +127,6 @@ export class NodePart implements Part {
 
   constructor(options: RenderOptions) {
     this.options = options;
-    // this.templateFactory = options && options.templateFactory ||
-    // defaultTemplateFactory;
   }
 
   /**

--- a/src/lib/render-options.ts
+++ b/src/lib/render-options.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+ * Copyright (c) 2018 The Polymer Project Authors. All rights reserved.
  * This code may only be used under the BSD style license found at
  * http://polymer.github.io/LICENSE.txt
  * The complete set of authors may be found at
@@ -11,15 +11,10 @@
  * subject to an additional IP rights grant found at
  * http://polymer.github.io/PATENTS.txt
  */
-import {render} from '../../lib/shady-render.js';
-import {TemplateResult} from '../../lit-html.js';
 
-/**
- * A helper for creating a shadowRoot on an element.
- */
-export const renderShadowRoot = (result: TemplateResult, element: Element) => {
-  if (!element.shadowRoot) {
-    element.attachShadow({mode: 'open'});
-  }
-  render(result, element.shadowRoot!, {scopeName: element.localName!});
-};
+import {TemplateFactory} from './template-factory.js';
+
+export interface RenderOptions {
+  templateFactory: TemplateFactory;
+  eventContext?: EventTarget;
+}

--- a/src/lib/render.ts
+++ b/src/lib/render.ts
@@ -14,7 +14,8 @@
 
 import {removeNodes} from './dom.js';
 import {NodePart} from './parts.js';
-import {templateFactory as defaultTemplateFactory, TemplateFactory} from './template-factory.js';
+import {RenderOptions} from './render-options.js';
+import {templateFactory as defaultTemplateFactory} from './template-factory.js';
 import {TemplateResult} from './template-result.js';
 
 export const parts = new WeakMap<Node, NodePart>();
@@ -36,11 +37,16 @@ export const parts = new WeakMap<Node, NodePart>();
 export function render(
     result: TemplateResult,
     container: Element|DocumentFragment,
-    templateFactory: TemplateFactory = defaultTemplateFactory) {
+    options?: Partial<RenderOptions>) {
   let part = parts.get(container);
   if (part === undefined) {
     removeNodes(container, container.firstChild);
-    parts.set(container, part = new NodePart(templateFactory));
+    parts.set(
+        container, part = new NodePart({
+                     eventContext: options && options.eventContext,
+                     templateFactory: options && options.templateFactory ||
+                         defaultTemplateFactory,
+                   }));
     part.appendInto(container);
   }
   part.setValue(result);

--- a/src/lib/render.ts
+++ b/src/lib/render.ts
@@ -31,8 +31,9 @@ export const parts = new WeakMap<Node, NodePart>();
  * @param container A DOM parent to render to. The entire contents are either
  *     replaced, or efficiently updated if the same result type was previous
  *     rendered there.
- * @param templateFactory a function to create a Template or retrieve one from
- *     cache.
+ * @param options RenderOptions for the entire render tree rendered to this
+ *     container. Render options must *not* change between renders to the same
+ *     container, as those changes will not effect previously rendered DOM.
  */
 export const render =
     (result: TemplateResult,

--- a/src/lib/render.ts
+++ b/src/lib/render.ts
@@ -15,7 +15,7 @@
 import {removeNodes} from './dom.js';
 import {NodePart} from './parts.js';
 import {RenderOptions} from './render-options.js';
-import {templateFactory as defaultTemplateFactory} from './template-factory.js';
+import {templateFactory} from './template-factory.js';
 import {TemplateResult} from './template-result.js';
 
 export const parts = new WeakMap<Node, NodePart>();
@@ -34,21 +34,19 @@ export const parts = new WeakMap<Node, NodePart>();
  * @param templateFactory a function to create a Template or retrieve one from
  *     cache.
  */
-export function render(
+export const render = (
     result: TemplateResult,
     container: Element|DocumentFragment,
-    options?: Partial<RenderOptions>) {
+    options?: Partial<RenderOptions>) => {
   let part = parts.get(container);
   if (part === undefined) {
     removeNodes(container, container.firstChild);
-    parts.set(
-        container, part = new NodePart({
-                     eventContext: options && options.eventContext,
-                     templateFactory: options && options.templateFactory ||
-                         defaultTemplateFactory,
-                   }));
+    parts.set(container, part = new NodePart({
+      templateFactory,
+      ...options,
+    }));
     part.appendInto(container);
   }
   part.setValue(result);
   part.commit();
-}
+};

--- a/src/lib/render.ts
+++ b/src/lib/render.ts
@@ -34,19 +34,19 @@ export const parts = new WeakMap<Node, NodePart>();
  * @param templateFactory a function to create a Template or retrieve one from
  *     cache.
  */
-export const render = (
-    result: TemplateResult,
-    container: Element|DocumentFragment,
-    options?: Partial<RenderOptions>) => {
-  let part = parts.get(container);
-  if (part === undefined) {
-    removeNodes(container, container.firstChild);
-    parts.set(container, part = new NodePart({
-      templateFactory,
-      ...options,
-    }));
-    part.appendInto(container);
-  }
-  part.setValue(result);
-  part.commit();
-};
+export const render =
+    (result: TemplateResult,
+     container: Element|DocumentFragment,
+     options?: Partial<RenderOptions>) => {
+      let part = parts.get(container);
+      if (part === undefined) {
+        removeNodes(container, container.firstChild);
+        parts.set(container, part = new NodePart({
+                               templateFactory,
+                               ...options,
+                             }));
+        part.appendInto(container);
+      }
+      part.setValue(result);
+      part.commit();
+    };

--- a/src/lib/shady-render.ts
+++ b/src/lib/shady-render.ts
@@ -75,7 +75,7 @@ const TEMPLATE_TYPES = ['html', 'svg'];
 /**
  * Removes all style elements from Templates for the given scopeName.
  */
-function removeStylesFromLitTemplates(scopeName: string) {
+const removeStylesFromLitTemplates = (scopeName: string) => {
   TEMPLATE_TYPES.forEach((type) => {
     const templates = templateCaches.get(getTemplateCacheKey(type, scopeName));
     if (templates !== undefined) {
@@ -90,7 +90,7 @@ function removeStylesFromLitTemplates(scopeName: string) {
       });
     }
   });
-}
+};
 
 const shadyRenderSet = new Set<string>();
 
@@ -162,29 +162,29 @@ export interface ShadyRenderOptions extends Partial<RenderOptions> {
   scopeName: string;
 }
 
-export function render(
-    result: TemplateResult,
-    container: Element|DocumentFragment,
-    options: ShadyRenderOptions) {
-  const scopeName = options.scopeName;
-  const hasRendered = parts.has(container);
-  litRender(result, container, {
-    templateFactory: shadyTemplateFactory(scopeName),
-    ...options,
-  } as RenderOptions);
-  // When rendering a TemplateResult, scope the template with ShadyCSS
-  if (container instanceof ShadowRoot && compatibleShadyCSSVersion &&
-      result instanceof TemplateResult) {
-    // Scope the element template one time only for this scope.
-    if (!shadyRenderSet.has(scopeName)) {
-      const part = parts.get(container)!;
-      const instance = part.value as TemplateInstance;
-      prepareTemplateStyles(
-          (container as ShadowRoot), instance.template, scopeName);
-    }
-    // Update styling if this is the initial render to this container.
-    if (!hasRendered) {
-      window.ShadyCSS.styleElement((container as ShadowRoot).host);
-    }
-  }
-}
+export const render =
+    (result: TemplateResult,
+     container: Element|DocumentFragment,
+     options: ShadyRenderOptions) => {
+      const scopeName = options.scopeName;
+      const hasRendered = parts.has(container);
+      litRender(result, container, {
+        templateFactory: shadyTemplateFactory(scopeName),
+        ...options,
+      } as RenderOptions);
+      // When rendering a TemplateResult, scope the template with ShadyCSS
+      if (container instanceof ShadowRoot && compatibleShadyCSSVersion &&
+          result instanceof TemplateResult) {
+        // Scope the element template one time only for this scope.
+        if (!shadyRenderSet.has(scopeName)) {
+          const part = parts.get(container)!;
+          const instance = part.value as TemplateInstance;
+          prepareTemplateStyles(
+              (container as ShadowRoot), instance.template, scopeName);
+        }
+        // Update styling if this is the initial render to this container.
+        if (!hasRendered) {
+          window.ShadyCSS.styleElement((container as ShadowRoot).host);
+        }
+      }
+    };

--- a/src/lib/shady-render.ts
+++ b/src/lib/shady-render.ts
@@ -169,9 +169,9 @@ export function render(
   const scopeName = options.scopeName;
   const hasRendered = parts.has(container);
   litRender(result, container, {
-    eventContext: options.eventContext,
     templateFactory: shadyTemplateFactory(scopeName),
-  });
+    ...options,
+  } as RenderOptions);
   // When rendering a TemplateResult, scope the template with ShadyCSS
   if (container instanceof ShadowRoot && compatibleShadyCSSVersion &&
       result instanceof TemplateResult) {

--- a/src/lib/shady-render.ts
+++ b/src/lib/shady-render.ts
@@ -13,6 +13,7 @@
  */
 
 import {insertNodeIntoTemplate, removeNodesFromTemplate} from './modify-template.js';
+import {RenderOptions} from './render-options.js';
 import {parts, render as litRender} from './render.js';
 import {templateCaches} from './template-factory.js';
 import {TemplateInstance} from './template-instance.js';
@@ -157,12 +158,20 @@ const prepareTemplateStyles =
       }
     };
 
+export interface ShadyRenderOptions extends Partial<RenderOptions> {
+  scopeName: string;
+}
+
 export function render(
     result: TemplateResult,
     container: Element|DocumentFragment,
-    scopeName: string) {
+    options: ShadyRenderOptions) {
+  const scopeName = options.scopeName;
   const hasRendered = parts.has(container);
-  litRender(result, container, shadyTemplateFactory(scopeName));
+  litRender(result, container, {
+    eventContext: options.eventContext,
+    templateFactory: shadyTemplateFactory(scopeName),
+  });
   // When rendering a TemplateResult, scope the template with ShadyCSS
   if (container instanceof ShadowRoot && compatibleShadyCSSVersion &&
       result instanceof TemplateResult) {

--- a/src/lib/template-instance.ts
+++ b/src/lib/template-instance.ts
@@ -15,7 +15,8 @@
 
 import {isCEPolyfill} from './dom.js';
 import {Part} from './part.js';
-import {TemplateFactory} from './template-factory.js';
+import {RenderOptions} from './render-options.js';
+// import {TemplateFactory} from './template-factory.js';
 import {TemplateProcessor} from './template-processor.js';
 import {isTemplatePartActive, Template} from './template.js';
 
@@ -26,15 +27,15 @@ import {isTemplatePartActive, Template} from './template.js';
 export class TemplateInstance {
   _parts: Array<Part|undefined> = [];
   processor: TemplateProcessor;
-  _getTemplate: TemplateFactory;
+  options: RenderOptions;
   template: Template;
 
   constructor(
       template: Template, processor: TemplateProcessor,
-      getTemplate: TemplateFactory) {
+      options: RenderOptions) {
     this.template = template;
     this.processor = processor;
-    this._getTemplate = getTemplate;
+    this.options = options;
   }
 
   update(values: any[]) {
@@ -88,12 +89,12 @@ export class TemplateInstance {
           partIndex++;
         } else if (nodeIndex === part.index) {
           if (part.type === 'node') {
-            const part = this.processor.handleTextExpression(this._getTemplate);
+            const part = this.processor.handleTextExpression(this.options);
             part.insertAfterNode(node);
             this._parts.push(part);
           } else {
             this._parts.push(...this.processor.handleAttributeExpressions(
-                node as Element, part.name, part.strings));
+                node as Element, part.name, part.strings, this.options));
           }
           partIndex++;
         } else {

--- a/src/lib/template-processor.ts
+++ b/src/lib/template-processor.ts
@@ -14,7 +14,7 @@
 
 import {Part} from './part.js';
 import {NodePart} from './parts.js';
-import {TemplateFactory} from './template-factory.js';
+import {RenderOptions} from './render-options.js';
 
 export interface TemplateProcessor {
   /**
@@ -26,12 +26,13 @@ export interface TemplateProcessor {
    * @param strings The string literals. There are always at least two strings,
    *   event for fully-controlled bindings with a single expression.
    */
-  handleAttributeExpressions(element: Element, name: string, strings: string[]):
-      Part[];
+  handleAttributeExpressions(
+      element: Element, name: string, strings: string[],
+      options: RenderOptions): Part[];
 
   /**
    * Create parts for a text-position binding.
-   * @param templateFactory
+   * @param partOptions
    */
-  handleTextExpression(templateFactory: TemplateFactory): NodePart;
+  handleTextExpression(options: RenderOptions): NodePart;
 }

--- a/src/test/lib/incompatible-shady-render_test.ts
+++ b/src/test/lib/incompatible-shady-render_test.ts
@@ -40,7 +40,9 @@ suite('shady-render', () => {
       </style>
       <div>Testing...</div>
     `;
-    render(result, container.shadowRoot as DocumentFragment, 'scope-4');
+    render(result, container.shadowRoot as DocumentFragment, {
+      scopeName: 'scope-4'
+    });
     assert.isAbove(window.WarnCount, 0);
     document.body.removeChild(container);
   });

--- a/src/test/lib/parts_test.ts
+++ b/src/test/lib/parts_test.ts
@@ -54,7 +54,7 @@ suite('Parts', () => {
       endNode = createMarker();
       container.appendChild(startNode);
       container.appendChild(endNode);
-      part = new NodePart(templateFactory);
+      part = new NodePart({templateFactory});
       part.startNode = startNode;
       part.endNode = endNode;
     });
@@ -159,9 +159,10 @@ suite('Parts', () => {
               element: Element, name: string, strings: string[]) {
             if (name[0] === '&') {
               return super.handleAttributeExpressions(
-                  element, name.slice(1), strings);
+                  element, name.slice(1), strings, {templateFactory});
             }
-            return super.handleAttributeExpressions(element, name, strings);
+            return super.handleAttributeExpressions(
+                element, name, strings, {templateFactory});
           }
         }
         const processor = new TestTemplateProcessor();
@@ -350,7 +351,7 @@ suite('Parts', () => {
           () => {
             const testEndNode = createMarker();
             container.appendChild(testEndNode);
-            const testPart = new NodePart(templateFactory);
+            const testPart = new NodePart({templateFactory});
             testPart.insertAfterNode(endNode);
             assert.equal(testPart.startNode, endNode);
             assert.equal(testPart.endNode, testEndNode);
@@ -367,7 +368,7 @@ suite('Parts', () => {
       test(
           'inserts part and sets values between ref node and its next sibling',
           () => {
-            const testPart = new NodePart(templateFactory);
+            const testPart = new NodePart({templateFactory});
             testPart.appendIntoPart(part);
             assert.instanceOf(testPart.startNode, Comment);
             assert.instanceOf(testPart.endNode, Comment);
@@ -395,7 +396,7 @@ suite('Parts', () => {
 
     suite('insertAfterPart', () => {
       test('inserts part and sets values after another part', () => {
-        const testPart = new NodePart(templateFactory);
+        const testPart = new NodePart({templateFactory});
         testPart.insertAfterPart(part);
         assert.instanceOf(testPart.startNode, Comment);
         assert.equal(testPart.endNode, endNode);

--- a/src/test/lib/render_test.ts
+++ b/src/test/lib/render_test.ts
@@ -537,10 +537,11 @@ suite('render()', () => {
         event = e;
         thisValue = this;
       };
-      render(html`<div @click=${listener}></div>`, container);
+      const eventContext = {} as EventTarget;
+      render(html`<div @click=${listener}></div>`, container, {eventContext});
       const div = container.querySelector('div')!;
       div.click();
-      assert.equal(thisValue, div);
+      assert.equal(thisValue, eventContext);
 
       // MouseEvent is not a function in IE, so the event cannot be an instance
       // of it
@@ -558,10 +559,11 @@ suite('render()', () => {
           thisValue = this;
         }
       };
-      render(html`<div @click=${listener}></div>`, container);
+      const eventContext = {} as EventTarget;
+      render(html`<div @click=${listener}></div>`, container, {eventContext});
       const div = container.querySelector('div')!;
       div.click();
-      assert.equal(thisValue, listener);
+      assert.equal(thisValue, eventContext);
     });
 
     test('only adds event listener once', () => {


### PR DESCRIPTION
This PR changes the signature of `render()` and a few other methods to accept an options object with an optional `eventContext` property. The property is used by EventPart as the `this` argument when calling event listeners.

This means that a Web Component class that calls `render()` can pass itself as the event context and event listeners in templates will not have to be bound to receive the component as 'this'.

LitElement can change roughly like this:

```ts
class LitElement {
  // ...
  update(changedProperties: PropertyValues) {
    render(this.render(), this.renderRoot!, {scopeName: this.localName!, eventContext: this});
  }
  // ...
}
```

And then subclasses can write event listeners as simple methods:

```ts
class MyElement extends LitElement {
  private _onButtonClick(e) {
    // now called with the correct `this` value
    this.doThing();
  }

  render() {
    return html`
      <button @click=${this._onButtonClick}>Click Me</button>
    `;
  }
}
```

This should improve both ergonomics and memory consumption, as developers don't have to create bound event listener functions for every instance of a component.

## Future Work

When combined with a fix for #145, we can write event listener options directly onto prototype methods, and also do so with a decorator:

```ts
class MyElement extends LitElement {
  
  @eventOptions({passive: true})
  private _onScroll(e) {
    //...
  }

  render() {
    return html`
      <div @scroll=${this._onScroll}></div>
    `;
  }
}
```