### PR TITLE
Enable TypeScript declaration maps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,9 +7,11 @@
 
 # Compiler output
 /lit-html.d.ts
+/lit-html.d.ts.map
 /lit-html.js
 /lit-html.js.map
 /test/**/*.d.ts
+/test/**/*.d.ts.map
 /test/**/*.js
 /test/**/*.js.map
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "/lit-html.js",
     "/lit-html.js.map",
     "/lit-html.d.ts",
+    "/lit-html.d.ts.map",
     "/lib/",
     "/directives/",
     "/src/",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "module": "es2015",
     "lib": ["es2017", "esnext.asynciterable", "dom"],
     "declaration": true,
+    "declarationMap": true,
     "sourceMap": true,
     "inlineSources": true,
     "outDir": "./",


### PR DESCRIPTION
Declaration maps are a neat feature that landed in TS 2.9, enabling it
emits a sourcemap for declaration files (.d.ts.map). Like JS .map files
they are for resolving to the original source of declaration files, but
instead of being used by the browser they are used by the user's text
editor/ide.

Basically, where before in vscode if you go to defintion on `html` in
`import {html} from 'lit-html'` you would end up in the declaration
file, now it will take you to the correct position in the original .ts file.