### PR TITLE
Support event listener options.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 * [Breaking] `render()` now takes an options object as the third argument. ([#523](https://github.com/Polymer/lit-html/pull/523))
 ### Added
 * Event listeners are called with a configurable `this` reference, which is set via the `eventContext` option to `render()`. ([#523](https://github.com/Polymer/lit-html/pull/523))
+* Support for event listener options, by passing the listener itself as both the second and third arguments to add/removeEventListener().
 
 <!-- ### Removed -->
 <!-- ### Fixed -->

--- a/docs-src/guide/02-writing-templates.md
+++ b/docs-src/guide/02-writing-templates.md
@@ -86,10 +86,24 @@ There are a few types of bindings:
     ```js
     html`<input .value=${value}>`
     ```
-  * Event Handler:
+  * Event Listener:
     ```js
     html`<button @click=${(e) => console.log('clicked')}>Click Me</button>`
     ```
+
+### Event Listeners
+
+Event listeners can be functions or objects with a `handleEvent` method. Listeners are passed as both the listener and options arguments to `addEventListener`/`removeEventListener`, so that the listener can carry event listener options like `capture`, `passive`, and `once`.
+
+```js
+const listener = {
+  handleEvent(e) {
+    console.log('clicked');
+  }
+  capture: true;
+}
+html`<button @click=${listener}>Click Me</button>`
+```
 
 ## Supported Data Types
 

--- a/src/lib/parts.ts
+++ b/src/lib/parts.ts
@@ -435,6 +435,7 @@ export class EventPart implements Part {
   eventName: string;
   eventContext?: EventTarget;
   value: any = undefined;
+  _options?: {capture?: boolean, passive?: boolean, once?: boolean};
   _pendingValue: any = undefined;
 
   constructor(element: Element, eventName: string, eventContext?: EventTarget) {
@@ -468,18 +469,11 @@ export class EventPart implements Part {
         newListener != null && (oldListener == null || shouldRemoveListener);
 
     if (shouldRemoveListener) {
-      try {
-        // This can throw if the options don't match the options that the
-        // listener was added with. This should never happen.
-        this.element.removeEventListener(
-            this.eventName, this, getOptions(oldListener));
-      } catch (e) {
-        console.error('Failed to remove listener');
-      }
+      this.element.removeEventListener(this.eventName, this, this._options);
     }
+    this._options = getOptions(newListener);
     if (shouldAddListener) {
-      this.element.addEventListener(
-          this.eventName, this, getOptions(newListener));
+      this.element.addEventListener(this.eventName, this, this._options);
     }
     this.value = newListener;
     this._pendingValue = noChange;

--- a/src/test/directives/repeat_test.ts
+++ b/src/test/directives/repeat_test.ts
@@ -406,8 +406,8 @@ suite('repeat', () => {
     });
 
     test('render objects as items with mutable update', () => {
-      let items = [{text: '0'}, {text: '1'}, {text: '2'}];
-      const t = () => html`${repeat(items, i => html`
+      const items = [{text: '0'}, {text: '1'}, {text: '2'}];
+      const t = () => html`${repeat(items, (i) => html`
             <li>item: ${i.text}</li>`)}`;
       render(t(), container);
       assert.equal(stripExpressionMarkers(container.innerHTML), `
@@ -428,7 +428,7 @@ suite('repeat', () => {
 
     test('render objects as items with immutable update', () => {
       let items = [{text: '0'}, {text: '1'}, {text: '2'}];
-      const t = () => html`${repeat(items, i => html`
+      const t = () => html`${repeat(items, (i) => html`
             <li>item: ${i.text}</li>`)}`;
       render(t(), container);
       assert.equal(stripExpressionMarkers(container.innerHTML), `

--- a/src/test/lib/parts_test.ts
+++ b/src/test/lib/parts_test.ts
@@ -545,8 +545,10 @@ suite('Parts', () => {
       element.click();
       assert.isTrue(listenerCalled, 'listenerCalled');
       assert.isTrue(captureCalled, 'captureCalled');
-      if (eventOptionsSupported) {
+      if (passiveSupported) {
         assert.isTrue(passiveCalled, 'passiveCalled');
+      }
+      if (onceSupported) {
         assert.isTrue(onceCalled, 'onceCalled');
       }
     });

--- a/src/test/lib/parts_test.ts
+++ b/src/test/lib/parts_test.ts
@@ -12,7 +12,7 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {AttributeCommitter, AttributePart, createMarker, DefaultTemplateProcessor, html, NodePart, render, templateFactory, TemplateResult} from '../../lit-html.js';
+import {AttributeCommitter, AttributePart, createMarker, DefaultTemplateProcessor, EventPart, html, NodePart, render, templateFactory, TemplateResult} from '../../lit-html.js';
 import {stripExpressionMarkers} from '../test-utils/strip-markers.js';
 
 const assert = chai.assert;
@@ -429,6 +429,126 @@ suite('Parts', () => {
         assert.deepEqual(
             Array.from(container.childNodes), [startNode, endNode]);
       });
+    });
+  });
+
+  suite('EventPart', () => {
+    let part: EventPart;
+    let element: HTMLElement;
+
+    // Detect event options support
+    let eventOptionsSupported = false;
+    let captureSupported = false;
+    let passiveSupported = false;
+    let onceSupported = false;
+
+    try {
+      const options = {
+        get capture() {
+          eventOptionsSupported = true;
+          captureSupported = true;
+          return false;
+        },
+        get passive() {
+          eventOptionsSupported = true;
+          passiveSupported = true;
+          return false;
+        },
+        get once() {
+          eventOptionsSupported = true;
+          onceSupported = true;
+          return false;
+        },
+      };
+      window.addEventListener('test', options as any, options);
+      window.removeEventListener('test', options as any, options);
+    } catch (_e) {
+    }
+
+    setup(() => {
+      element = document.createElement('div');
+      document.body.appendChild(element);
+    });
+
+    test('supports event listener options on functions', () => {
+      console.log('eventOptionsSupported', eventOptionsSupported);
+      console.log('captureSupported', captureSupported);
+      console.log('passiveSupported', passiveSupported);
+      console.log('onceSupported', onceSupported);
+      part = new EventPart(element, 'click');
+      let listenerCalled = false;
+      let captureCalled = false;
+      let passiveCalled = false;
+      let onceCalled = false;
+
+      const listener = (_e: Event) => {
+        listenerCalled = true;
+      };
+      Object.defineProperties(listener, {
+        capture: {
+          get() {
+            captureCalled = true;
+          }
+        },
+        passive: {
+          get() {
+            passiveCalled = true;
+          }
+        },
+        once: {
+          get() {
+            onceCalled = true;
+          }
+        }
+      });
+
+      part.setValue(listener);
+      part.commit();
+      element.click();
+      assert.isTrue(listenerCalled, 'listenerCalled');
+      assert.isTrue(captureCalled, 'captureCalled');
+      if (passiveSupported) {
+        assert.isTrue(passiveCalled, 'passiveCalled');
+      }
+      if (onceSupported) {
+        assert.isTrue(onceCalled, 'onceCalled');
+      }
+    });
+
+    test('supports event listener options on objects', () => {
+      part = new EventPart(element, 'click');
+      let listenerCalled = false;
+      let captureCalled = false;
+      let passiveCalled = false;
+      let onceCalled = false;
+
+      const listener = {
+        handleEvent(_e: Event) {
+          listenerCalled = true;
+        },
+        get capture() {
+          captureCalled = true;
+          return undefined;
+        },
+        get passive() {
+          passiveCalled = true;
+          return undefined;
+        },
+        get once() {
+          onceCalled = true;
+          return undefined;
+        }
+      };
+
+      part.setValue(listener);
+      part.commit();
+      element.click();
+      assert.isTrue(listenerCalled, 'listenerCalled');
+      assert.isTrue(captureCalled, 'captureCalled');
+      if (eventOptionsSupported) {
+        assert.isTrue(passiveCalled, 'passiveCalled');
+        assert.isTrue(onceCalled, 'onceCalled');
+      }
     });
   });
 });

--- a/src/test/lib/render_test.ts
+++ b/src/test/lib/render_test.ts
@@ -665,11 +665,13 @@ suite('render()', () => {
         },
         capture: true,
       };
-      render(html`
+      render(
+          html`
         <div id="outer" @test=${listener}>
           <div id="inner"><div>
         </div>
-      `, container);
+      `,
+          container);
       const inner = container.querySelector('#inner')!;
       inner.dispatchEvent(new CustomEvent('test'));
       assert.isOk(event);

--- a/src/test/lib/render_test.ts
+++ b/src/test/lib/render_test.ts
@@ -673,7 +673,7 @@ suite('render()', () => {
       `,
           container);
       const inner = container.querySelector('#inner')!;
-      inner.dispatchEvent(new CustomEvent('test'));
+      inner.dispatchEvent(new Event('test'));
       assert.isOk(event);
       assert.equal(eventPhase, Event.CAPTURING_PHASE);
     });

--- a/src/test/lib/render_test.ts
+++ b/src/test/lib/render_test.ts
@@ -530,6 +530,15 @@ suite('render()', () => {
   });
 
   suite('events', () => {
+
+    setup(() => {
+      document.body.appendChild(container);
+    });
+
+    teardown(() => {
+      document.body.removeChild(container);
+    });
+
     test('adds event listener functions, calls with right this value', () => {
       let thisValue;
       let event: Event;

--- a/src/test/lib/render_test.ts
+++ b/src/test/lib/render_test.ts
@@ -530,7 +530,6 @@ suite('render()', () => {
   });
 
   suite('events', () => {
-
     setup(() => {
       document.body.appendChild(container);
     });

--- a/src/test/lib/render_test.ts
+++ b/src/test/lib/render_test.ts
@@ -652,6 +652,29 @@ suite('render()', () => {
       div.click();
       assert.equal(target, undefined);
     });
+
+
+    test('allows capturing events', () => {
+      let event!: Event;
+      let eventPhase!: number;
+      const listener = {
+        handleEvent(e: Event) {
+          event = e;
+          // read here because it changes
+          eventPhase = event.eventPhase;
+        },
+        capture: true,
+      };
+      render(html`
+        <div id="outer" @test=${listener}>
+          <div id="inner"><div>
+        </div>
+      `, container);
+      const inner = container.querySelector('#inner')!;
+      inner.dispatchEvent(new CustomEvent('test'));
+      assert.isOk(event);
+      assert.equal(eventPhase, Event.CAPTURING_PHASE);
+    });
   });
 
   suite('directives', () => {


### PR DESCRIPTION
Event listeners can be functions or objects with a `handleEvent` method. Listeners are passed as both the listener and options arguments to `addEventListener`/`removeEventListener`, so that the listener can carry event listener options like `capture`, `passive`, and `once`.

```js
const listener = {
  handleEvent(e) {
    console.log('clicked');
  }
  capture: true;
}
html`<button @click=${listener}>Click Me</button>`
```

Fixes #145 