### PR TITLE
Don't clear() parts in asyncAppend and asyncReplace if the iterable isn't the current value.

### DIFF
--- a/src/directives/async-append.ts
+++ b/src/directives/async-append.ts
@@ -50,16 +50,16 @@ export const asyncAppend = directive(
       let i = 0;
 
       for await (let v of value) {
-        // When we get the first value, clear the part. This lets the
-        // previous value display until we can replace it.
-        if (i === 0) {
-          part.clear();
-        }
-
         // Check to make sure that value is the still the current value of
         // the part, and if not bail because a new value owns this part
         if (part.value !== value) {
           break;
+        }
+
+        // When we get the first value, clear the part. This lets the
+        // previous value display until we can replace it.
+        if (i === 0) {
+          part.clear();
         }
 
         // As a convenience, because functional-programming-style

--- a/src/directives/async-replace.ts
+++ b/src/directives/async-replace.ts
@@ -52,17 +52,17 @@ export const asyncReplace = directive(
           let i = 0;
 
           for await (let v of value) {
+            // Check to make sure that value is the still the current value of
+            // the part, and if not bail because a new value owns this part
+            if (part.value !== value) {
+              break;
+            }
+
             // When we get the first value, clear the part. This let's the
             // previous value display until we can replace it.
             if (i === 0) {
               part.clear();
               itemPart.appendIntoPart(part);
-            }
-
-            // Check to make sure that value is the still the current value of
-            // the part, and if not bail because a new value owns this part
-            if (part.value !== value) {
-              break;
             }
 
             // As a convenience, because functional-programming-style

--- a/src/test/directives/async-append_test.ts
+++ b/src/test/directives/async-append_test.ts
@@ -115,4 +115,20 @@ suite('asyncAppend', () => {
     assert.equal(
         stripExpressionMarkers(container.innerHTML), '<div>hello</div>');
   });
+
+  test('does not render the first value if it is replaced first', async () => {
+    async function* generator(delay: Promise<any>, value: any) {
+      await delay;
+      yield value;
+    }
+
+    const component = (value: any) => html`<p>${asyncAppend(value)}</p>`;
+    const delay = (delay: number) => new Promise(res => setTimeout(res, delay));
+
+    render(component(generator(delay(20), 'slow')), container);
+    render(component(generator(delay(10), 'fast')), container);
+    await delay(30);
+
+    assert.equal(stripExpressionMarkers(container.innerHTML), '<p>fast</p>');
+  });
 });

--- a/src/test/directives/async-replace_test.ts
+++ b/src/test/directives/async-replace_test.ts
@@ -135,4 +135,20 @@ suite('asyncReplace', () => {
     assert.equal(
         stripExpressionMarkers(container.innerHTML), '<div>hello</div>');
   });
+
+  test('does not render the first value if it is replaced first', async () => {
+    async function* generator(delay: Promise<any>, value: any) {
+      await delay;
+      yield value;
+    }
+
+    const component = (value: any) => html`<p>${asyncReplace(value)}</p>`;
+    const delay = (delay: number) => new Promise(res => setTimeout(res, delay));
+
+    render(component(generator(delay(20), 'slow')), container);
+    render(component(generator(delay(10), 'fast')), container);
+    await delay(30);
+
+    assert.equal(stripExpressionMarkers(container.innerHTML), '<p>fast</p>');
+  });
 });


### PR DESCRIPTION
This is a fix to issue #543 