### PR TITLE
Feature/update when

### DIFF
--- a/docs/_guide/02-writing-templates.md
+++ b/docs/_guide/02-writing-templates.md
@@ -282,9 +282,24 @@ const render = () => html`
 
 lit-html includes a few built-in directives:
 
-### `when(condition, trueTemplate, falseTemplate)`
+### `when(condition, trueValue)` ###
+Directive for handling if-statements in your template.
 
-Efficiently switches between two templates based on the given condition. The rendered content is cached, and re-used when switching conditions. Templates are evaluated lazily, so the passed values must be functions.
+Example:
+
+```js
+import { when } from 'lit-html/directives/when';
+
+let renderMessage = false;
+html`
+  ${when(renderMessage, () => html`<span>My message</span>`)}
+`
+```
+
+When `renderMessage` is true, the message is rendered. Otherwise, nothing is rendered.
+
+### `when(condition, trueValue, falseValue)` ###
+Directive for handling if/else-statements in your template.
 
 Example:
 
@@ -292,11 +307,56 @@ Example:
 import { when } from 'lit-html/directives/when';
 
 let checked = false;
-
 html`
-  when(checked, () => html`Checkmark is checked`, () => html`Checkmark is not
-checked`);
+  ${when(checked,
+    () => html`<span>Checkmark is checked</span>`,
+    () => html`<span>Checkmark is not checked</span>`
+  )}
+`
 ```
+
+The `when` directive will switch between the two templates based on the condition passed in the first parameter. Dom nodes are recreated when switching conditions, for caching see `cachingWhen`.
+
+### `when(condition, caseMap)` ###
+Directive for handling condition switching in your template.
+
+Example:
+
+```js
+import { when } from 'lit-html/directives/when';
+
+let fruit = 'apples';
+html`
+  ${when(fruit, {
+    bananas: () => html`<div>Bananas are nice</div>`,
+    apples: () => html`<div>Apples are great</div>`,
+    lemons: () => html`<div>Lemons are sour</div>`,
+    default: () => html`<span>Unknown fruit</span>`
+  })}
+`
+```
+
+When given an object, the `when` directive will look up and render the case matching the condition passed in the first parameter. If no case matches, the default case is rendered. A default case is optional. If there is no default, nothing is rendered. Dom nodes are recreated when switching cases, for caching see `cachingWhen`.
+
+### `cachingWhen(condition, trueTemplate, falseTemplate)`
+
+`cachingWhen` is an extension of `when` which caches dom nodes when switching conditions or cases. This can be useful when frequently switching between conditions or when switching between large DOM trees. In general the regular `when` directive is sufficient, `cachingWhen` should only be used when you need the caching.
+
+Example:
+
+```js
+import { cachingWhen } from 'lit-html/directives/caching-when';
+
+let checked = false;
+html`
+  ${cachingWhen(checked,
+    () => html`<span>Checkmark is checked</span>`,
+    () => html`<span>Checkmark is not checked</span>`
+  )}
+`
+```
+
+The interface of `cachingWhen` is identical to `when`, see `when` for more examples.
 
 ### `repeat(items, keyfn, template)`
 

--- a/src/directives/caching-when.ts
+++ b/src/directives/caching-when.ts
@@ -1,0 +1,118 @@
+/**
+ * @license
+ * Copyright (c) 2018 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+import { directive, Directive, NodePart, reparentNodes } from '../lit-html.js';
+import { WhenValue, CaseMap } from './when';
+
+interface ConditionCache {
+  part: NodePart;
+  cacheContainer: DocumentFragment;
+}
+
+interface PartCache {
+  conditions: Map<any, ConditionCache>;
+  prevCondition?: any;
+}
+
+const partCaches = new WeakMap<NodePart, PartCache>();
+
+/**
+ * Directive for handling conditional logic inside templates. The logic
+ * is identical to the regular when directive, with the addition that
+ * nodes are cached between switching conditions. This prevents re-creating
+ * the nodes of a template each switch, and can help improve render performance.
+ *
+ * Use this directive only when you need the caching, for example when frequently
+ * switching cases or when switching between large dom trees. In other cases use
+ * the regular when directive.
+ *
+ * @param condition the condition to check for truthiness
+ * @param caseMap object where keys are cases and values are functions which return the value to render
+ * @param trueValue function that returns the value to render in case of truthiness
+ * @param falseValue function that returns the value to render in case of falsiness
+ */
+export function cachingWhen(condition: any, trueValue: WhenValue, falseValue?: WhenValue): Directive<NodePart>;
+export function cachingWhen(condition: any, caseMap: CaseMap): Directive<NodePart>;
+export function cachingWhen(condition: any, trueValueOrCaseMap: WhenValue | CaseMap, falseValue?: WhenValue): Directive<NodePart> {
+  let caseMap: CaseMap;
+  let trueValue: WhenValue;
+  let nextCondition: any;
+
+  // test whether we are in case or in if/else mode
+  if (typeof trueValueOrCaseMap === 'object') {
+    caseMap = trueValueOrCaseMap;
+    nextCondition = condition;
+  } else {
+    trueValue = trueValueOrCaseMap;
+    // in if or if/else mode, the condition is checked on truthiness
+    // so we coerce the condition to a boolean
+    nextCondition = Boolean(condition);
+  }
+
+  return directive((parentPart: NodePart) => {
+    let cache = partCaches.get(parentPart);
+
+    // create a new PartCache if this is the first render
+    if (cache === undefined) {
+      cache = { conditions: new Map() };
+      partCaches.set(parentPart, cache);
+    }
+
+    const { prevCondition } = cache;
+    const prevCache = cache.conditions.get(prevCondition);
+    let nextCache = cache.conditions.get(nextCondition);
+
+    // create a new ConditionCache if this is the first time rendering
+    // this condition
+    if (!nextCache) {
+      nextCache = {
+        part: new NodePart(parentPart.options),
+        cacheContainer: document.createDocumentFragment(),
+      }
+      cache.conditions.set(nextCondition, nextCache);
+      nextCache.part.appendIntoPart(parentPart);
+    }
+
+    // determine what the next render value is, based on case or if/else mode
+    let nextValue: WhenValue | undefined;
+    if (caseMap) {
+      nextValue = caseMap[nextCondition] || caseMap.default;
+    } else {
+      nextValue = condition ? trueValue : falseValue;
+    }
+
+    // if we switched conditions, swap nodes to/from the cache.
+    if (nextCondition !== prevCondition) {
+      // take next part from the cache, if it was rendered before
+      if (nextCache.part.value) {
+        parentPart.startNode.parentNode!.appendChild(
+          nextCache.cacheContainer);
+      }
+
+      // move the prev part from the cache, if it was rendered before
+      if (prevCache && prevCache.part.value) {
+        reparentNodes(
+            prevCache.cacheContainer,
+            prevCache.part.startNode,
+            prevCache.part.endNode.nextSibling);
+      }
+    }
+
+    nextCache.part.setValue(nextValue ? nextValue() : undefined);
+    nextCache.part.commit();
+
+    cache.prevCondition = nextCondition;
+  });
+
+}

--- a/src/directives/caching-when.ts
+++ b/src/directives/caching-when.ts
@@ -12,8 +12,9 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import { directive, Directive, NodePart, reparentNodes } from '../lit-html.js';
-import { WhenValue, CaseMap } from './when';
+import {directive, Directive, NodePart, reparentNodes} from '../lit-html.js';
+
+import {CaseMap, WhenValue} from './when';
 
 interface ConditionCache {
   part: NodePart;
@@ -33,18 +34,27 @@ const partCaches = new WeakMap<NodePart, PartCache>();
  * nodes are cached between switching conditions. This prevents re-creating
  * the nodes of a template each switch, and can help improve render performance.
  *
- * Use this directive only when you need the caching, for example when frequently
- * switching cases or when switching between large dom trees. In other cases use
- * the regular when directive.
+ * Use this directive only when you need the caching, for example when
+ * frequently switching cases or when switching between large dom trees. In
+ * other cases use the regular when directive.
  *
  * @param condition the condition to check for truthiness
- * @param caseMap object where keys are cases and values are functions which return the value to render
- * @param trueValue function that returns the value to render in case of truthiness
- * @param falseValue function that returns the value to render in case of falsiness
+ * @param caseMap object where keys are cases and values are functions which
+ *     return the value to render
+ * @param trueValue function that returns the value to render in case of
+ *     truthiness
+ * @param falseValue function that returns the value to render in case of
+ *     falsiness
  */
-export function cachingWhen(condition: any, trueValue: WhenValue, falseValue?: WhenValue): Directive<NodePart>;
-export function cachingWhen(condition: any, caseMap: CaseMap): Directive<NodePart>;
-export function cachingWhen(condition: any, trueValueOrCaseMap: WhenValue | CaseMap, falseValue?: WhenValue): Directive<NodePart> {
+export function cachingWhen(
+    condition: any, trueValue: WhenValue, falseValue?: WhenValue):
+    Directive<NodePart>;
+export function cachingWhen(
+    condition: any, caseMap: CaseMap): Directive<NodePart>;
+export function cachingWhen(
+    condition: any,
+    trueValueOrCaseMap: WhenValue|CaseMap,
+    falseValue?: WhenValue): Directive<NodePart> {
   let caseMap: CaseMap;
   let trueValue: WhenValue;
   let nextCondition: any;
@@ -65,11 +75,11 @@ export function cachingWhen(condition: any, trueValueOrCaseMap: WhenValue | Case
 
     // create a new PartCache if this is the first render
     if (cache === undefined) {
-      cache = { conditions: new Map() };
+      cache = {conditions: new Map()};
       partCaches.set(parentPart, cache);
     }
 
-    const { prevCondition } = cache;
+    const {prevCondition} = cache;
     const prevCache = cache.conditions.get(prevCondition);
     let nextCache = cache.conditions.get(nextCondition);
 
@@ -79,13 +89,13 @@ export function cachingWhen(condition: any, trueValueOrCaseMap: WhenValue | Case
       nextCache = {
         part: new NodePart(parentPart.options),
         cacheContainer: document.createDocumentFragment(),
-      }
+      };
       cache.conditions.set(nextCondition, nextCache);
       nextCache.part.appendIntoPart(parentPart);
     }
 
     // determine what the next render value is, based on case or if/else mode
-    let nextValue: WhenValue | undefined;
+    let nextValue: WhenValue|undefined;
     if (caseMap) {
       nextValue = caseMap[nextCondition] || caseMap.default;
     } else {
@@ -96,8 +106,7 @@ export function cachingWhen(condition: any, trueValueOrCaseMap: WhenValue | Case
     if (nextCondition !== prevCondition) {
       // take next part from the cache, if it was rendered before
       if (nextCache.part.value) {
-        parentPart.startNode.parentNode!.appendChild(
-          nextCache.cacheContainer);
+        parentPart.startNode.parentNode!.appendChild(nextCache.cacheContainer);
       }
 
       // move the prev part from the cache, if it was rendered before
@@ -114,5 +123,4 @@ export function cachingWhen(condition: any, trueValueOrCaseMap: WhenValue | Case
 
     cache.prevCondition = nextCondition;
   });
-
 }

--- a/src/directives/caching-when.ts
+++ b/src/directives/caching-when.ts
@@ -106,7 +106,8 @@ export function cachingWhen(
     if (nextCondition !== prevCondition) {
       // take next part from the cache, if it was rendered before
       if (nextCache.part.value) {
-        parentPart.startNode.parentNode!.insertBefore(nextCache.cacheContainer, parentPart.endNode);
+        parentPart.startNode.parentNode!.insertBefore(
+            nextCache.cacheContainer, parentPart.endNode);
       }
 
       // move the prev part from the cache, if it was rendered before

--- a/src/directives/caching-when.ts
+++ b/src/directives/caching-when.ts
@@ -106,7 +106,7 @@ export function cachingWhen(
     if (nextCondition !== prevCondition) {
       // take next part from the cache, if it was rendered before
       if (nextCache.part.value) {
-        parentPart.startNode.parentNode!.appendChild(nextCache.cacheContainer);
+        parentPart.startNode.parentNode!.insertBefore(nextCache.cacheContainer, parentPart.endNode);
       }
 
       // move the prev part from the cache, if it was rendered before

--- a/src/directives/when.ts
+++ b/src/directives/when.ts
@@ -12,10 +12,12 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import { directive, Directive, NodePart } from '../lit-html.js';
+import {directive, Directive, NodePart} from '../lit-html.js';
 
 export type WhenValue = () => any;
-export type CaseMap = { [key: string]: WhenValue };
+export type CaseMap = {
+  [key: string]: WhenValue
+};
 
 /**
  * Directive for handling conditional logic inside templates. One or
@@ -25,19 +27,28 @@ export type CaseMap = { [key: string]: WhenValue };
  *
  * An object is treated as a case switch, where the condition is used as
  * key to render the value of the matched case on the object. If no condition
- * matches the default case is rendered if present. Keys can be strings and symbols.
+ * matches the default case is rendered if present. Keys can be strings and
+ * symbols.
  *
- * Templates are re-instantiated each re-render. For caching nodes between renders,
- * see the cachingWhen directive.
+ * Templates are re-instantiated each re-render. For caching nodes between
+ * renders, see the cachingWhen directive.
  *
  * @param condition the condition to check for truthiness
- * @param caseMap object where keys are cases and values are functions which return the value to render
- * @param trueValue function that returns the value to render in case of truthiness
- * @param falseValue function that returns the value to render in case of falsiness
+ * @param caseMap object where keys are cases and values are functions which
+ *     return the value to render
+ * @param trueValue function that returns the value to render in case of
+ *     truthiness
+ * @param falseValue function that returns the value to render in case of
+ *     falsiness
  */
-export function when(condition: any, trueValue: WhenValue, falseValue?: WhenValue): Directive<NodePart>;
+export function when(
+    condition: any, trueValue: WhenValue, falseValue?: WhenValue):
+    Directive<NodePart>;
 export function when(condition: any, caseMap: CaseMap): Directive<NodePart>;
-export function when(condition: any, trueValueOrCaseMap: WhenValue | CaseMap, falseValue?: WhenValue): Directive<NodePart> {
+export function when(
+    condition: any,
+    trueValueOrCaseMap: WhenValue|CaseMap,
+    falseValue?: WhenValue): Directive<NodePart> {
   let caseMap: CaseMap;
   let trueValue: WhenValue;
 
@@ -49,7 +60,7 @@ export function when(condition: any, trueValueOrCaseMap: WhenValue | CaseMap, fa
   }
 
   return directive((part: NodePart) => {
-    let nextValue: WhenValue | undefined;
+    let nextValue: WhenValue|undefined;
 
     if (caseMap) {
       nextValue = caseMap[condition] || caseMap.default;

--- a/src/directives/when.ts
+++ b/src/directives/when.ts
@@ -30,8 +30,8 @@ export type CaseMap = {
  * matches the default case is rendered if present. Keys can be strings and
  * symbols.
  *
- * Templates are re-instantiated each re-render. For caching nodes between
- * renders, see the cachingWhen directive.
+ * When switching between conditions, templates re-instantiated. See cachingWhen
+ * for an implementation where nodes are cached when switching conditions.
  *
  * @param condition the condition to check for truthiness
  * @param caseMap object where keys are cases and values are functions which

--- a/src/test/directives/caching-when_test.ts
+++ b/src/test/directives/caching-when_test.ts
@@ -1,0 +1,174 @@
+/**
+ * @license
+ * Copyright (c) 2018 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+/// <reference path="../../../node_modules/@types/mocha/index.d.ts" />
+/// <reference path="../../../node_modules/@types/chai/index.d.ts" />
+
+import {cachingWhen} from '../../directives/caching-when.js';
+import {render} from '../../lib/render.js';
+import {html} from '../../lit-html.js';
+import {stripExpressionMarkers} from '../test-utils/strip-markers.js';
+
+const assert = chai.assert;
+
+suite('when', () => {
+  let container: HTMLDivElement;
+
+  setup(() => {
+    container = document.createElement('div');
+  });
+
+  suite('if mode', () => {
+    function renderWhen(condition: any) {
+      const template = html`${cachingWhen(condition, () => html`<div>Condition is true</div>`)}`;
+      render(template, container);
+    }
+
+    test('renders the value if condition is true', () => {
+      renderWhen(true);
+      assert.equal(
+        stripExpressionMarkers(container.innerHTML), '<div>Condition is true</div>');
+    });
+
+    test('does not render anything when condition is false', () => {
+      renderWhen(false);
+      assert.equal(
+        stripExpressionMarkers(container.innerHTML), '');
+    });
+
+    test('clears container when switching from true to false', () => {
+      renderWhen(true);
+      renderWhen(false);
+      assert.equal(
+        stripExpressionMarkers(container.innerHTML), '');
+    });
+
+    test('caches templates between renders', () => {
+      renderWhen(true);
+      const trueEl = container.firstElementChild;
+
+      renderWhen(false);
+
+      renderWhen(true);
+      assert.equal(trueEl, container.firstElementChild);
+    });
+  });
+
+  suite('if/else mode', () => {
+    function renderWhen(condition: any) {
+      const template = html`${cachingWhen(condition,
+          () => html`<div>Condition is true</div>`,
+          () => html`<div>Condition is false</div>`)}`;
+      render(template, container);
+    }
+
+    test('renders the value if condition is true', () => {
+      renderWhen(true);
+      assert.equal(
+        stripExpressionMarkers(container.innerHTML), '<div>Condition is true</div>');
+    });
+
+    test('renders the value if condition is false', () => {
+      renderWhen(false);
+      assert.equal(
+        stripExpressionMarkers(container.innerHTML), '<div>Condition is false</div>');
+    });
+
+    test('renders one condition at a time when switching conditions', () => {
+      renderWhen(true);
+      renderWhen(false);
+      assert.equal(
+        stripExpressionMarkers(container.innerHTML), '<div>Condition is false</div>');
+    });
+
+    test('caches templates between renders', () => {
+      renderWhen(true);
+      const trueEl = container.firstElementChild;
+
+      renderWhen(false);
+      const falseEl = container.firstElementChild;
+
+      renderWhen(true);
+      assert.equal(trueEl, container.firstElementChild);
+
+      renderWhen(false);
+      assert.equal(falseEl, container.firstElementChild);
+    });
+  });
+
+  suite('switch mode mode', () => {
+    suite('with default', () => {
+      function renderWhen(condition: any) {
+        const template = html`${cachingWhen(condition, {
+            a: () => html`<div>Condition is a</div>`,
+            b: () => html`<div>Condition is b</div>`,
+            c: () => html`<div>Condition is c</div>`,
+            default: () => html`<div>Condition is default</div>`}
+          )}`;
+        render(template, container);
+      }
+
+      test('renders the matched case', () => {
+        renderWhen('a');
+        assert.equal(
+          stripExpressionMarkers(container.innerHTML), '<div>Condition is a</div>');
+      });
+
+      test('renders the default case if no match', () => {
+        renderWhen('foo');
+        assert.equal(
+          stripExpressionMarkers(container.innerHTML), '<div>Condition is default</div>');
+      });
+
+      test('renders one condition at a time when switching conditions', () => {
+        renderWhen('a');
+        renderWhen('b');
+        assert.equal(
+          stripExpressionMarkers(container.innerHTML), '<div>Condition is b</div>');
+      });
+
+      test('caches templates between renders', () => {
+        renderWhen('a');
+        const aEl = container.firstElementChild;
+
+        renderWhen('b');
+        const bEl = container.firstElementChild;
+
+        renderWhen('foo');
+        const defaultEl = container.firstElementChild;
+
+        renderWhen('b');
+        assert.equal(bEl, container.firstElementChild);
+
+        renderWhen('foo');
+        assert.equal(defaultEl, container.firstElementChild);
+
+        renderWhen('a');
+        assert.equal(aEl, container.firstElementChild);
+      });
+    });
+
+    test('renders nothing if no match and no default condition', () => {
+      const template = html`${cachingWhen('foo', {
+          a: () => html`<div>Condition is a</div>`,
+          b: () => html`<div>Condition is b</div>`}
+        )}`;
+
+      render(template, container);
+      assert.equal(
+        stripExpressionMarkers(container.innerHTML), '');
+    });
+  });
+
+});

--- a/src/test/directives/caching-when_test.ts
+++ b/src/test/directives/caching-when_test.ts
@@ -22,7 +22,7 @@ import {stripExpressionMarkers} from '../test-utils/strip-markers.js';
 
 const assert = chai.assert;
 
-suite('when', () => {
+suite('cachingWhen', () => {
   let container: HTMLDivElement;
 
   setup(() => {
@@ -175,6 +175,42 @@ suite('when', () => {
 
       render(template, container);
       assert.equal(stripExpressionMarkers(container.innerHTML), '');
+    });
+  });
+
+  suite('cached content is re-injected in the right location', () => {
+    test('surrounded by dom nodes', () => {
+      function renderWhen(condition: boolean) {
+        render(html`<div>before</div>${cachingWhen(condition,
+            () => html`<div>Condition is true</div>`,
+            () => html`<div>Condition is false</div>`
+          )}<div>after</div>`, container);
+      }
+
+      renderWhen(true);
+      renderWhen(false);
+      renderWhen(true);
+      assert.equal(
+        stripExpressionMarkers(container.innerHTML),
+        '<div>before</div><div>Condition is true</div><div>after</div>'
+      );
+    });
+
+    test('surrounded by parts', () => {
+      function renderWhen(condition: boolean) {
+        render(html`${html`<div>before</div>`}${cachingWhen(condition,
+            () => html`<div>Condition is true</div>`,
+            () => html`<div>Condition is false</div>`
+          )}${html`<div>after</div>`}`, container);
+      }
+
+      renderWhen(true);
+      renderWhen(false);
+      renderWhen(true);
+      assert.equal(
+        stripExpressionMarkers(container.innerHTML),
+        '<div>before</div><div>Condition is true</div><div>after</div>'
+      );
     });
   });
 });

--- a/src/test/directives/caching-when_test.ts
+++ b/src/test/directives/caching-when_test.ts
@@ -31,27 +31,27 @@ suite('when', () => {
 
   suite('if mode', () => {
     function renderWhen(condition: any) {
-      const template = html`${cachingWhen(condition, () => html`<div>Condition is true</div>`)}`;
+      const template = html
+      `${cachingWhen(condition, () => html`<div>Condition is true</div>`)}`;
       render(template, container);
     }
 
     test('renders the value if condition is true', () => {
       renderWhen(true);
       assert.equal(
-        stripExpressionMarkers(container.innerHTML), '<div>Condition is true</div>');
+          stripExpressionMarkers(container.innerHTML),
+          '<div>Condition is true</div>');
     });
 
     test('does not render anything when condition is false', () => {
       renderWhen(false);
-      assert.equal(
-        stripExpressionMarkers(container.innerHTML), '');
+      assert.equal(stripExpressionMarkers(container.innerHTML), '');
     });
 
     test('clears container when switching from true to false', () => {
       renderWhen(true);
       renderWhen(false);
-      assert.equal(
-        stripExpressionMarkers(container.innerHTML), '');
+      assert.equal(stripExpressionMarkers(container.innerHTML), '');
     });
 
     test('caches templates between renders', () => {
@@ -67,29 +67,34 @@ suite('when', () => {
 
   suite('if/else mode', () => {
     function renderWhen(condition: any) {
-      const template = html`${cachingWhen(condition,
-          () => html`<div>Condition is true</div>`,
-          () => html`<div>Condition is false</div>`)}`;
+      const template = html`${
+          cachingWhen(
+              condition,
+              () => html`<div>Condition is true</div>`,
+              () => html`<div>Condition is false</div>`)}`;
       render(template, container);
     }
 
     test('renders the value if condition is true', () => {
       renderWhen(true);
       assert.equal(
-        stripExpressionMarkers(container.innerHTML), '<div>Condition is true</div>');
+          stripExpressionMarkers(container.innerHTML),
+          '<div>Condition is true</div>');
     });
 
     test('renders the value if condition is false', () => {
       renderWhen(false);
       assert.equal(
-        stripExpressionMarkers(container.innerHTML), '<div>Condition is false</div>');
+          stripExpressionMarkers(container.innerHTML),
+          '<div>Condition is false</div>');
     });
 
     test('renders one condition at a time when switching conditions', () => {
       renderWhen(true);
       renderWhen(false);
       assert.equal(
-        stripExpressionMarkers(container.innerHTML), '<div>Condition is false</div>');
+          stripExpressionMarkers(container.innerHTML),
+          '<div>Condition is false</div>');
     });
 
     test('caches templates between renders', () => {
@@ -111,31 +116,34 @@ suite('when', () => {
     suite('with default', () => {
       function renderWhen(condition: any) {
         const template = html`${cachingWhen(condition, {
-            a: () => html`<div>Condition is a</div>`,
-            b: () => html`<div>Condition is b</div>`,
-            c: () => html`<div>Condition is c</div>`,
-            default: () => html`<div>Condition is default</div>`}
-          )}`;
+          a: () => html`<div>Condition is a</div>`,
+          b: () => html`<div>Condition is b</div>`,
+          c: () => html`<div>Condition is c</div>`,
+          default: () => html`<div>Condition is default</div>`
+        })}`;
         render(template, container);
       }
 
       test('renders the matched case', () => {
         renderWhen('a');
         assert.equal(
-          stripExpressionMarkers(container.innerHTML), '<div>Condition is a</div>');
+            stripExpressionMarkers(container.innerHTML),
+            '<div>Condition is a</div>');
       });
 
       test('renders the default case if no match', () => {
         renderWhen('foo');
         assert.equal(
-          stripExpressionMarkers(container.innerHTML), '<div>Condition is default</div>');
+            stripExpressionMarkers(container.innerHTML),
+            '<div>Condition is default</div>');
       });
 
       test('renders one condition at a time when switching conditions', () => {
         renderWhen('a');
         renderWhen('b');
         assert.equal(
-          stripExpressionMarkers(container.innerHTML), '<div>Condition is b</div>');
+            stripExpressionMarkers(container.innerHTML),
+            '<div>Condition is b</div>');
       });
 
       test('caches templates between renders', () => {
@@ -161,14 +169,12 @@ suite('when', () => {
 
     test('renders nothing if no match and no default condition', () => {
       const template = html`${cachingWhen('foo', {
-          a: () => html`<div>Condition is a</div>`,
-          b: () => html`<div>Condition is b</div>`}
-        )}`;
+        a: () => html`<div>Condition is a</div>`,
+        b: () => html`<div>Condition is b</div>`
+      })}`;
 
       render(template, container);
-      assert.equal(
-        stripExpressionMarkers(container.innerHTML), '');
+      assert.equal(stripExpressionMarkers(container.innerHTML), '');
     });
   });
-
 });

--- a/src/test/directives/caching-when_test.ts
+++ b/src/test/directives/caching-when_test.ts
@@ -181,36 +181,42 @@ suite('cachingWhen', () => {
   suite('cached content is re-injected in the right location', () => {
     test('surrounded by dom nodes', () => {
       function renderWhen(condition: boolean) {
-        render(html`<div>before</div>${cachingWhen(condition,
-            () => html`<div>Condition is true</div>`,
-            () => html`<div>Condition is false</div>`
-          )}<div>after</div>`, container);
+        render(
+            html`<div>before</div>${
+                cachingWhen(
+                    condition,
+                    () => html`<div>Condition is true</div>`,
+                    () =>
+                        html`<div>Condition is false</div>`)}<div>after</div>`,
+            container);
       }
 
       renderWhen(true);
       renderWhen(false);
       renderWhen(true);
       assert.equal(
-        stripExpressionMarkers(container.innerHTML),
-        '<div>before</div><div>Condition is true</div><div>after</div>'
-      );
+          stripExpressionMarkers(container.innerHTML),
+          '<div>before</div><div>Condition is true</div><div>after</div>');
     });
 
     test('surrounded by parts', () => {
       function renderWhen(condition: boolean) {
-        render(html`${html`<div>before</div>`}${cachingWhen(condition,
-            () => html`<div>Condition is true</div>`,
-            () => html`<div>Condition is false</div>`
-          )}${html`<div>after</div>`}`, container);
+        render(
+            html`${html`<div>before</div>`}${
+                cachingWhen(
+                    condition,
+                    () => html`<div>Condition is true</div>`,
+                    () => html
+                    `<div>Condition is false</div>`)}${html`<div>after</div>`}`,
+            container);
       }
 
       renderWhen(true);
       renderWhen(false);
       renderWhen(true);
       assert.equal(
-        stripExpressionMarkers(container.innerHTML),
-        '<div>before</div><div>Condition is true</div><div>after</div>'
-      );
+          stripExpressionMarkers(container.innerHTML),
+          '<div>before</div><div>Condition is true</div><div>after</div>');
     });
   });
 });

--- a/src/test/directives/when_test.ts
+++ b/src/test/directives/when_test.ts
@@ -31,55 +31,60 @@ suite('when', () => {
 
   suite('if mode', () => {
     function renderWhen(condition: any) {
-      const template = html`${when(condition, () => html`<div>Condition is true</div>`)}`;
+      const template =
+          html`${when(condition, () => html`<div>Condition is true</div>`)}`;
       render(template, container);
     }
 
     test('renders the value if condition is true', () => {
       renderWhen(true);
       assert.equal(
-        stripExpressionMarkers(container.innerHTML), '<div>Condition is true</div>');
+          stripExpressionMarkers(container.innerHTML),
+          '<div>Condition is true</div>');
     });
 
     test('does not render anything when condition is false', () => {
       renderWhen(false);
-      assert.equal(
-        stripExpressionMarkers(container.innerHTML), '');
+      assert.equal(stripExpressionMarkers(container.innerHTML), '');
     });
 
     test('clears container when switching from true to false', () => {
       renderWhen(true);
       renderWhen(false);
-      assert.equal(
-        stripExpressionMarkers(container.innerHTML), '');
+      assert.equal(stripExpressionMarkers(container.innerHTML), '');
     });
   });
 
   suite('if/else mode', () => {
     function renderWhen(condition: any) {
-      const template = html`${when(condition,
-          () => html`<div>Condition is true</div>`,
-          () => html`<div>Condition is false</div>`)}`;
+      const template = html`${
+          when(
+              condition,
+              () => html`<div>Condition is true</div>`,
+              () => html`<div>Condition is false</div>`)}`;
       render(template, container);
     }
 
     test('renders the value if condition is true', () => {
       renderWhen(true);
       assert.equal(
-        stripExpressionMarkers(container.innerHTML), '<div>Condition is true</div>');
+          stripExpressionMarkers(container.innerHTML),
+          '<div>Condition is true</div>');
     });
 
     test('renders the value if condition is false', () => {
       renderWhen(false);
       assert.equal(
-        stripExpressionMarkers(container.innerHTML), '<div>Condition is false</div>');
+          stripExpressionMarkers(container.innerHTML),
+          '<div>Condition is false</div>');
     });
 
     test('renders one condition at a time when switching conditions', () => {
       renderWhen(true);
       renderWhen(false);
       assert.equal(
-        stripExpressionMarkers(container.innerHTML), '<div>Condition is false</div>');
+          stripExpressionMarkers(container.innerHTML),
+          '<div>Condition is false</div>');
     });
   });
 
@@ -87,43 +92,45 @@ suite('when', () => {
     suite('with default', () => {
       function renderWhen(condition: any) {
         const template = html`${when(condition, {
-            a: () => html`<div>Condition is a</div>`,
-            b: () => html`<div>Condition is b</div>`,
-            c: () => html`<div>Condition is c</div>`,
-            default: () => html`<div>Condition is default</div>`}
-          )}`;
+          a: () => html`<div>Condition is a</div>`,
+          b: () => html`<div>Condition is b</div>`,
+          c: () => html`<div>Condition is c</div>`,
+          default: () => html`<div>Condition is default</div>`
+        })}`;
         render(template, container);
       }
 
       test('renders the matched case', () => {
         renderWhen('a');
         assert.equal(
-          stripExpressionMarkers(container.innerHTML), '<div>Condition is a</div>');
+            stripExpressionMarkers(container.innerHTML),
+            '<div>Condition is a</div>');
       });
 
       test('renders the default case if no match', () => {
         renderWhen('foo');
         assert.equal(
-          stripExpressionMarkers(container.innerHTML), '<div>Condition is default</div>');
+            stripExpressionMarkers(container.innerHTML),
+            '<div>Condition is default</div>');
       });
 
       test('renders one condition at a time when switching conditions', () => {
         renderWhen('a');
         renderWhen('b');
         assert.equal(
-          stripExpressionMarkers(container.innerHTML), '<div>Condition is b</div>');
+            stripExpressionMarkers(container.innerHTML),
+            '<div>Condition is b</div>');
       });
     });
 
     test('renders nothing if no match and no default condition', () => {
       const template = html`${when('foo', {
-          a: () => html`<div>Condition is a</div>`,
-          b: () => html`<div>Condition is b</div>`}
-        )}`;
+        a: () => html`<div>Condition is a</div>`,
+        b: () => html`<div>Condition is b</div>`
+      })}`;
 
       render(template, container);
-      assert.equal(
-        stripExpressionMarkers(container.innerHTML), '');
+      assert.equal(stripExpressionMarkers(container.innerHTML), '');
     });
   });
 });

--- a/test/index.html
+++ b/test/index.html
@@ -20,6 +20,7 @@
     <script type="module" src="./directives/until_test.js"></script>
     <script type="module" src="./directives/unsafe-html_test.js"></script>
     <script type="module" src="./directives/when_test.js"></script>
+    <script type="module" src="./directives/caching-when_test.js"></script>
     <script type="module" src="./directives/classMap_test.js"></script>
     <script type="module" src="./directives/styleMap_test.js"></script>
     <script>


### PR DESCRIPTION
Fixes https://github.com/Polymer/lit-html/issues/552
Fixed https://github.com/Polymer/lit-html/issues/565

The cacheless `when` is just syntax sugar, and strictly speaking could be implemented as a simple function instead of a directive. For consistency I think it's better to keep it as a directive, we might want to add other things later.

The cached version becomes more complex due to the addition of the caseMap, I tried to keep it as concise as possible and share the same cache system between the if-mode and the case-mode.