### PR TITLE
Change directive() function to wrap the entire directive factory.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
    Unreleased section, uncommenting the header as necessary.
 -->
 
-<!-- ## Unreleased -->
+## Unreleased
 <!-- ### Added -->
-<!-- ### Changed -->
+### Changed
+* Directive are now defined by passing the entire directive factory function to `directive()`.
 <!-- ### Removed -->
 <!-- ### Fixed -->
 

--- a/docs/_guide/02-writing-templates.md
+++ b/docs/_guide/02-writing-templates.md
@@ -244,10 +244,16 @@ html`
 
 Directives are functions that can extend lit-html by directly interacting with the Part API.
 
-Directives will usually be created from factory functions that accept some arguments for values and configuration. Directives are created by passing a function to lit-html's `directive()` function:
+Directives are functions that accept some arguments for values and configuration and then return another function that accepts a `Part` object. Directives are created by passing a function to lit-html's `directive()` function:
 
 ```javascript
-html`<div>${directive((part) => { part.setValue('Hello')})}</div>`
+import {directive, html} from 'lit-html';
+
+const hello = directive(() => (part) => {
+  part.setValue('Hello');
+});
+
+html`<div>${hello()}</div>`
 ```
 
 The `part` argument is a `Part` object with an API for directly managing the dynamic DOM associated with expressions. See the `Part` API in api.md.
@@ -255,7 +261,9 @@ The `part` argument is a `Part` object with an API for directly managing the dyn
 Here's an example of a directive that takes a function, and evaluates it in a try/catch to implement exception safe expressions:
 
 ```javascript
-const safe = (f) => directive((part) => {
+import {directive, html, render} from 'lit-html';
+
+const safe = directive((f) => (part) => {
   try {
     return f();
   } catch (e) {
@@ -274,10 +282,13 @@ const render = () => html`foo = ${safe(_=>data.foo)}`;
 This example increments a counter on every render:
 
 ```javascript
-const render = () => html`
-  <div>
-    ${directive((part) => part.setValue((part.previousValue + 1) || 0))}
-  </div>`;
+import {directive, html, render} from 'lit-html';
+
+const counter = directive(() => (part) => {
+  part.setValue((part.previousValue + 1) || 0);
+});
+
+const template = () => html`<div>${counter()}</div>`;
 ```
 
 lit-html includes a few built-in directives:
@@ -289,7 +300,7 @@ Efficiently switches between two templates based on the given condition. The ren
 Example:
 
 ```js
-import { when } from 'lit-html/directives/when';
+import {when} from 'lit-html/directives/when';
 
 let checked = false;
 
@@ -311,7 +322,7 @@ items to values, and DOM will be reused against potentially different items.
 Example:
 
 ```javascript
-import { repeat } from 'lit-html/directives/repeat';
+import {repeat} from 'lit-html/directives/repeat';
 
 const render = () => html`
   <ul>
@@ -330,7 +341,7 @@ For other part types, this directive is a no-op.
 Example:
 
 ```javascript
-import { ifDefined } from 'lit-html/directives/if-defined';
+import {ifDefined} from 'lit-html/directives/if-defined';
 
 const render = () => html`
   <div class=${ifDefined(className)}></div>
@@ -344,7 +355,7 @@ Prevents any re-render until the identity of the expression changes, for example
 Example:
 
 ```js
-import { guard } from 'lit-html/directives/guard';
+import {guard} from 'lit-html/directives/guard';
 
 html`
   <div>
@@ -362,7 +373,7 @@ Renders `defaultContent` until `promise` resolves, then it renders the resolved 
 Example:
 
 ```javascript
-import { until } from 'lit-html/directives/until';
+import {until} from 'lit-html/directives/until';
 
 const render = () => html`
   <p>

--- a/src/directives/async-append.ts
+++ b/src/directives/async-append.ts
@@ -12,7 +12,7 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {createMarker, directive, Directive, NodePart} from '../lit-html.js';
+import {createMarker, directive, NodePart, Part} from '../lit-html.js';
 
 /**
  * A directive that renders the items of an async iterable[1], appending new
@@ -31,9 +31,12 @@ import {createMarker, directive, Directive, NodePart} from '../lit-html.js';
  * @param mapper An optional function that maps from (value, index) to another
  *     value. Useful for generating templates for each item in the iterable.
  */
-export const asyncAppend = <T>(
-    value: AsyncIterable<T>, mapper?: (v: T, index?: number) => any):
-    Directive<NodePart> => directive(async (part: NodePart) => {
+export const asyncAppend = directive(
+    <T>(value: AsyncIterable<T>,
+        mapper?: (v: T, index?: number) => any) => async (part: Part) => {
+      if (!(part instanceof NodePart)) {
+        throw new Error('asyncAppend can only be used in text bindings');
+      }
       // If we've already set up this particular iterable, we don't need
       // to do anything.
       if (value === part.value) {
@@ -47,8 +50,8 @@ export const asyncAppend = <T>(
       let i = 0;
 
       for await (let v of value) {
-        // When we get the first value, clear the part. This lets the previous
-        // value display until we can replace it.
+        // When we get the first value, clear the part. This lets the
+        // previous value display until we can replace it.
         if (i === 0) {
           part.clear();
         }

--- a/src/directives/async-replace.ts
+++ b/src/directives/async-replace.ts
@@ -12,7 +12,7 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {directive, Directive, NodePart} from '../lit-html.js';
+import {directive, NodePart, Part} from '../lit-html.js';
 
 /**
  * A directive that renders the items of an async iterable[1], replacing
@@ -32,9 +32,12 @@ import {directive, Directive, NodePart} from '../lit-html.js';
  * @param mapper An optional function that maps from (value, index) to another
  *     value. Useful for generating templates for each item in the iterable.
  */
-export const asyncReplace =
-    <T>(value: AsyncIterable<T>, mapper?: (v: T, index?: number) => any):
-        Directive<NodePart> => directive(async (part: NodePart) => {
+export const asyncReplace = directive(
+    <T>(value: AsyncIterable<T>, mapper?: (v: T, index?: number) => any) =>
+        async (part: Part) => {
+          if (!(part instanceof NodePart)) {
+            throw new Error('asyncReplace can only be used in text bindings');
+          }
           // If we've already set up this particular iterable, we don't need
           // to do anything.
           if (value === part.value) {

--- a/src/directives/classMap.ts
+++ b/src/directives/classMap.ts
@@ -12,7 +12,7 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {AttributePart, directive, Directive, PropertyPart} from '../lit-html.js';
+import {AttributePart, directive, Part, PropertyPart} from '../lit-html.js';
 
 
 // On IE11, classList.toggle doesn't accept a second argument.
@@ -57,34 +57,32 @@ const classMapStatics = new WeakMap();
  * `{foo: bar}` applies the class `foo` if the value of `bar` is truthy.
  * @param classInfo {ClassInfo}
  */
-export const classMap = (classInfo: ClassInfo): Directive<AttributePart> =>
-    directive((part: AttributePart) => {
-      if (!(part instanceof AttributePart) || (part instanceof PropertyPart) ||
-          part.committer.name !== 'class' || part.committer.parts.length > 1) {
-        throw new Error(
-            'The `classMap` directive must be used in the `class` attribute ' +
-            'and must be the only part in the attribute.');
-      }
-      // handle static classes
-      if (!classMapStatics.has(part)) {
-        part.committer.element.className = part.committer.strings.join(' ');
-        classMapStatics.set(part, true);
-      }
-      // remove old classes that no longer apply
-      const oldInfo = classMapCache.get(part);
-      for (const name in oldInfo) {
-        if (!(name in classInfo)) {
-          part.committer.element.classList.remove(name);
-        }
-      }
-      // add new classes
-      for (const name in classInfo) {
-        if (!oldInfo || (oldInfo[name] !== classInfo[name])) {
-          // We explicitly want a loose truthy check here because
-          // it seems more convenient that '' and 0 are skipped.
-          part.committer.element.classList.toggle(
-              name, Boolean(classInfo[name]));
-        }
-      }
-      classMapCache.set(part, classInfo);
-    });
+export const classMap = directive((classInfo: ClassInfo) => (part: Part) => {
+  if (!(part instanceof AttributePart) || (part instanceof PropertyPart) ||
+      part.committer.name !== 'class' || part.committer.parts.length > 1) {
+    throw new Error(
+        'The `classMap` directive must be used in the `class` attribute ' +
+        'and must be the only part in the attribute.');
+  }
+  // handle static classes
+  if (!classMapStatics.has(part)) {
+    part.committer.element.className = part.committer.strings.join(' ');
+    classMapStatics.set(part, true);
+  }
+  // remove old classes that no longer apply
+  const oldInfo = classMapCache.get(part);
+  for (const name in oldInfo) {
+    if (!(name in classInfo)) {
+      part.committer.element.classList.remove(name);
+    }
+  }
+  // add new classes
+  for (const name in classInfo) {
+    if (!oldInfo || (oldInfo[name] !== classInfo[name])) {
+      // We explicitly want a loose truthy check here because
+      // it seems more convenient that '' and 0 are skipped.
+      part.committer.element.classList.toggle(name, Boolean(classInfo[name]));
+    }
+  }
+  classMapCache.set(part, classInfo);
+});

--- a/src/directives/guard.ts
+++ b/src/directives/guard.ts
@@ -12,9 +12,9 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {directive, Directive, NodePart} from '../lit-html.js';
+import {directive, Part} from '../lit-html.js';
 
-const previousExpressions = new WeakMap<NodePart, any>();
+const previousExpressions = new WeakMap<Part, any>();
 
 /**
  * Creates a guard directive. Prevents any re-render until the identity of the
@@ -36,13 +36,12 @@ const previousExpressions = new WeakMap<NodePart, any>();
  * @param valueFn function which returns the render value
  */
 export const guard =
-    (expression: any, valueFn: () => any): Directive<NodePart> =>
-        directive((part: NodePart): void => {
-          // Dirty check previous expression
-          if (previousExpressions.get(part) === expression) {
-            return;
-          }
+    directive((expression: any, valueFn: () => any) => (part: Part): void => {
+      // Dirty check previous expression
+      if (previousExpressions.get(part) === expression) {
+        return;
+      }
 
-          part.setValue(valueFn());
-          previousExpressions.set(part, expression);
-        });
+      part.setValue(valueFn());
+      previousExpressions.set(part, expression);
+    });

--- a/src/directives/if-defined.ts
+++ b/src/directives/if-defined.ts
@@ -12,7 +12,7 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {AttributePart, directive, Directive, Part} from '../lit-html.js';
+import {AttributePart, directive, Part} from '../lit-html.js';
 
 /**
  * For AttributeParts, sets the attribute if the value is defined and removes
@@ -20,14 +20,13 @@ import {AttributePart, directive, Directive, Part} from '../lit-html.js';
  *
  * For other part types, this directive is a no-op.
  */
-export const ifDefined = (value: any): Directive<Part> =>
-    directive((part: Part) => {
-      if (value === undefined && part instanceof AttributePart) {
-        if (value !== part.value) {
-          const name = part.committer.name;
-          part.committer.element.removeAttribute(name);
-        }
-      } else {
-        part.setValue(value);
-      }
-    });
+export const ifDefined = directive((value: any) => (part: Part) => {
+  if (value === undefined && part instanceof AttributePart) {
+    if (value !== part.value) {
+      const name = part.committer.name;
+      part.committer.element.removeAttribute(name);
+    }
+  } else {
+    part.setValue(value);
+  }
+});

--- a/src/directives/repeat.ts
+++ b/src/directives/repeat.ts
@@ -12,7 +12,8 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {createMarker, directive, Directive, NodePart, removeNodes, reparentNodes} from '../lit-html.js';
+import {DirectiveFn} from '../lib/directive.js';
+import {createMarker, directive, NodePart, Part, removeNodes, reparentNodes} from '../lit-html.js';
 
 export type KeyFn<T> = (item: T, index?: number) => any;
 export type ItemTemplate<T> = (item: T, index?: number) => any;
@@ -79,322 +80,340 @@ const keyListCache = new WeakMap<NodePart, unknown[]>();
  * way to use `repeat` since it performs minimum unnecessary work for insertions
  * amd removals.
  *
- * IMPORTANT: if providing a `keyFn`, keys *must* be unique for all items in a
- * given call to `repeat`. The behavior when providing duplicate keys is
- * undefined.
+ * IMPORTANT: If providing a `keyFn`, keys *must* be unique for all items in a
+ * given call to `repeat`. The behavior when two or more items have the same key
+ * is undefined.
  *
  * If no `keyFn` is provided, this directive will perform similar to mapping
  * items to values, and DOM will be reused against potentially different items.
  */
-export function repeat<T>(
-    items: Iterable<T>, keyFn: KeyFn<T>, template: ItemTemplate<T>):
-    Directive<NodePart>;
-export function repeat<T>(
-    items: Iterable<T>, template: ItemTemplate<T>): Directive<NodePart>;
-export function repeat<T>(
-    items: Iterable<T>,
-    keyFnOrTemplate: KeyFn<T>|ItemTemplate<T>,
-    template?: ItemTemplate<T>): Directive<NodePart> {
-  let keyFn: KeyFn<T>;
-  if (arguments.length === 2) {
-    template = keyFnOrTemplate;
-  } else if (arguments.length === 3) {
-    keyFn = keyFnOrTemplate as KeyFn<T>;
-  }
+export const repeat = directive(
+    <T>(items: Iterable<T>,
+        keyFnOrTemplate: KeyFn<T>|ItemTemplate<T>,
+        template?: ItemTemplate<T>): DirectiveFn => {
+      let keyFn: KeyFn<T>;
+      if (template === undefined) {
+        template = keyFnOrTemplate;
+      } else if (keyFnOrTemplate !== undefined) {
+        keyFn = keyFnOrTemplate as KeyFn<T>;
+      }
 
-  return directive((containerPart: NodePart): void => {
-    // Old part & key lists are retrieved from the last update (associated with
-    // the part for this instance of the directive)
-    const oldParts = partListCache.get(containerPart) || [];
-    const oldKeys = keyListCache.get(containerPart) || [];
-
-    // New part list will be built up as we go (either reused from old parts or
-    // created for new keys in this update). This is saved in the above cache
-    // at the end of the update.
-    const newParts: NodePart[] = [];
-
-    // New value list is eagerly generated from items along with a parallel
-    // array indicating its key.
-    const newValues: unknown[] = [];
-    const newKeys: unknown[] = [];
-    let index = 0;
-    for (const item of items) {
-      newKeys[index] = keyFn ? keyFn(item, index) : index;
-      newValues[index] = template !(item, index);
-      index++;
-    }
-
-    // Maps from key to index for current and previous update; these are
-    // generated lazily only when needed as a performance optimization, since
-    // they are only required for multiple non-contiguous changes in the list,
-    // which are less common.
-    let newKeyToIndexMap!: Map<unknown, number>;
-    let oldKeyToIndexMap!: Map<unknown, number>;
-
-    // Head and tail pointers to old parts and new values
-    let oldHead = 0;
-    let oldTail = oldParts.length - 1;
-    let newHead = 0;
-    let newTail = newValues.length - 1;
-
-    // Overview of O(n) reconciliation algorithm (general approach based on
-    // ideas found in ivi, vue, snabbdom, etc.):
-    //
-    // * We start with the list of old parts and new values (and arrays of
-    //   their respective keys), head/tail pointers into each, and we build
-    //   up the new list of parts by updating (and when needed, moving) old
-    //   parts or creating new ones. The initial scenario might look like this
-    //   (for brevity of the diagrams, the numbers in the array reflect keys
-    //   associated with the old parts or new values, although keys and
-    //   parts/values are actually stored in parallel arrays indexed using the
-    //   same head/tail pointers):
-    //
-    //      oldHead v                 v oldTail
-    //   oldKeys:  [0, 1, 2, 3, 4, 5, 6]
-    //   newParts: [ ,  ,  ,  ,  ,  ,  ]
-    //   newKeys:  [0, 2, 1, 4, 3, 7, 6] <- reflects the user's new item order
-    //      newHead ^                 ^ newTail
-    //
-    // * Iterate old & new lists from both sides, updating, swapping, or
-    //   removing parts at the head/tail locations until neither head nor tail
-    //   can move.
-    //
-    // * Example below: keys at head pointers match, so update old part 0 in-
-    //   place (no need to move it) and record part 0 in the `newParts` list.
-    //   The last thing we do is advance the `oldHead` and `newHead` pointers
-    //   (will be reflected in the next diagram).
-    //
-    //      oldHead v                 v oldTail
-    //   oldKeys:  [0, 1, 2, 3, 4, 5, 6]
-    //   newParts: [0,  ,  ,  ,  ,  ,  ] <- heads matched: update 0 and
-    //   newKeys:  [0, 2, 1, 4, 3, 7, 6]    advance both oldHead & newHead
-    //      newHead ^                 ^ newTail
-    //
-    // * Example below: head pointers don't match, but tail pointers do, so
-    //   update part 6 in place (no need to move it), and record part 6 in the
-    //   `newParts` list. Last, advance the `oldTail` and `oldHead` pointers.
-    //
-    //         oldHead v              v oldTail
-    //   oldKeys:  [0, 1, 2, 3, 4, 5, 6]
-    //   newParts: [0,  ,  ,  ,  ,  , 6] <- tails matched: update 6 and
-    //   newKeys:  [0, 2, 1, 4, 3, 7, 6]    advance both oldTail & newTail
-    //         newHead ^              ^ newTail
-    //
-    // * If neither head nor tail match; next check if one of the old head/tail
-    //   items was removed. We first need to generate the reverse map of new
-    //   keys to index (`newKeyToIndexMap`), which is done once lazily as a
-    //   performance optimization, since we only hit this case if multiple
-    //   non-contiguous changes were made. Note that for contiguous removal
-    //   anywhere in the list, the head and tails would advance from either end
-    //   and pass each other before we get to this case and removals would be
-    //   handled in the final while loop without needing to generate the map.
-    //
-    // * Example below: The key at `oldTail` was removed (no longer in the
-    //   `newKeyToIndexMap`), so remove that part from the DOM and advance just
-    //   the `oldTail` pointer.
-    //
-    //         oldHead v           v oldTail
-    //   oldKeys:  [0, 1, 2, 3, 4, 5, 6]
-    //   newParts: [0,  ,  ,  ,  ,  , 6] <- 5 not in new map; remove 5 and
-    //   newKeys:  [0, 2, 1, 4, 3, 7, 6]    advance oldTail
-    //         newHead ^           ^ newTail
-    //
-    // * Once head and tail cannot move, any mismatches are due to either new or
-    //   moved items; if a new key is in the previous "old key to old index"
-    //   map, move the old part to the new location, otherwise create and insert
-    //   a new part. Note that when moving an old part we null its position in
-    //   the oldParts array if it lies between the head and tail so we know to
-    //   skip it when the pointers get there.
-    //
-    // * Example below: neither head nor tail match, and neither were removed;
-    //   so find the `newHead` key in the `oldKeyToIndexMap`, and move that old
-    //   part's DOM into the next head position (before `oldParts[oldHead]`).
-    //   Last, null the part in the `oldPart` array since it was somewhere in
-    //   the remaining oldParts still to be scanned (between the head and tail
-    //   pointers) so that we know to skip that old part on future iterations.
-    //
-    //         oldHead v        v oldTail
-    //   oldKeys:  [0, 1, -, 3, 4, 5, 6]
-    //   newParts: [0, 2,  ,  ,  ,  , 6] <- stuck; update & move 2 into place
-    //   newKeys:  [0, 2, 1, 4, 3, 7, 6]    and advance newHead
-    //         newHead ^           ^ newTail
-    //
-    // * Note that for moves/insertions like the one above, a part inserted at
-    //   the head pointer is inserted before the current `oldParts[oldHead]`,
-    //   and a part inserted at the tail pointer is inserted before
-    //   `newParts[newTail+1]`. The seeming asymmetry lies in the fact that new
-    //   parts are moved into place outside in, so to the right of the head
-    //   pointer are old parts, and to the right of the tail pointer are new
-    //   parts.
-    //
-    // * We always restart back from the top of the algorithm, allowing matching
-    //   and simple updates in place to continue...
-    //
-    // * Example below: the head pointers once again match, so simply update
-    //   part 1 and record it in the `newParts` array.  Last, advance both head
-    //   pointers.
-    //
-    //         oldHead v        v oldTail
-    //   oldKeys:  [0, 1, -, 3, 4, 5, 6]
-    //   newParts: [0, 2, 1,  ,  ,  , 6] <- heads matched; update 1 and
-    //   newKeys:  [0, 2, 1, 4, 3, 7, 6]    advance both oldHead & newHead
-    //            newHead ^        ^ newTail
-    //
-    // * As mentioned above, items that were moved as a result of being stuck
-    //   (the final else clause in the code below) are marked with null, so we
-    //   always advance old pointers over these so we're comparing the next
-    //   actual old value on either end.
-    //
-    // * Example below: `oldHead` is null (already placed in newParts), so
-    //   advance `oldHead`.
-    //
-    //            oldHead v     v oldTail
-    //   oldKeys:  [0, 1, -, 3, 4, 5, 6] // old head already used; advance
-    //   newParts: [0, 2, 1,  ,  ,  , 6] // oldHead
-    //   newKeys:  [0, 2, 1, 4, 3, 7, 6]
-    //               newHead ^     ^ newTail
-    //
-    // * Note it's not critical to mark old parts as null when they are moved
-    //   from head to tail or tail to head, since they will be outside the
-    //   pointer range and never visited again.
-    //
-    // * Example below: Here the old tail key matches the new head key, so
-    //   the part at the `oldTail` position and move its DOM to the new
-    //   head position (before `oldParts[oldHead]`). Last, advance `oldTail`
-    //   and `newHead` pointers.
-    //
-    //               oldHead v  v oldTail
-    //   oldKeys:  [0, 1, -, 3, 4, 5, 6]
-    //   newParts: [0, 2, 1, 4,  ,  , 6] <- old tail matches new head: update
-    //   newKeys:  [0, 2, 1, 4, 3, 7, 6]   & move 4, advance oldTail & newHead
-    //               newHead ^     ^ newTail
-    //
-    // * Example below: Old and new head keys match, so update the old head
-    //   part in place, and advance the `oldHead` and `newHead` pointers.
-    //
-    //               oldHead v oldTail
-    //   oldKeys:  [0, 1, -, 3, 4, 5, 6]
-    //   newParts: [0, 2, 1, 4, 3,   ,6] <- heads match: update 3 and advance
-    //   newKeys:  [0, 2, 1, 4, 3, 7, 6]    oldHead & newHead
-    //                  newHead ^  ^ newTail
-    //
-    // * Once the new or old pointers move past each other then all we have
-    //   left is additions (if old list exhausted) or removals (if new list
-    //   exhausted). Those are handled in the final while loops at the end.
-    //
-    // * Example below: `oldHead` exceeded `oldTail`, so we're done with the
-    //   main loop.  Create the remaining part and insert it at the new head
-    //   position, and the update is complete.
-    //
-    //                   (oldHead > oldTail)
-    //   oldKeys:  [0, 1, -, 3, 4, 5, 6]
-    //   newParts: [0, 2, 1, 4, 3, 7 ,6] <- create and insert 7
-    //   newKeys:  [0, 2, 1, 4, 3, 7, 6]
-    //                     newHead ^ newTail
-    //
-    // * Note that the order of the if/else clauses is not important to the
-    //   algorithm, as long as the null checks come first (to ensure we're
-    //   always working on valid old parts) and that the final else clause
-    //   comes last (since that's where the expensive moves occur). The
-    //   order of remaining clauses is is just a simple guess at which cases
-    //   will be most common.
-    //
-    // * TODO(kschaaf) Note, we could calculate the longest increasing
-    //   subsequence (LIS) of old items in new position, and only move those not
-    //   in the LIS set. However that costs O(nlogn) time and adds a bit more
-    //   code, and only helps make rare types of mutations require fewer moves.
-    //   The above handles removes, adds, reversal, swaps, and single moves of
-    //   contiguous items in linear time, in the minimum number of moves. As
-    //   the number of multiple moves where LIS might help approaches a random
-    //   shuffle, the LIS optimization becomes less helpful, so it seems not
-    //   worth the code at this point. Could reconsider if a compelling case
-    //   arises.
-
-    while (oldHead <= oldTail && newHead <= newTail) {
-      if (oldParts[oldHead] === null) {
-        // `null` means old part at head has already been used below; skip
-        oldHead++;
-      } else if (oldParts[oldTail] === null) {
-        // `null` means old part at tail has already been used below; skip
-        oldTail--;
-      } else if (oldKeys[oldHead] === newKeys[newHead]) {
-        // Old head matches new head; update in place
-        newParts[newHead] = updatePart(oldParts[oldHead]!, newValues[newHead]);
-        oldHead++;
-        newHead++;
-      } else if (oldKeys[oldTail] === newKeys[newTail]) {
-        // Old tail matches new tail; update in place
-        newParts[newTail] = updatePart(oldParts[oldTail]!, newValues[newTail]);
-        oldTail--;
-        newTail--;
-      } else if (oldKeys[oldHead] === newKeys[newTail]) {
-        // Old head matches new tail; update and move to new tail
-        newParts[newTail] = updatePart(oldParts[oldHead]!, newValues[newTail]);
-        insertPartBefore(
-            containerPart, oldParts[oldHead]!, newParts[newTail + 1]);
-        oldHead++;
-        newTail--;
-      } else if (oldKeys[oldTail] === newKeys[newHead]) {
-        // Old tail matches new head; update and move to new head
-        newParts[newHead] = updatePart(oldParts[oldTail]!, newValues[newHead]);
-        insertPartBefore(containerPart, oldParts[oldTail]!, oldParts[oldHead]!);
-        oldTail--;
-        newHead++;
-      } else {
-        if (newKeyToIndexMap === undefined) {
-          // Lazily generate key-to-index maps, used for removals & moves below
-          newKeyToIndexMap = generateMap(newKeys, newHead, newTail);
-          oldKeyToIndexMap = generateMap(oldKeys, oldHead, oldTail);
+      return (containerPart: Part): void => {
+        if (!(containerPart instanceof NodePart)) {
+          throw new Error('repeat can only be used in text bindings');
         }
-        if (!newKeyToIndexMap.has(oldKeys[oldHead])) {
-          // Old head is no longer in new list; remove
-          removePart(oldParts[oldHead]!);
-          oldHead++;
-        } else if (!newKeyToIndexMap.has(oldKeys[oldTail])) {
-          // Old tail is no longer in new list; remove
-          removePart(oldParts[oldTail]!);
-          oldTail--;
-        } else {
-          // Any mismatches at this point are due to additions or moves; see if
-          // we have an old part we can reuse and move into place
-          const oldIndex = oldKeyToIndexMap.get(newKeys[newHead]);
-          const oldPart = oldIndex !== undefined ? oldParts[oldIndex] : null;
-          if (oldPart === null) {
-            // No old part for this value; create a new one and insert it
-            const newPart =
-                createAndInsertPart(containerPart, oldParts[oldHead]!);
-            updatePart(newPart, newValues[newHead]);
-            newParts[newHead] = newPart;
+        // Old part & key lists are retrieved from the last update (associated
+        // with the part for this instance of the directive)
+        const oldParts = partListCache.get(containerPart) || [];
+        const oldKeys = keyListCache.get(containerPart) || [];
+
+        // New part list will be built up as we go (either reused from old parts
+        // or created for new keys in this update). This is saved in the above
+        // cache at the end of the update.
+        const newParts: NodePart[] = [];
+
+        // New value list is eagerly generated from items along with a parallel
+        // array indicating its key.
+        const newValues: unknown[] = [];
+        const newKeys: unknown[] = [];
+        let index = 0;
+        for (const item of items) {
+          newKeys[index] = keyFn ? keyFn(item, index) : index;
+          newValues[index] = template !(item, index);
+          index++;
+        }
+
+        // Maps from key to index for current and previous update; these are
+        // generated lazily only when needed as a performance optimization,
+        // since they are only required for multiple non-contiguous changes in
+        // the list, which are less common.
+        let newKeyToIndexMap!: Map<unknown, number>;
+        let oldKeyToIndexMap!: Map<unknown, number>;
+
+        // Head and tail pointers to old parts and new values
+        let oldHead = 0;
+        let oldTail = oldParts.length - 1;
+        let newHead = 0;
+        let newTail = newValues.length - 1;
+
+        // Overview of O(n) reconciliation algorithm (general approach based on
+        // ideas found in ivi, vue, snabbdom, etc.):
+        //
+        // * We start with the list of old parts and new values (and arrays of
+        //   their respective keys), head/tail pointers into each, and we build
+        //   up the new list of parts by updating (and when needed, moving) old
+        //   parts or creating new ones. The initial scenario might look like
+        //   this (for brevity of the diagrams, the numbers in the array reflect
+        //   keys associated with the old parts or new values, although keys and
+        //   parts/values are actually stored in parallel arrays indexed using
+        //   the same head/tail pointers):
+        //
+        //      oldHead v                 v oldTail
+        //   oldKeys:  [0, 1, 2, 3, 4, 5, 6]
+        //   newParts: [ ,  ,  ,  ,  ,  ,  ]
+        //   newKeys:  [0, 2, 1, 4, 3, 7, 6] <- reflects the user's new item
+        //   order
+        //      newHead ^                 ^ newTail
+        //
+        // * Iterate old & new lists from both sides, updating, swapping, or
+        //   removing parts at the head/tail locations until neither head nor
+        //   tail can move.
+        //
+        // * Example below: keys at head pointers match, so update old part 0
+        // in-
+        //   place (no need to move it) and record part 0 in the `newParts`
+        //   list. The last thing we do is advance the `oldHead` and `newHead`
+        //   pointers (will be reflected in the next diagram).
+        //
+        //      oldHead v                 v oldTail
+        //   oldKeys:  [0, 1, 2, 3, 4, 5, 6]
+        //   newParts: [0,  ,  ,  ,  ,  ,  ] <- heads matched: update 0 and
+        //   newKeys:  [0, 2, 1, 4, 3, 7, 6]    advance both oldHead & newHead
+        //      newHead ^                 ^ newTail
+        //
+        // * Example below: head pointers don't match, but tail pointers do, so
+        //   update part 6 in place (no need to move it), and record part 6 in
+        //   the `newParts` list. Last, advance the `oldTail` and `oldHead`
+        //   pointers.
+        //
+        //         oldHead v              v oldTail
+        //   oldKeys:  [0, 1, 2, 3, 4, 5, 6]
+        //   newParts: [0,  ,  ,  ,  ,  , 6] <- tails matched: update 6 and
+        //   newKeys:  [0, 2, 1, 4, 3, 7, 6]    advance both oldTail & newTail
+        //         newHead ^              ^ newTail
+        //
+        // * If neither head nor tail match; next check if one of the old
+        // head/tail
+        //   items was removed. We first need to generate the reverse map of new
+        //   keys to index (`newKeyToIndexMap`), which is done once lazily as a
+        //   performance optimization, since we only hit this case if multiple
+        //   non-contiguous changes were made. Note that for contiguous removal
+        //   anywhere in the list, the head and tails would advance from either
+        //   end and pass each other before we get to this case and removals
+        //   would be handled in the final while loop without needing to
+        //   generate the map.
+        //
+        // * Example below: The key at `oldTail` was removed (no longer in the
+        //   `newKeyToIndexMap`), so remove that part from the DOM and advance
+        //   just the `oldTail` pointer.
+        //
+        //         oldHead v           v oldTail
+        //   oldKeys:  [0, 1, 2, 3, 4, 5, 6]
+        //   newParts: [0,  ,  ,  ,  ,  , 6] <- 5 not in new map; remove 5 and
+        //   newKeys:  [0, 2, 1, 4, 3, 7, 6]    advance oldTail
+        //         newHead ^           ^ newTail
+        //
+        // * Once head and tail cannot move, any mismatches are due to either
+        // new or
+        //   moved items; if a new key is in the previous "old key to old index"
+        //   map, move the old part to the new location, otherwise create and
+        //   insert a new part. Note that when moving an old part we null its
+        //   position in the oldParts array if it lies between the head and tail
+        //   so we know to skip it when the pointers get there.
+        //
+        // * Example below: neither head nor tail match, and neither were
+        // removed;
+        //   so find the `newHead` key in the `oldKeyToIndexMap`, and move that
+        //   old part's DOM into the next head position (before
+        //   `oldParts[oldHead]`). Last, null the part in the `oldPart` array
+        //   since it was somewhere in the remaining oldParts still to be
+        //   scanned (between the head and tail pointers) so that we know to
+        //   skip that old part on future iterations.
+        //
+        //         oldHead v        v oldTail
+        //   oldKeys:  [0, 1, -, 3, 4, 5, 6]
+        //   newParts: [0, 2,  ,  ,  ,  , 6] <- stuck; update & move 2 into
+        //   place newKeys:  [0, 2, 1, 4, 3, 7, 6]    and advance newHead
+        //         newHead ^           ^ newTail
+        //
+        // * Note that for moves/insertions like the one above, a part inserted
+        // at
+        //   the head pointer is inserted before the current
+        //   `oldParts[oldHead]`, and a part inserted at the tail pointer is
+        //   inserted before `newParts[newTail+1]`. The seeming asymmetry lies
+        //   in the fact that new parts are moved into place outside in, so to
+        //   the right of the head pointer are old parts, and to the right of
+        //   the tail pointer are new parts.
+        //
+        // * We always restart back from the top of the algorithm, allowing
+        // matching
+        //   and simple updates in place to continue...
+        //
+        // * Example below: the head pointers once again match, so simply update
+        //   part 1 and record it in the `newParts` array.  Last, advance both
+        //   head pointers.
+        //
+        //         oldHead v        v oldTail
+        //   oldKeys:  [0, 1, -, 3, 4, 5, 6]
+        //   newParts: [0, 2, 1,  ,  ,  , 6] <- heads matched; update 1 and
+        //   newKeys:  [0, 2, 1, 4, 3, 7, 6]    advance both oldHead & newHead
+        //            newHead ^        ^ newTail
+        //
+        // * As mentioned above, items that were moved as a result of being
+        // stuck
+        //   (the final else clause in the code below) are marked with null, so
+        //   we always advance old pointers over these so we're comparing the
+        //   next actual old value on either end.
+        //
+        // * Example below: `oldHead` is null (already placed in newParts), so
+        //   advance `oldHead`.
+        //
+        //            oldHead v     v oldTail
+        //   oldKeys:  [0, 1, -, 3, 4, 5, 6] // old head already used; advance
+        //   newParts: [0, 2, 1,  ,  ,  , 6] // oldHead
+        //   newKeys:  [0, 2, 1, 4, 3, 7, 6]
+        //               newHead ^     ^ newTail
+        //
+        // * Note it's not critical to mark old parts as null when they are
+        // moved
+        //   from head to tail or tail to head, since they will be outside the
+        //   pointer range and never visited again.
+        //
+        // * Example below: Here the old tail key matches the new head key, so
+        //   the part at the `oldTail` position and move its DOM to the new
+        //   head position (before `oldParts[oldHead]`). Last, advance `oldTail`
+        //   and `newHead` pointers.
+        //
+        //               oldHead v  v oldTail
+        //   oldKeys:  [0, 1, -, 3, 4, 5, 6]
+        //   newParts: [0, 2, 1, 4,  ,  , 6] <- old tail matches new head:
+        //   update newKeys:  [0, 2, 1, 4, 3, 7, 6]   & move 4, advance oldTail
+        //   & newHead
+        //               newHead ^     ^ newTail
+        //
+        // * Example below: Old and new head keys match, so update the old head
+        //   part in place, and advance the `oldHead` and `newHead` pointers.
+        //
+        //               oldHead v oldTail
+        //   oldKeys:  [0, 1, -, 3, 4, 5, 6]
+        //   newParts: [0, 2, 1, 4, 3,   ,6] <- heads match: update 3 and
+        //   advance newKeys:  [0, 2, 1, 4, 3, 7, 6]    oldHead & newHead
+        //                  newHead ^  ^ newTail
+        //
+        // * Once the new or old pointers move past each other then all we have
+        //   left is additions (if old list exhausted) or removals (if new list
+        //   exhausted). Those are handled in the final while loops at the end.
+        //
+        // * Example below: `oldHead` exceeded `oldTail`, so we're done with the
+        //   main loop.  Create the remaining part and insert it at the new head
+        //   position, and the update is complete.
+        //
+        //                   (oldHead > oldTail)
+        //   oldKeys:  [0, 1, -, 3, 4, 5, 6]
+        //   newParts: [0, 2, 1, 4, 3, 7 ,6] <- create and insert 7
+        //   newKeys:  [0, 2, 1, 4, 3, 7, 6]
+        //                     newHead ^ newTail
+        //
+        // * Note that the order of the if/else clauses is not important to the
+        //   algorithm, as long as the null checks come first (to ensure we're
+        //   always working on valid old parts) and that the final else clause
+        //   comes last (since that's where the expensive moves occur). The
+        //   order of remaining clauses is is just a simple guess at which cases
+        //   will be most common.
+        //
+        // * TODO(kschaaf) Note, we could calculate the longest increasing
+        //   subsequence (LIS) of old items in new position, and only move those
+        //   not in the LIS set. However that costs O(nlogn) time and adds a bit
+        //   more code, and only helps make rare types of mutations require
+        //   fewer moves. The above handles removes, adds, reversal, swaps, and
+        //   single moves of contiguous items in linear time, in the minimum
+        //   number of moves. As the number of multiple moves where LIS might
+        //   help approaches a random shuffle, the LIS optimization becomes less
+        //   helpful, so it seems not worth the code at this point. Could
+        //   reconsider if a compelling case arises.
+
+        while (oldHead <= oldTail && newHead <= newTail) {
+          if (oldParts[oldHead] === null) {
+            // `null` means old part at head has already been used below; skip
+            oldHead++;
+          } else if (oldParts[oldTail] === null) {
+            // `null` means old part at tail has already been used below; skip
+            oldTail--;
+          } else if (oldKeys[oldHead] === newKeys[newHead]) {
+            // Old head matches new head; update in place
+            newParts[newHead] =
+                updatePart(oldParts[oldHead]!, newValues[newHead]);
+            oldHead++;
+            newHead++;
+          } else if (oldKeys[oldTail] === newKeys[newTail]) {
+            // Old tail matches new tail; update in place
+            newParts[newTail] =
+                updatePart(oldParts[oldTail]!, newValues[newTail]);
+            oldTail--;
+            newTail--;
+          } else if (oldKeys[oldHead] === newKeys[newTail]) {
+            // Old head matches new tail; update and move to new tail
+            newParts[newTail] =
+                updatePart(oldParts[oldHead]!, newValues[newTail]);
+            insertPartBefore(
+                containerPart, oldParts[oldHead]!, newParts[newTail + 1]);
+            oldHead++;
+            newTail--;
+          } else if (oldKeys[oldTail] === newKeys[newHead]) {
+            // Old tail matches new head; update and move to new head
+            newParts[newHead] =
+                updatePart(oldParts[oldTail]!, newValues[newHead]);
+            insertPartBefore(
+                containerPart, oldParts[oldTail]!, oldParts[oldHead]!);
+            oldTail--;
+            newHead++;
           } else {
-            // Reuse old part
-            newParts[newHead] = updatePart(oldPart, newValues[newHead]);
-            insertPartBefore(containerPart, oldPart, oldParts[oldHead]!);
-            // This marks the old part as having been used, so that it will be
-            // skipped in the first two checks above
-            oldParts[oldIndex as number] = null;
+            if (newKeyToIndexMap === undefined) {
+              // Lazily generate key-to-index maps, used for removals & moves
+              // below
+              newKeyToIndexMap = generateMap(newKeys, newHead, newTail);
+              oldKeyToIndexMap = generateMap(oldKeys, oldHead, oldTail);
+            }
+            if (!newKeyToIndexMap.has(oldKeys[oldHead])) {
+              // Old head is no longer in new list; remove
+              removePart(oldParts[oldHead]!);
+              oldHead++;
+            } else if (!newKeyToIndexMap.has(oldKeys[oldTail])) {
+              // Old tail is no longer in new list; remove
+              removePart(oldParts[oldTail]!);
+              oldTail--;
+            } else {
+              // Any mismatches at this point are due to additions or moves; see
+              // if we have an old part we can reuse and move into place
+              const oldIndex = oldKeyToIndexMap.get(newKeys[newHead]);
+              const oldPart =
+                  oldIndex !== undefined ? oldParts[oldIndex] : null;
+              if (oldPart === null) {
+                // No old part for this value; create a new one and insert it
+                const newPart =
+                    createAndInsertPart(containerPart, oldParts[oldHead]!);
+                updatePart(newPart, newValues[newHead]);
+                newParts[newHead] = newPart;
+              } else {
+                // Reuse old part
+                newParts[newHead] = updatePart(oldPart, newValues[newHead]);
+                insertPartBefore(containerPart, oldPart, oldParts[oldHead]!);
+                // This marks the old part as having been used, so that it will
+                // be skipped in the first two checks above
+                oldParts[oldIndex as number] = null;
+              }
+              newHead++;
+            }
           }
-          newHead++;
         }
-      }
-    }
-    // Add parts for any remaining new values
-    while (newHead <= newTail) {
-      // For all remaining additions, we insert before last new tail,
-      // since old pointers are no longer valid
-      const newPart =
-          createAndInsertPart(containerPart, newParts[newTail + 1]!);
-      updatePart(newPart, newValues[newHead]);
-      newParts[newHead++] = newPart;
-    }
-    // Remove any remaining unused old parts
-    while (oldHead <= oldTail) {
-      const oldPart = oldParts[oldHead++];
-      if (oldPart !== null) {
-        removePart(oldPart);
-      }
-    }
-    // Save order of new parts for next round
-    partListCache.set(containerPart, newParts);
-    keyListCache.set(containerPart, newKeys);
-  });
-}
+        // Add parts for any remaining new values
+        while (newHead <= newTail) {
+          // For all remaining additions, we insert before last new tail,
+          // since old pointers are no longer valid
+          const newPart =
+              createAndInsertPart(containerPart, newParts[newTail + 1]!);
+          updatePart(newPart, newValues[newHead]);
+          newParts[newHead++] = newPart;
+        }
+        // Remove any remaining unused old parts
+        while (oldHead <= oldTail) {
+          const oldPart = oldParts[oldHead++];
+          if (oldPart !== null) {
+            removePart(oldPart);
+          }
+        }
+        // Save order of new parts for next round
+        partListCache.set(containerPart, newParts);
+        keyListCache.set(containerPart, newKeys);
+      };
+    });

--- a/src/directives/styleMap.ts
+++ b/src/directives/styleMap.ts
@@ -12,7 +12,7 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {AttributePart, directive, Directive, PropertyPart} from '../lit-html.js';
+import {AttributePart, directive, Part, PropertyPart} from '../lit-html.js';
 
 export interface StyleInfo {
   [name: string]: string;
@@ -40,27 +40,26 @@ const styleMapStatics = new WeakMap();
  * sets these properties to the element's style.
  * @param styleInfo {StyleInfo}
  */
-export const styleMap = (styleInfo: StyleInfo): Directive<AttributePart> =>
-    directive((part: AttributePart) => {
-      if (!(part instanceof AttributePart) || (part instanceof PropertyPart) ||
-          part.committer.name !== 'style' || part.committer.parts.length > 1) {
-        throw new Error(
-            'The `styleMap` directive must be used in the style attribute ' +
-            'and must be the only part in the attribute.');
-      }
-      // handle static styles
-      if (!styleMapStatics.has(part)) {
-        (part.committer.element as HTMLElement).style.cssText =
-            part.committer.strings.join(' ');
-        styleMapStatics.set(part, true);
-      }
-      // remove old styles that no longer apply
-      const oldInfo = styleMapCache.get(part);
-      for (const name in oldInfo) {
-        if (!(name in styleInfo)) {
-          ((part.committer.element as HTMLElement).style as any)[name] = null;
-        }
-      }
-      Object.assign((part.committer.element as HTMLElement).style, styleInfo);
-      styleMapCache.set(part, styleInfo);
-    });
+export const styleMap = directive((styleInfo: StyleInfo) => (part: Part) => {
+  if (!(part instanceof AttributePart) || (part instanceof PropertyPart) ||
+      part.committer.name !== 'style' || part.committer.parts.length > 1) {
+    throw new Error(
+        'The `styleMap` directive must be used in the style attribute ' +
+        'and must be the only part in the attribute.');
+  }
+  // handle static styles
+  if (!styleMapStatics.has(part)) {
+    (part.committer.element as HTMLElement).style.cssText =
+        part.committer.strings.join(' ');
+    styleMapStatics.set(part, true);
+  }
+  // remove old styles that no longer apply
+  const oldInfo = styleMapCache.get(part);
+  for (const name in oldInfo) {
+    if (!(name in styleInfo)) {
+      ((part.committer.element as HTMLElement).style as any)[name] = null;
+    }
+  }
+  Object.assign((part.committer.element as HTMLElement).style, styleInfo);
+  styleMapCache.set(part, styleInfo);
+});

--- a/src/directives/unsafe-html.ts
+++ b/src/directives/unsafe-html.ts
@@ -12,7 +12,7 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {directive, Directive, isPrimitive, NodePart} from '../lit-html.js';
+import {directive, isPrimitive, NodePart, Part} from '../lit-html.js';
 
 /**
  * Renders the result as HTML, rather than text.
@@ -24,17 +24,19 @@ import {directive, Directive, isPrimitive, NodePart} from '../lit-html.js';
 
 const previousValues = new WeakMap<NodePart, string>();
 
-export const unsafeHTML = (value: any): Directive<NodePart> =>
-    directive((part: NodePart): void => {
-      // Dirty check primitive values
-      const previousValue = previousValues.get(part);
-      if (previousValue === value && isPrimitive(value)) {
-        return;
-      }
+export const unsafeHTML = directive((value: any) => (part: Part): void => {
+  if (!(part instanceof NodePart)) {
+    throw new Error('unsafeHTML can only be used in text bindings');
+  }
+  // Dirty check primitive values
+  const previousValue = previousValues.get(part);
+  if (previousValue === value && isPrimitive(value)) {
+    return;
+  }
 
-      // Use a <template> to parse HTML into Nodes
-      const tmp = document.createElement('template');
-      tmp.innerHTML = value;
-      part.setValue(document.importNode(tmp.content, true));
-      previousValues.set(part, value);
-    });
+  // Use a <template> to parse HTML into Nodes
+  const tmp = document.createElement('template');
+  tmp.innerHTML = value;
+  part.setValue(document.importNode(tmp.content, true));
+  previousValues.set(part, value);
+});

--- a/src/directives/until.ts
+++ b/src/directives/until.ts
@@ -12,15 +12,14 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {directive, Directive, NodePart} from '../lit-html.js';
+import {directive, Part} from '../lit-html.js';
 
 /**
  * Display `defaultContent` until `promise` resolves.
  */
 export const until =
-    (promise: Promise<any>, defaultContent: any): Directive<NodePart> =>
-        directive((part: NodePart) => {
-          part.setValue(defaultContent);
-          part.commit();
-          part.setValue(promise);
-        });
+    directive((promise: Promise<any>, defaultContent: any) => (part: Part) => {
+      part.setValue(defaultContent);
+      part.commit();
+      part.setValue(promise);
+    });

--- a/src/lib/directive.ts
+++ b/src/lib/directive.ts
@@ -1,3 +1,4 @@
+
 /**
  * @license
  * Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
@@ -16,14 +17,34 @@ import {Part} from './part.js';
 
 const directives = new WeakMap<any, Boolean>();
 
-export interface Directive<P = Part> {
-  (part: P): void;
-}
+export type DirectiveFn = (part: Part) => void;
 
-export const directive = <P = Part>(f: Directive<P>): Directive<P> => {
-  directives.set(f, true);
-  return f;
-};
+/**
+ * Brands a function as a directive so that lit-html will call the function
+ * during template rendering, rather than passing as a value.
+ *
+ * @param f The directive factory function. Must be a function that returns a
+ * function of the signature `(part: Part) => void`. The returned function will
+ * be called with the part object
+ *
+ * @example
+ *
+ * ```
+ * import {directive, html} from 'lit-html';
+ *
+ * const immutable = directive((v) => (part) => {
+ *   if (part.value !== v) {
+ *     part.setValue(v)
+ *   }
+ * });
+ * ```
+ */
+export const directive = <F extends Function>(f: F): F =>
+    ((...args: any[]) => {
+      const d = f(...args);
+      directives.set(d, true);
+      return d;
+    }) as unknown as F;
 
 export const isDirective = (o: any) =>
     typeof o === 'function' && directives.has(o);

--- a/src/lit-html.ts
+++ b/src/lit-html.ts
@@ -16,7 +16,7 @@ import {defaultTemplateProcessor} from './lib/default-template-processor.js';
 import {SVGTemplateResult, TemplateResult} from './lib/template-result.js';
 
 export {DefaultTemplateProcessor, defaultTemplateProcessor} from './lib/default-template-processor.js';
-export {Directive, directive, isDirective} from './lib/directive.js';
+export {directive, DirectiveFn, isDirective} from './lib/directive.js';
 // TODO(justinfagnani): remove line when we get NodePart moving methods
 export {removeNodes, reparentNodes} from './lib/dom.js';
 export {noChange, Part} from './lib/part.js';

--- a/src/test/lib/render_test.ts
+++ b/src/test/lib/render_test.ts
@@ -12,7 +12,7 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {AttributePart, directive, html, NodePart, render, svg, templateFactory} from '../../lit-html.js';
+import {AttributePart, directive, html, NodePart, Part, render, svg, templateFactory} from '../../lit-html.js';
 import {stripExpressionMarkers} from '../test-utils/strip-markers.js';
 
 const assert = chai.assert;
@@ -689,23 +689,33 @@ suite('render()', () => {
 
   suite('directives', () => {
     test('renders directives on NodeParts', () => {
-      const fooDirective = directive((part: NodePart) => {
+      const fooDirective = directive(() => (part: Part) => {
         part.setValue('foo');
       });
 
-      render(html`<div>${fooDirective}</div>`, container);
+      render(html`<div>${fooDirective()}</div>`, container);
       assert.equal(
           stripExpressionMarkers(container.innerHTML), '<div>foo</div>');
     });
 
     test('renders directives on AttributeParts', () => {
-      const fooDirective = directive((part: AttributePart) => {
+      const fooDirective = directive(() => (part: AttributePart) => {
         part.setValue('foo');
       });
 
-      render(html`<div foo="${fooDirective}"></div>`, container);
+      render(html`<div foo="${fooDirective()}"></div>`, container);
       assert.equal(
           stripExpressionMarkers(container.innerHTML), '<div foo="foo"></div>');
+    });
+
+    test('renders directives on PropertyParts', () => {
+      const fooDirective = directive(() => (part: AttributePart) => {
+        part.setValue(1234);
+      });
+
+      render(html`<div .foo="${fooDirective()}"></div>`, container);
+      assert.equal(stripExpressionMarkers(container.innerHTML), '<div></div>');
+      assert.strictEqual((container.firstElementChild as any).foo, 1234);
     });
 
     testSkipChrome41(
@@ -719,13 +729,13 @@ suite('render()', () => {
         <div @test-event=${(e: Event) => {
                 event = e;
               }}>
-          ${directive((part: NodePart) => {
+          ${directive(() => (part: NodePart) => {
                 // This emulates a custom element that fires an event in its
                 // connectedCallback
                 part.startNode.dispatchEvent(new CustomEvent('test-event', {
                   bubbles: true,
                 }));
-              })}
+              })()}
         </div>`,
               container);
           document.body.removeChild(container);
@@ -738,7 +748,7 @@ suite('render()', () => {
           // This tests that attribute directives are called in the commit
           // phase, not the setValue phase
           let event = undefined;
-          const fire = directive((part: AttributePart) => {
+          const fire = directive(() => (part: AttributePart) => {
             part.committer.element.dispatchEvent(new CustomEvent('test-event', {
               bubbles: true,
             }));
@@ -747,20 +757,10 @@ suite('render()', () => {
           render(
               html`<div @test-event=${(e: Event) => {
                 event = e;
-              }} b=${fire}></div>`,
+              }} b=${fire()}></div>`,
               container);
           assert.isOk(event);
         });
-
-    test('renders directives on PropertyParts', () => {
-      const fooDirective = directive((part: AttributePart) => {
-        part.setValue(1234);
-      });
-
-      render(html`<div .foo="${fooDirective}"></div>`, container);
-      assert.equal(stripExpressionMarkers(container.innerHTML), '<div></div>');
-      assert.strictEqual((container.firstElementChild as any).foo, 1234);
-    });
   });
 
   suite('<table>', () => {


### PR DESCRIPTION
This change lets us abstract over directive arguments in the future if we need to, which might offer a way to build directive state management into lit's core, rather than forcing directives to use WeakMaps keyed off Parts.

In the meantime, it's a no-op in terms of functionality, though I think it looks a marginally nicer to write directives.

This is a smaller change than converting directives to classes, which I did in https://github.com/Polymer/lit-html/compare/directives