### PR TITLE
Move global types to project d.ts file

### DIFF
--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,0 +1,22 @@
+interface ShadyCSS {
+  nativeCss: boolean;
+  nativeShadow: boolean;
+  styleElement(host: Element, overrideProps?: { [key: string]: string }): void;
+  prepareTemplateDom(template: Element, elementName: string): void;
+  prepareTemplateStyles(template: Element, elementName: string, typeExtension?: string): void;
+}
+
+interface ShadyDOM {
+  inUse: boolean;
+}
+
+interface Window {
+  ShadyCSS?: ShadyCSS;
+  ShadyDOM?: ShadyDOM;
+}
+
+/** Allows code to check `instanceof ShadowRoot`. */
+declare interface ShadowRootConstructor {
+  new (): ShadowRoot;
+}
+declare const ShadowRoot: ShadowRootConstructor;

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,9 +1,10 @@
 interface ShadyCSS {
   nativeCss: boolean;
   nativeShadow: boolean;
-  styleElement(host: Element, overrideProps?: { [key: string]: string }): void;
+  styleElement(host: Element, overrideProps?: {[key: string]: string}): void;
   prepareTemplateDom(template: Element, elementName: string): void;
-  prepareTemplateStyles(template: Element, elementName: string, typeExtension?: string): void;
+  prepareTemplateStyles(
+      template: Element, elementName: string, typeExtension?: string): void;
 }
 
 interface ShadyDOM {
@@ -17,6 +18,6 @@ interface Window {
 
 /** Allows code to check `instanceof ShadowRoot`. */
 declare interface ShadowRootConstructor {
-  new (): ShadowRoot;
+  new(): ShadowRoot;
 }
 declare const ShadowRoot: ShadowRootConstructor;

--- a/src/lib/parts.ts
+++ b/src/lib/parts.ts
@@ -404,14 +404,6 @@ export class PropertyCommitter extends AttributeCommitter {
 
 export class PropertyPart extends AttributePart {}
 
-declare global {
-  interface EventListenerOptions {
-    capture?: boolean;
-    once?: boolean;
-    passive?: boolean;
-  }
-}
-
 // Detect event listener options support. If the `capture` property is read
 // from the options object, then options are supported. If not, then the thrid
 // argument to add/removeEventListener is interpreted as the boolean capture
@@ -435,7 +427,7 @@ export class EventPart implements Part {
   eventName: string;
   eventContext?: EventTarget;
   value: any = undefined;
-  _options?: {capture?: boolean, passive?: boolean, once?: boolean};
+  _options?: AddEventListenerOptions;
   _pendingValue: any = undefined;
 
   constructor(element: Element, eventName: string, eventContext?: EventTarget) {

--- a/src/lib/shady-render.ts
+++ b/src/lib/shady-render.ts
@@ -22,12 +22,6 @@ import {Template} from './template.js';
 
 export {html, svg, TemplateResult} from '../lit-html.js';
 
-declare global {
-  interface Window {
-    ShadyCSS: any;
-  }
-  class ShadowRoot {}
-}
 
 // Get a key to lookup in `templateCaches`.
 const getTemplateCacheKey = (type: string, scopeName: string) =>
@@ -61,7 +55,7 @@ const shadyTemplateFactory = (scopeName: string) =>
       if (template === undefined) {
         const element = result.getTemplateElement();
         if (compatibleShadyCSSVersion) {
-          window.ShadyCSS.prepareTemplateDom(element, scopeName);
+          window.ShadyCSS!.prepareTemplateDom(element, scopeName);
         }
         template = new Template(result, element);
         templateCache.set(result.strings, template);
@@ -137,8 +131,8 @@ const prepareTemplateStyles =
       // Note, it's important that ShadyCSS gets the template that `lit-html`
       // will actually render so that it can update the style inside when
       // needed (e.g. @apply native Shadow DOM case).
-      window.ShadyCSS.prepareTemplateStyles(template.element, scopeName);
-      if (window.ShadyCSS.nativeShadow) {
+      window.ShadyCSS!.prepareTemplateStyles(template.element, scopeName);
+      if (window.ShadyCSS!.nativeShadow) {
         // When in native Shadow DOM, re-add styling to rendered content using
         // the style ShadyCSS produced.
         const style = template.element.content.querySelector('style')!;
@@ -184,7 +178,7 @@ export const render =
         }
         // Update styling if this is the initial render to this container.
         if (!hasRendered) {
-          window.ShadyCSS.styleElement((container as ShadowRoot).host);
+          window.ShadyCSS!.styleElement((container as ShadowRoot).host);
         }
       }
     };

--- a/src/test/lib/incompatible-shady-render_test.ts
+++ b/src/test/lib/incompatible-shady-render_test.ts
@@ -18,7 +18,6 @@ const assert = chai.assert;
 
 declare global {
   interface Window {
-    ShadyDOM: any;  // tslint:disable-line
     WarnCount: number;
   }
 }

--- a/src/test/lib/shady-render_test.ts
+++ b/src/test/lib/shady-render_test.ts
@@ -17,12 +17,6 @@ import {renderShadowRoot} from '../test-utils/shadow-root.js';
 
 const assert = chai.assert;
 
-declare global {
-  interface Window {
-    ShadyDOM: any;  // tslint:disable-line
-  }
-}
-
 suite('shady-render', () => {
   test('style elements apply in shadowRoots', () => {
     const container = document.createElement('scope-1');

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
     "target": "es2017",
     "module": "es2015",
     "lib": ["es2017", "esnext.asynciterable", "dom"],
+    "types": ["chai", "mocha"],
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,
@@ -12,8 +13,7 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": true,
-    "skipLibCheck": true
+    "noFallthroughCasesInSwitch": true
   },
   "include": [
     "src/**/*.ts"


### PR DESCRIPTION
Some minor improvements to Typescript usage (I think). I'm open to feedback 😄

- Moves `ShadowRoot`, `ShadyCSS`, and `ShadyDOM` typings to `env.d.ts` (I'm open to other names)
- Uses `AddEventListenerOptions` interface from `dom.d.ts`
- Removes `skipLibCheck: true` setting from `tsconfig.json`

Fixes #566