### PR TITLE
Add UnsafeStatic extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /node_modules/
 /lib/
 /directives/
+/extensions/
 
 /tools/node_modules/
 /tools/lib/

--- a/src/extensions/unsafe-static.ts
+++ b/src/extensions/unsafe-static.ts
@@ -1,0 +1,136 @@
+/**
+ * @license
+ * Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+import {TemplateResult} from '../lib/template-result.js';
+
+const stringsCache = new WeakMap<TemplateStringsArray, TemplateStringsArray>();
+
+/**
+ * A value that's interpolated directly into the template before parsing.
+ *
+ * Static values cannot be updated, since they don't define a part and are
+ * effectively merged into the literal part of a lit-html template. Because
+ * they are interpolated before the template is parsed as HTML, static values
+ * may occupy positions in the template that regular interpolations may not,
+ * such as tag and attribute names.
+ *
+ * UnsafeStatic values are inherently very unsafe, as the name states. They
+ * can break well-formedness assumptions and aren't escaped, and thus a
+ * potential XSS vulnerability if created from user-provided data.
+ *
+ * It's recommended that no user templates ever use UnsafeStatic directly,
+ * but directive-like functions are written by library authors to validate
+ * and sanitize values for a specific purpose, before wrapping in an
+ * UnsafeStatic value.
+ *
+ * An example would be a `tag()` directive that lets a template contain tags
+ * whose names aren't known until runtime, like:
+ *
+ *     html`<${tag(myTagName)>Whoa</tag(MyElement)>`
+ *
+ * Here, `tag()` should validate that `myTagName` is a valid HTML tag name,
+ * and throw if it contains any illegal characters.
+ */
+export class UnsafeStatic {
+  readonly value: unknown;
+
+  constructor(value: unknown) {
+    this.value = value;
+  }
+}
+
+/**
+ * Interpolates a value before template parsing and making it available to
+ * template pre-processing steps.
+ *
+ * Static values cannot be updated, since they don't define a part and are
+ * effectively merged into the literal part of a lit-html template. Because
+ * they are interpolated before the template is parsed as HTML, static values
+ * may occupy positions in the template that regular interpolations may not,
+ * such as tag and attribute names.
+ */
+export const unsafeStatic = (value: unknown) => new UnsafeStatic(value);
+
+/**
+ * Decorates initial `html` function to produce preprocessed templates that
+ * include unsafe static values.
+ *
+ * No sanitization provided. Any static value is considered as a string and
+ * merged to a template, so it can lead to undefined behavior if you use
+ * angle brackets or any other html-specific symbols.
+ *
+ * Updating static values is impossible. If you try to replace one static
+ * value with another, it will be ignored, and if it is a dynamic value,
+ * the error will be thrown.
+ *
+ * @param processor `html` function
+ *
+ */
+export const withUnsafeStatic = (processor: (strings: TemplateStringsArray, ...values: any[]) => TemplateResult) =>
+  (strings: TemplateStringsArray, ...values: any[]) => {
+    let finalStrings: any | undefined = stringsCache.get(strings);
+
+    if (!finalStrings) {
+      // Convert the initial array of strings into a new one with merged
+      // static values. Values array is used only to know where the static
+      // value is placed.
+      if (values.some((v) => v instanceof UnsafeStatic)) {
+        finalStrings = [];
+
+        let previousValueWasStatic = false;
+
+        for (let i = 0; i < strings.length; i++) {
+          if (previousValueWasStatic) {
+            // Append the string part that follows static value.
+            finalStrings[finalStrings.length - 1] += strings[i];
+          } else {
+            finalStrings.push(strings[i]);
+          }
+
+          // Since length of values array is N and strings array is N+1,
+          // it is necessary to check if we have crossed the values boundaries.
+          if (i < values.length && values[i] instanceof UnsafeStatic) {
+            // Append static value.
+            finalStrings[finalStrings.length - 1] += String(values[i].value);
+            previousValueWasStatic = true;
+          } else {
+            previousValueWasStatic = false;
+          }
+        }
+      } else {
+        // if there is no static value remember original strings array
+        finalStrings = strings;
+      }
+
+      stringsCache.set(strings, finalStrings);
+    }
+
+    // If there is static values remove all statics from it. Otherwise,
+    // just use original values array.
+    const finalValues = finalStrings !== strings
+      ? values.filter((v) => !(v instanceof UnsafeStatic))
+      : values;
+
+    // If user try to replace static value with dynamic one we cannot filter it.
+    // It produces different amount of filtered values we have so we can catch
+    // it and throw an error to avoid undefined behavior during template update.
+    if (finalValues.length >= finalStrings.length) {
+      throw new Error(
+        'Amount of values provided does not fit amount of available parts. '
+        + 'It could happen if you try to change your UnsafeStatic value to a dynamic one.'
+      );
+    }
+
+    return processor(finalStrings, ...finalValues);
+  };

--- a/src/test/extensions/unsafe-static_test.ts
+++ b/src/test/extensions/unsafe-static_test.ts
@@ -1,0 +1,68 @@
+/**
+ * @license
+ * Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+import {html, render} from '../../lit-html.js';
+import {unsafeStatic, withUnsafeStatic} from '../../extensions/unsafe-static.js';
+
+const assert = chai.assert;
+const expect = chai.expect;
+
+suite('UnsafeStatic', () => {
+  let container: HTMLElement;
+  let staticHtml: typeof html;
+
+  setup(() => {
+    container = document.createElement('div');
+    staticHtml = withUnsafeStatic(html);
+  });
+
+  test('renders static values into template', () => {
+    const tag = unsafeStatic('div');
+    const cls = unsafeStatic('class');
+    const template = staticHtml`<${tag} ${cls}="test"></${tag}>`;
+    render(template, container);
+
+    assert(container.innerHTML, '<div class="test"></div>');
+  });
+
+  test('handles nesting', () => {
+    const div = unsafeStatic('div');
+    const span = unsafeStatic('span');
+    const cls = unsafeStatic('class');
+    const template = staticHtml`<${div}><${span} ${cls}="test">Test</${span}></${div}>`;
+    render(template, container);
+
+    assert(container.innerHTML, '<div><span class="test">Test</span></div>');
+  });
+
+  test('throws an error if static value is changed to dynamic', () => {
+    let text: any = unsafeStatic('Test');
+    const template = () => staticHtml`<div>${text}</div>`;
+    render(template(), container);
+
+    text = 'New Test';
+
+    expect(() => render(template(), container)).to.throw();
+  });
+
+  test('ignores if one static value is changed to another', () => {
+    let text = unsafeStatic('Test');
+    const template = () => staticHtml`<div>${text}</div>`;
+    render(template(), container);
+
+    text = unsafeStatic('New Test');
+    render(template(), container);
+
+    assert(container.innerHTML, '<div>Test</div>');
+  });
+});

--- a/src/test/extensions/unsafe-static_test.ts
+++ b/src/test/extensions/unsafe-static_test.ts
@@ -11,8 +11,8 @@
  * subject to an additional IP rights grant found at
  * http://polymer.github.io/PATENTS.txt
  */
-import {html, render} from '../../lit-html.js';
 import {unsafeStatic, withUnsafeStatic} from '../../extensions/unsafe-static.js';
+import {html, render} from '../../lit-html.js';
 
 const assert = chai.assert;
 const expect = chai.expect;
@@ -39,7 +39,8 @@ suite('UnsafeStatic', () => {
     const div = unsafeStatic('div');
     const span = unsafeStatic('span');
     const cls = unsafeStatic('class');
-    const template = staticHtml`<${div}><${span} ${cls}="test">Test</${span}></${div}>`;
+    const template =
+        staticHtml`<${div}><${span} ${cls}="test">Test</${span}></${div}>`;
     render(template, container);
 
     assert(container.innerHTML, '<div><span class="test">Test</span></div>');

--- a/test/index.html
+++ b/test/index.html
@@ -22,6 +22,7 @@
     <script type="module" src="./directives/when_test.js"></script>
     <script type="module" src="./directives/classMap_test.js"></script>
     <script type="module" src="./directives/styleMap_test.js"></script>
+    <script type="module" src="./extensions/unsafe-static_test.js"></script>
     <script>
       WCT.loadSuites([
         'shady.html',


### PR DESCRIPTION
Fixes #78
Fixes #218
Closes #274 

One of the things I always missed in `lit-html` was the inability to use variables as tag names. Especially it affects work with WebComponents and their string names. You just unable to check if you've done everything correctly at compile time. If you write component name in a wrong way or if you don't import proper file you can know it only at runtime. And even in runtime you don't have a proper error support because component with a wrong name will just be an empty tag. 

The initial implmenetation of that functional, #274, has its own performance issues mostly connected with the fact that unsafe static values breaks the basic flow of the `lit-html` core.

The latest discussion about moving Promises support out of the core (#550) was the last push to create this PR. I believe that we really don't need to have everything inside the core. Core should be fast and simple, and additional functional can be implemented anywhere else. E.g. not everyone want to use static values, they would be good with a vanilla `html` function. That's why it is important to let them avoid loading additional bytes.

Basing on this idea I suggest a conception of "extensions", a simple decorator functions that wrap the original `html` and add new abilities to it. The `withUnsafeStatic` function proposed by this PR provides merging static values into the template and caching the result to a `WeakMap`. Each following repetition uses the cache and removes all `UnsafeStatic` values from values list.

Also there was a blocker I didn't aware of, but looks like it is already resolved: Microsoft/ChakraCore#5201.

### Example
Basic usage of unsafe static values is following. However, since `withUnsafeStatic` doesn't sanitize and validate incoming values it wouldn't be safe to use them this way.
```typescript
// utils.ts
import {html} from 'lit-html';
import {withUnsafeStatic} from 'lit-html/lib/extensions/unsafe-static';

export const shtml = withUnsafeStatic(html);

// my-component.ts
import {shtml} from './utils'; 

export default class MyComponent extends LitElement {
  public static readonly is: string = name;

  public render() {
    return shtml`<div><slot/></div>`
  }
}

// app.ts
import {unsafeStatic} from 'lit-html/lib/extensions/unsafe-static';
import {MyComponent as MyComponentClass} from './my-component';
import {shtml} from './utils'; 

const MyComponent = unsafeStatic(MyComponentClass.is);

export default class App extends ListElement {
  public render() {
    return shtml`<${MyComponent}>Content</${MyComponent}>`
  }
}
```