### PR TITLE
Don’t use `eventContext` for `this` of event listener objects.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 * Directive are now defined by passing the entire directive factory function to `directive()`.
 <!-- ### Removed -->
-<!-- ### Fixed -->
+### Fixed
+* `eventContext` is no longer used as the `this` value for event listener objects (object with a `handleEvent` method), as the object itself is supposed to be the `this` value.
 
 ## [0.12.0] - 2018-10-05
 ### Changed

--- a/src/lib/parts.ts
+++ b/src/lib/parts.ts
@@ -480,12 +480,11 @@ export class EventPart implements Part {
   }
 
   handleEvent(event: Event) {
-    const listener = (typeof this.value === 'function') ?
-        this.value :
-        (typeof this.value.handleEvent === 'function') ?
-        this.value.handleEvent :
-        () => null;
-    listener.call(this.eventContext || this.element, event);
+    if (typeof this.value === 'function') {
+      this.value.call(this.eventContext || this.element, event);
+    } else {
+      this.value.handleEvent(event);
+    }
   }
 }
 

--- a/src/test/lib/render_test.ts
+++ b/src/test/lib/render_test.ts
@@ -571,7 +571,7 @@ suite('render()', () => {
       render(html`<div @click=${listener}></div>`, container, {eventContext});
       const div = container.querySelector('div')!;
       div.click();
-      assert.equal(thisValue, eventContext);
+      assert.equal(thisValue, listener);
     });
 
     test('only adds event listener once', () => {


### PR DESCRIPTION
Fixes https://github.com/Polymer/lit-html/issues/571