### PR TITLE
Use callback as event part listener

### DIFF
--- a/src/lib/parts.ts
+++ b/src/lib/parts.ts
@@ -437,11 +437,13 @@ export class EventPart implements Part {
   value: any = undefined;
   _options?: {capture?: boolean, passive?: boolean, once?: boolean};
   _pendingValue: any = undefined;
+  _boundHandleEvent: (event: Event) => void;
 
   constructor(element: Element, eventName: string, eventContext?: EventTarget) {
     this.element = element;
     this.eventName = eventName;
     this.eventContext = eventContext;
+    this._boundHandleEvent = this.handleEvent.bind(this);
   }
 
   setValue(value: any): void {
@@ -469,11 +471,13 @@ export class EventPart implements Part {
         newListener != null && (oldListener == null || shouldRemoveListener);
 
     if (shouldRemoveListener) {
-      this.element.removeEventListener(this.eventName, this, this._options);
+      this.element.removeEventListener(
+          this.eventName, this._boundHandleEvent, this._options);
     }
     this._options = getOptions(newListener);
     if (shouldAddListener) {
-      this.element.addEventListener(this.eventName, this, this._options);
+      this.element.addEventListener(
+          this.eventName, this._boundHandleEvent, this._options);
     }
     this.value = newListener;
     this._pendingValue = noChange;

--- a/src/lib/parts.ts
+++ b/src/lib/parts.ts
@@ -443,7 +443,7 @@ export class EventPart implements Part {
     this.element = element;
     this.eventName = eventName;
     this.eventContext = eventContext;
-    this._boundHandleEvent = this.handleEvent.bind(this);
+    this._boundHandleEvent = (e) => this.handleEvent(e);
   }
 
   setValue(value: any): void {


### PR DESCRIPTION
Cobalt has a bug on using event listener object. They are fixing the bug but it won't reach all Cobalt users until at least one year later.
This noop change will unblock us from developing lit-html on Cobalt platform.

