### PR TITLE
UpdateWritingTemplate

### DIFF
--- a/docs/_guide/02-writing-templates.md
+++ b/docs/_guide/02-writing-templates.md
@@ -84,7 +84,7 @@ There are a few types of bindings:
     ```
   * Boolean Attribute:
     ```js
-    html`<button type="submit" ?disabled=${disabled}>`
+    html`<input ?disabled=${disabled}>`
     ```
   * Property:
     ```js

--- a/docs/_guide/02-writing-templates.md
+++ b/docs/_guide/02-writing-templates.md
@@ -84,7 +84,7 @@ There are a few types of bindings:
     ```
   * Boolean Attribute:
     ```js
-    html`<input type="checkbox" ?checked=${checked}>`
+    html`<button type="submit" ?disabled=${disabled}>`
     ```
   * Property:
     ```js


### PR DESCRIPTION
See #496 

The checked boolean attribute has problems in Google Chrome as the property of the element is favored by the engine over the attribute.
I recommend changing the docs to use disabled as the Boolean attribute example.
