### PR TITLE
Fixed `when` directive example syntax errors.

### DIFF
--- a/docs/_guide/02-writing-templates.md
+++ b/docs/_guide/02-writing-templates.md
@@ -304,9 +304,7 @@ import {when} from 'lit-html/directives/when';
 
 let checked = false;
 
-html`
-  when(checked, () => html`Checkmark is checked`, () => html`Checkmark is not
-checked`);
+const render = checked => html`<div>${when(checked, () => html`Checkmark is checked`, () => html`Checkmark is not checked`)}</div>`;
 ```
 
 ### `repeat(items, keyfn, template)`


### PR DESCRIPTION
Fixes #592 

The `when` directive had errors in it and was not functional, to fix this I interpolated the `when` directive.