### PR TITLE
Fixed directive examples bad code

### DIFF
--- a/docs/_guide/02-writing-templates.md
+++ b/docs/_guide/02-writing-templates.md
@@ -249,7 +249,7 @@ Directives are functions that accept some arguments for values and configuration
 ```javascript
 import {directive, html} from 'lit-html';
 
-const hello = directive(() => (part) => {
+const hello = () => directive(part => {
   part.setValue('Hello');
 });
 
@@ -263,7 +263,7 @@ Here's an example of a directive that takes a function, and evaluates it in a tr
 ```javascript
 import {directive, html, render} from 'lit-html';
 
-const safe = directive((f) => (part) => {
+const safe = f => directive(part => {
   try {
     return f();
   } catch (e) {


### PR DESCRIPTION
This fixes #595 

This changes the first two directives examples to be functional by **moving the first arrow function outside of the call to `directive`**, therefore, no longer rendering the second arrow function to the screen but rather executing it.