### PR TITLE
Fix directive examples in docs

### DIFF
--- a/docs/_guide/02-writing-templates.md
+++ b/docs/_guide/02-writing-templates.md
@@ -249,7 +249,7 @@ Directives are functions that accept some arguments for values and configuration
 ```javascript
 import {directive, html} from 'lit-html';
 
-const hello = directive(() => (part) => {
+const hello = () => directive((part) => {
   part.setValue('Hello');
 });
 
@@ -263,7 +263,7 @@ Here's an example of a directive that takes a function, and evaluates it in a tr
 ```javascript
 import {directive, html, render} from 'lit-html';
 
-const safe = directive((f) => (part) => {
+const safe = (f) => directive((part) => {
   try {
     return f();
   } catch (e) {


### PR DESCRIPTION
Seems like the documentation has incorrect examples on how to define a directive.

I tried to do it according to the docs and saw the stringified function in the rendered DOM. Then I looked the implementation of existing ones in the core and made mine in the same way (https://codepen.io/bashmish/pen/oQxBYZ) and it started working. I fixed examples accordingly.