### PR TITLE
impl for removal notification for repeat directive

### DIFF
--- a/src/directives/repeat.ts
+++ b/src/directives/repeat.ts
@@ -59,7 +59,7 @@ export class NodeRemovalToken {
   }
 
   commit() {
-    commitRemoveNode(this.container, this.target);
+    commitRemoveNode(this.target, this.container);
   }
 }
 

--- a/src/directives/repeat.ts
+++ b/src/directives/repeat.ts
@@ -62,7 +62,7 @@ export class NodeRemovalToken {
   commit() {
     if (this._isCommitted)
       return;
-    commitRemoveNode(this.container, this.target);
+    commitRemoveNode(this.target, this.container);
     this._isCommitted = true;
   }
 }

--- a/src/directives/repeat.ts
+++ b/src/directives/repeat.ts
@@ -83,12 +83,15 @@ const removeNodesWithRemovalHandler =
       let node = startNode;
       // We cannot assume here the node will be present. Since we
       // give away control to the user, if the user does something potentially
-      // harmful like removing the endNode, we'd end up in an infinite loop.
+      // harmful like removing the endNode and setting it equal to the current
+      // one, however unlikely, could put us in an infinite loop.
       // So, it's important to check first.
       while (node && node !== endNode) {
         const next = node.nextSibling;
         // Check if it's a marker node, which is a comment node with value ''.
-        if (!(node.nodeType === node.COMMENT_NODE && node.nodeValue === '')) {
+        if (node.nodeType === node.COMMENT_NODE && node.nodeValue === '') {
+          commitRemoveNode(node, container);
+        } else {
           const token = new NodeRemovalToken(node, container);
           nodeRemovalHandler(token);
           if (!token.defaultPrevented)

--- a/src/directives/repeat.ts
+++ b/src/directives/repeat.ts
@@ -54,12 +54,12 @@ export class NodeRemovalToken {
   private _isCommitted: boolean = false;
   constructor(public target: Node, public container: Node) {
   }
+  preventDefault =
+      () => {
+        this.defaultPrevented = true;
+      }
 
-  preventDefault() {
-    this.defaultPrevented = true;
-  }
-
-  commit() {
+  commit = () => {
     if (this._isCommitted)
       return;
     commitRemoveNode(this.target, this.container);

--- a/src/directives/repeat.ts
+++ b/src/directives/repeat.ts
@@ -81,13 +81,15 @@ const removeNodesWithRemovalHandler =
       if (nodeRemovalHandler === undefined)
         return removeNodes(container, startNode, endNode);
       let node = startNode;
-      while (node !== endNode) {
-        if (!node)
-          return throwIllegalNodeModification();
+      // We cannot assume here the node will be present. Since we
+      // give away control to the user, if the user does something potentially
+      // harmful like removing the endNode, we'd end up in an infinite loop.
+      // So, it's important to check first.
+      while (node && node !== endNode) {
         const next = node.nextSibling;
         // Check if it's a marker node, which is a comment node with value ''.
         if (!(node.nodeType === node.COMMENT_NODE && node.nodeValue === '')) {
-          let token = new NodeRemovalToken(node, container);
+          const token = new NodeRemovalToken(node, container);
           nodeRemovalHandler(token);
           if (!token.defaultPrevented)
             token.commit();

--- a/src/directives/repeat.ts
+++ b/src/directives/repeat.ts
@@ -51,6 +51,7 @@ const insertPartBefore =
 
 export class NodeRemovalToken {
   public defaultPrevented: boolean = false;
+  private _isCommitted: boolean = false;
   constructor(public target: Node, public container: Node) {
   }
 
@@ -59,7 +60,10 @@ export class NodeRemovalToken {
   }
 
   commit() {
-    commitRemoveNode(this.target, this.container);
+    if (this._isCommitted)
+      return;
+    commitRemoveNode(this.container, this.target);
+    this._isCommitted = true;
   }
 }
 


### PR DESCRIPTION
A very "naive" implementation of `onRemove` just to get the ball rolling. It currently has the following limitations:

- API shape has be thought through.
- ~`markerNodes` are also notified of removal, which is probably is better filtered off.~
- ~The `commit` callback probably should have an better behavior where deferring it is opt in, by calling something, or setting a flag -- similar to `event.preventDefault`, etc.~
- This can potentially integrate in 3 different ways: 
    - A separate directive entirely: Which means, abstracting the inner details of `repeat` to be more portable so that it can be reused.
    - Just make `repeat` have simpler `onremove` handler as per the initial stage of this commit, taking in node and `commit` functions as arguments
    - Make this fit into the context of `lit-html` in a larger scale, by exploring where else an `onremove` fits in context, and refactor the whole project (== lot of work ==)
 
Other things to do:
- ~refactor and cleanup - currently code is just duplicated - eg, `removeNode` .~
- ~linting fails due to formatting (causing test to fail)~

Please let me know if fits into your direction for the project. If it does, we can start ironing out the details, and work on this commit. That being said, it works as expected. 

Related issue: #635