### PR TITLE
Make it possible to extend the values that a NodePart can render

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,5 @@
 {
-  "typescript.tsdk": "node_modules/typescript/lib"
+  "typescript.tsdk": "node_modules/typescript/lib",
+  "typescript.referencesCodeLens.enabled": true,
+  "typescript.implementationsCodeLens.enabled": true
 }

--- a/src/lib/nodepart.ts
+++ b/src/lib/nodepart.ts
@@ -1,0 +1,145 @@
+import { NodePart, isPrimitive } from './parts';
+import { TemplateResult } from './template-result';
+import { TemplateInstance } from './template-instance';
+
+export interface NodePartValueHandler<T> {
+  test(value: any): value is T;
+  insert(part: NodePart, value: T): void;
+}
+
+export const primitiveHandler: NodePartValueHandler<any> = {
+  test(value: any): value is any {
+    return isPrimitive(value);
+  },
+  insert(part: NodePart, value: any) {
+    if (part.value === value) return;
+
+    const node = part.startNode.nextSibling!;
+    value = value == null ? '' : value;
+    if (node === part.endNode.previousSibling &&
+        node.nodeType === Node.TEXT_NODE) {
+      // If we only have a single text node between the markers, we can just
+      // set its value, rather than replacing it.
+      // TODO(justinfagnani): Can we just check if part.value is primitive?
+      node.textContent = value;
+    } else {
+      nodeHandler.insert(part, document.createTextNode(
+          typeof value === 'string' ? value : String(value)));
+    }
+    part.value = value;
+  }
+};
+
+export const templateResultHandler: NodePartValueHandler<TemplateResult> = {
+  test(value: any): value is TemplateResult {
+    return value instanceof TemplateResult;
+  },
+  insert(part: NodePart, value: TemplateResult) {
+    const template = part.options.templateFactory(value);
+    if (part.value && part.value.template === template) {
+      part.value.update(value.values);
+    } else {
+      // Make sure we propagate the template processor from the TemplateResult
+      // so that we use its syntax extension, etc. The template factory comes
+      // from the render function options so that it can control template
+      // caching and preprocessing.
+      const instance = new TemplateInstance(template, value.processor, part.options);
+      const fragment = instance._clone();
+      instance.update(value.values);
+      nodeHandler.insert(part, fragment);
+      part.value = instance;
+    }
+  }
+};
+
+export const nodeHandler: NodePartValueHandler<Node> = {
+  test(value: any): value is Node {
+    return value instanceof Node;
+  },
+  insert(part: NodePart, value: Node) {
+    if (part.value === value) {
+      return;
+    }
+    part.clear();
+    part.endNode.parentNode!.insertBefore(value, part.endNode);
+    part.value = value;
+  }
+};
+
+export const iterableHandler: NodePartValueHandler<Iterable<any>> = {
+  test(value: any): value is Iterable<any> {
+    return Array.isArray(value) || value[Symbol.iterator];
+  },
+  insert(part: NodePart, value: Iterable<any>) {
+    // For an Iterable, we create a new InstancePart per item, then set its
+    // value to the item. This is a little bit of overhead for every item in
+    // an Iterable, but it lets us recurse easily and efficiently update Arrays
+    // of TemplateResults that will be commonly returned from expressions like:
+    // array.map((i) => html`${i}`), by reusing existing TemplateInstances.
+
+    // If _value is an array, then the previous render was of an
+    // iterable and _value will contain the NodeParts from the previous
+    // render. If _value is not an array, clear this part and make a new
+    // array for NodeParts.
+    if (!Array.isArray(part.value)) {
+      part.value = [];
+      part.clear();
+    }
+
+    // Lets us keep track of how many items we stamped so we can clear leftover
+    // items from a previous render
+    const itemParts = part.value as NodePart[];
+    let partIndex = 0;
+    let itemPart: NodePart|undefined;
+
+    for (const item of value) {
+      // Try to reuse an existing part
+      itemPart = itemParts[partIndex];
+
+      // If no existing part, create a new one
+      if (itemPart === undefined) {
+        itemPart = new NodePart(part.options);
+        itemParts.push(itemPart);
+        if (partIndex === 0) {
+          itemPart.appendIntoPart(part);
+        } else {
+          itemPart.insertAfterPart(itemParts[partIndex - 1]);
+        }
+      }
+      itemPart.setValue(item);
+      itemPart.commit();
+      partIndex++;
+    }
+
+    if (partIndex < itemParts.length) {
+      // Truncate the parts array so _value reflects the current state
+      itemParts.length = partIndex;
+      part.clear(itemPart && itemPart!.endNode);
+    }
+  }
+};
+
+export const promiseHandler: NodePartValueHandler<Promise<any>> = {
+  test(value: any): value is Promise<any> {
+    return value.then !== undefined;
+  },
+  insert(part: NodePart, value: Promise<any>) {
+    part.value = value;
+    value.then((v: any) => {
+      if (part.value === value) {
+        part.setValue(v);
+        part.commit();
+      }
+    });
+  }
+};
+
+// This is a function so that we don't accidentally mutate the default
+// handler list.
+export const getDefaultHandlers = () => [
+  primitiveHandler,
+  templateResultHandler,
+  nodeHandler,
+  iterableHandler,
+  promiseHandler
+];

--- a/src/lib/render-options.ts
+++ b/src/lib/render-options.ts
@@ -13,8 +13,10 @@
  */
 
 import {TemplateFactory} from './template-factory.js';
+import { NodePartValueHandler } from './nodepart.js';
 
 export interface RenderOptions {
   templateFactory: TemplateFactory;
   eventContext?: EventTarget;
+  nodePartValueHandlers: NodePartValueHandler<any>[];
 }

--- a/src/lib/render.ts
+++ b/src/lib/render.ts
@@ -17,6 +17,7 @@ import {NodePart} from './parts.js';
 import {RenderOptions} from './render-options.js';
 import {templateFactory} from './template-factory.js';
 import {TemplateResult} from './template-result.js';
+import { getDefaultHandlers } from './nodepart.js';
 
 export const parts = new WeakMap<Node, NodePart>();
 
@@ -44,6 +45,7 @@ export const render =
         removeNodes(container, container.firstChild);
         parts.set(container, part = new NodePart({
                                templateFactory,
+                               nodePartValueHandlers: getDefaultHandlers(),
                                ...options,
                              }));
         part.appendInto(container);

--- a/src/test/lib/parts_test.ts
+++ b/src/test/lib/parts_test.ts
@@ -14,8 +14,13 @@
 
 import {AttributeCommitter, AttributePart, createMarker, DefaultTemplateProcessor, EventPart, html, NodePart, render, templateFactory, TemplateResult} from '../../lit-html.js';
 import {stripExpressionMarkers} from '../test-utils/strip-markers.js';
+import { getDefaultHandlers } from '../../lib/nodepart.js';
 
 const assert = chai.assert;
+const defaultOptions = {
+  templateFactory,
+  nodePartValueHandlers: getDefaultHandlers()
+};
 
 suite('Parts', () => {
   suite('AttributePart', () => {
@@ -54,7 +59,7 @@ suite('Parts', () => {
       endNode = createMarker();
       container.appendChild(startNode);
       container.appendChild(endNode);
-      part = new NodePart({templateFactory});
+      part = new NodePart(defaultOptions);
       part.startNode = startNode;
       part.endNode = endNode;
     });
@@ -159,10 +164,10 @@ suite('Parts', () => {
               element: Element, name: string, strings: string[]) {
             if (name[0] === '&') {
               return super.handleAttributeExpressions(
-                  element, name.slice(1), strings, {templateFactory});
+                  element, name.slice(1), strings, defaultOptions);
             }
             return super.handleAttributeExpressions(
-                element, name, strings, {templateFactory});
+                element, name, strings, defaultOptions);
           }
         }
         const processor = new TestTemplateProcessor();
@@ -351,7 +356,7 @@ suite('Parts', () => {
           () => {
             const testEndNode = createMarker();
             container.appendChild(testEndNode);
-            const testPart = new NodePart({templateFactory});
+            const testPart = new NodePart(defaultOptions);
             testPart.insertAfterNode(endNode);
             assert.equal(testPart.startNode, endNode);
             assert.equal(testPart.endNode, testEndNode);
@@ -368,7 +373,7 @@ suite('Parts', () => {
       test(
           'inserts part and sets values between ref node and its next sibling',
           () => {
-            const testPart = new NodePart({templateFactory});
+            const testPart = new NodePart(defaultOptions);
             testPart.appendIntoPart(part);
             assert.instanceOf(testPart.startNode, Comment);
             assert.instanceOf(testPart.endNode, Comment);
@@ -396,7 +401,7 @@ suite('Parts', () => {
 
     suite('insertAfterPart', () => {
       test('inserts part and sets values after another part', () => {
-        const testPart = new NodePart({templateFactory});
+        const testPart = new NodePart(defaultOptions);
         testPart.insertAfterPart(part);
         assert.instanceOf(testPart.startNode, Comment);
         assert.equal(testPart.endNode, endNode);


### PR DESCRIPTION
Summary: This makes it possible to extend the types of values that a NodePart can render.

Instead of having a long `if{}else if{...}else{}` statement in the NodePart, pull all the code out and supply an array of tests and insert methods as part of the options. This way lit-html can be extended, through the options passed to the render function, so that it can handle new types of values passed to NodeParts. For example, if the [Promise support is moved to a directive](https://github.com/Polymer/lit-html/pull/555), this pull-request will make it possible to reapply the built-in support if that is what I want for my project. Or, I can add other value handlers, for example, this handler will serialize an object to a json string:

```ts
export const jsonHandler: NodePartValueHandler<Object> = {
  test(value: any): value is Object {
    return typeof value === 'object';
  },
  insert(part: NodePart, value: Object) {
    primitiveHandler.insert(part, JSON.stringify(value));
  }
}
```