### PR TITLE
Fix broken documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Efficient, Expressive, Extensible HTML templates in JavaScript
 
 ## Documentation
 
-Full documentation is available at [polymer.github.io/lit-html](https://polymer.github.io/lit-html).
+Full documentation is available at [https://lit-html.polymer-project.org/](https://lit-html.polymer-project.org).
 
 ## Overview
 


### PR DESCRIPTION
The documentation link in the `README.md` file is no longer working.