### PR TITLE
Rewrite attribute handling to always avoid IE/Edge value parsing and rewriting

### DIFF
--- a/src/lib/template-result.ts
+++ b/src/lib/template-result.ts
@@ -50,13 +50,11 @@ export class TemplateResult {
       // The Template class also appends the same suffix when looking up
       // attributes to creat Parts.
       let addedMarker = false;
-      acc += s.replace(lastAttributeNameRegex, (match, p1, p2, p3) => {
-        addedMarker = true;
-        return (p2.substring(p2.length - boundAttributeSuffix.length) ===
-                boundAttributeSuffix) ?
-            match :
-            `${p1}${p2}${boundAttributeSuffix}${p3}${marker}`;
-      });
+      acc += s.replace(
+          lastAttributeNameRegex, (_match, whitespace, name, value) => {
+            addedMarker = true;
+            return whitespace + name + boundAttributeSuffix + value + marker;
+          });
       if (!addedMarker) {
         acc += nodeMarker;
       }

--- a/src/lib/template-result.ts
+++ b/src/lib/template-result.ts
@@ -43,11 +43,15 @@ export class TemplateResult {
     let html = '';
     for (let i = 0; i < endIndex; i++) {
       const s = this.strings[i];
-      // Append a suffix to all bound attribute names to opt out of special
+      // This replace() call does two things:
+      // 1) Appends a suffix to all bound attribute names to opt out of special
       // attribute value parsing that IE11 and Edge do, like for style and
-      // many SVG attributes.
-      // The Template class also appends the same suffix when looking up
-      // attributes to creat Parts.
+      // many SVG attributes. The Template class also appends the same suffix
+      // when looking up attributes to creat Parts.
+      // 2) Adds an unquoted-attribute-safe marker for the first expression in
+      // an attribute. Subsequent attribute expressions will use node markers,
+      // and this is safe since attributes with multiple expressions are
+      // guaranteed to be quoted.
       let addedMarker = false;
       html += s.replace(
           lastAttributeNameRegex, (_match, whitespace, name, value) => {

--- a/src/lib/template-result.ts
+++ b/src/lib/template-result.ts
@@ -40,26 +40,25 @@ export class TemplateResult {
    */
   getHTML(): string {
     const endIndex = this.strings.length - 1;
-    return this.strings.reduce((acc, s, i) => {
-      if (i === endIndex) {
-        return acc + s;
-      }
+    let html = '';
+    for (let i = 0; i < endIndex; i++) {
+      const s = this.strings[i];
       // Append a suffix to all bound attribute names to opt out of special
       // attribute value parsing that IE11 and Edge do, like for style and
       // many SVG attributes.
       // The Template class also appends the same suffix when looking up
       // attributes to creat Parts.
       let addedMarker = false;
-      acc += s.replace(
+      html += s.replace(
           lastAttributeNameRegex, (_match, whitespace, name, value) => {
             addedMarker = true;
             return whitespace + name + boundAttributeSuffix + value + marker;
           });
       if (!addedMarker) {
-        acc += nodeMarker;
+        html += nodeMarker;
       }
-      return acc;
-    }, '');
+    }
+    return html + this.strings[endIndex];
   }
 
   getTemplateElement(): HTMLTemplateElement {

--- a/src/lib/template-result.ts
+++ b/src/lib/template-result.ts
@@ -14,7 +14,7 @@
 
 import {reparentNodes} from './dom.js';
 import {TemplateProcessor} from './template-processor.js';
-import {lastAttributeNameRegex, marker, nodeMarker, rewritesStyleAttribute} from './template.js';
+import {boundAttributeSuffix, lastAttributeNameRegex, marker, nodeMarker} from './template.js';
 
 /**
  * The return type of `html`, which holds a Template and the values from
@@ -39,32 +39,28 @@ export class TemplateResult {
    * Returns a string of HTML used to create a `<template>` element.
    */
   getHTML(): string {
-    const l = this.strings.length - 1;
-    let html = '';
-    let isTextBinding = true;
-    for (let i = 0; i < l; i++) {
-      const s = this.strings[i];
-      html += s;
-      const close = s.lastIndexOf('>');
-      // We're in a text position if the previous string closed its last tag, an
-      // attribute position if the string opened an unclosed tag, and unchanged
-      // if the string had no brackets at all:
-      //
-      // "...>...": text position. open === -1, close > -1
-      // "...<...": attribute position. open > -1
-      // "...": no change. open === -1, close === -1
-      isTextBinding =
-          (close > -1 || isTextBinding) && s.indexOf('<', close + 1) === -1;
-
-      if (!isTextBinding && rewritesStyleAttribute) {
-        html = html.replace(lastAttributeNameRegex, (match, p1, p2, p3) => {
-          return (p2 === 'style') ? `${p1}style$${p3}` : match;
-        });
+    const endIndex = this.strings.length - 1;
+    return this.strings.reduce((acc, s, i) => {
+      if (i === endIndex) {
+        return acc + s;
       }
-      html += isTextBinding ? nodeMarker : marker;
-    }
-    html += this.strings[l];
-    return html;
+      // Append a suffix to all bound attribute names to opt out of special
+      // attribute value parsing that IE11 and Edge do, like for style and
+      // many SVG attributes.
+      // The Template class also appends the same suffix when looking up
+      // attributes to creat Parts.
+      let addedMarker = false;
+      acc += s.replace(lastAttributeNameRegex, (match, p1, p2, p3) => {
+        addedMarker = true;
+        return (p2.substring(p2.length - 5) === boundAttributeSuffix) ?
+            match :
+            `${p1}${p2}${boundAttributeSuffix}${p3}${marker}`;
+      });
+      if (!addedMarker) {
+        acc += nodeMarker;
+      }
+      return acc;
+    }, '');
   }
 
   getTemplateElement(): HTMLTemplateElement {

--- a/src/lib/template-result.ts
+++ b/src/lib/template-result.ts
@@ -52,7 +52,8 @@ export class TemplateResult {
       let addedMarker = false;
       acc += s.replace(lastAttributeNameRegex, (match, p1, p2, p3) => {
         addedMarker = true;
-        return (p2.substring(p2.length - 5) === boundAttributeSuffix) ?
+        return (p2.substring(p2.length - boundAttributeSuffix.length) ===
+                boundAttributeSuffix) ?
             match :
             `${p1}${p2}${boundAttributeSuffix}${p3}${marker}`;
       });

--- a/src/lib/template.ts
+++ b/src/lib/template.ts
@@ -21,8 +21,8 @@ import {TemplateResult} from './template-result.js';
 export const marker = `{{lit-${String(Math.random()).slice(2)}}}`;
 
 /**
- * An expression marker used text-positions, not attribute positions,
- * in template.
+ * An expression marker used text-positions, multi-binding attributes, and
+ * attributes with markup-like text values.
  */
 export const nodeMarker = `<!--${marker}-->`;
 

--- a/src/lib/template.ts
+++ b/src/lib/template.ts
@@ -28,11 +28,10 @@ export const nodeMarker = `<!--${marker}-->`;
 
 export const markerRegex = new RegExp(`${marker}|${nodeMarker}`);
 
-export const rewritesStyleAttribute = (() => {
-  const el = document.createElement('div');
-  el.setAttribute('style', '{{bad value}}');
-  return el.getAttribute('style') !== '{{bad value}}';
-})();
+/**
+ * Suffix appended to all bound attribute names.
+ */
+export const boundAttributeSuffix = '$lit$';
 
 /**
  * An updateable Template that tracks the location of dynamic parts.
@@ -87,18 +86,12 @@ export class Template {
               // Find the attribute name
               const name = lastAttributeNameRegex.exec(stringForPart)![2];
               // Find the corresponding attribute
-              // If the attribute name contains special characters, lower-case
-              // it so that on XML nodes with case-sensitive getAttribute() we
-              // can still find the attribute, which will have been lower-cased
-              // by the parser.
-              //
-              // If the attribute name doesn't contain special character, it's
-              // important to _not_ lower-case it, in case the name is
-              // case-sensitive, like with XML attributes like "viewBox".
+              // All bound attributes have had a suffix added in
+              // TemplateResult#getHTML to opt out of special attribute
+              // handling. To look up the attribute value we also need to add
+              // the suffix.
               const attributeLookupName =
-                  (rewritesStyleAttribute && name === 'style') ?
-                  'style$' :
-                  /^[a-zA-Z-]*$/.test(name) ? name : name.toLowerCase();
+                  name.toLowerCase() + boundAttributeSuffix;
               const attributeValue = node.getAttribute(attributeLookupName)!;
               const strings = attributeValue.split(markerRegex);
               this.parts.push({type: 'attribute', index, name, strings});

--- a/src/test/lib/template-result_test.ts
+++ b/src/test/lib/template-result_test.ts
@@ -17,10 +17,6 @@ import {html} from '../../lit-html.js';
 
 const assert = chai.assert;
 
-const ua = window.navigator.userAgent;
-const isIe = ua.indexOf('Trident/') > 0;
-const testOnIE = isIe ? test : test.skip;
-
 suite('TemplateResult', () => {
   test('strings are identical for multiple calls', () => {
     const t = () => html``;
@@ -32,8 +28,8 @@ suite('TemplateResult', () => {
     assert.deepEqual(html`${foo}${bar}`.values, [foo, bar]);
   });
 
-  testOnIE('style attributes are renamed on IE', () => {
+  test('style attributes are renamed', () => {
     const templateHTML = html`<div style="color: ${'red'}"></div>`.getHTML();
-    assert.equal(templateHTML, `<div style$="color: ${marker}"></div>`);
+    assert.equal(templateHTML, `<div style$lit$="color: ${marker}"></div>`);
   });
 });

--- a/test/index.html
+++ b/test/index.html
@@ -24,7 +24,7 @@
     <script type="module" src="./directives/when_test.js"></script>
     <script type="module" src="./directives/classMap_test.js"></script>
     <script type="module" src="./directives/styleMap_test.js"></script>
-    <!-- <script>
+    <script>
       WCT.loadSuites([
         'shady.html',
         'shady.html?shadydom=true',
@@ -33,6 +33,6 @@
         'shady-apply.html?shadydom=true',
         'shady-apply.html?shadydom=true&shimcssproperties=true',
       ]);
-    </script> -->
+    </script>
   </body>
 </html>

--- a/test/index.html
+++ b/test/index.html
@@ -24,7 +24,7 @@
     <script type="module" src="./directives/when_test.js"></script>
     <script type="module" src="./directives/classMap_test.js"></script>
     <script type="module" src="./directives/styleMap_test.js"></script>
-    <script>
+    <!-- <script>
       WCT.loadSuites([
         'shady.html',
         'shady.html?shadydom=true',
@@ -33,6 +33,6 @@
         'shady-apply.html?shadydom=true',
         'shady-apply.html?shadydom=true&shimcssproperties=true',
       ]);
-    </script>
+    </script> -->
   </body>
 </html>


### PR DESCRIPTION
Fixes #594

This changes attribute handling pretty significantly. First, it always rewrites attributes now. We could add back the conditional to only rewrite on Edge. Second, it removes the `isTextBinding` check, and instead relies on the `lastAttributeNameRegex` check to tell us if an expression is in a text position. I was a bit worried about this regex matching for non-attribute cases, but not of the tests fail. I'll try to come up with some more cases to make sure.

@frankiefu, @keanulee, and @azakus it'd be awesome to try this branch with more real-world templates like we have in PWASK and MWC, if you have a chance to do that.