### PR TITLE
Ensure shady-render prepares styling for a scope before attaching child elements

### DIFF
--- a/src/lib/shady-render.ts
+++ b/src/lib/shady-render.ts
@@ -206,12 +206,11 @@ export interface ShadyRenderOptions extends Partial<RenderOptions> {
  *
  * * Whenever any dynamic changes are made which affect
  * css custom properties, `ShadyCSS.styleElement(element)` must be called
- * to update the element. This render method automatically does this on first
- * render, but if subsequent changes are made, this call is required. When
- * rendering via a custom element, it's common to include this call in the
- * element's `connectedCallback`.
- *
- * * Rendering a ShadowRoot within a directive is not supported.
+ * to update the element. There are two cases when this is needed:
+ * (1) the element is connected to a new parent, (2) a class is added to the
+ * element that causes it to match different custom properties.
+ * To address the first case when rendering a custom element, `styleElement`
+ * should be called in the element's `connectedCallback`.
  *
  * * Shimmed custom properties may only be defined either for an entire
  * shadowRoot (e.g. via `:host`) or via a rule that directly matches an element
@@ -243,9 +242,10 @@ export const render =
           {templateFactory: shadyTemplateFactory(scopeName), ...options} as
               RenderOptions);
       // When performing first scope render,
-      // (1) we've rendered into a fragment so that there's a chance to
+      // (1) We've rendered into a fragment so that there's a chance to
       // `prepareTemplateStyles` before sub-elements hit the DOM
-      // (where they would normally render);
+      // (which might cause them to render based on a common pattern of
+      // rendering in a custom element's `connectedCallback`);
       // (2) Scope the template with ShadyCSS one time only for this scope.
       // (3) Render the fragment into the container and make sure the
       // container knows its `part` is the one we just rendered. This ensures

--- a/src/test/lib/shady-render-apply_test.ts
+++ b/src/test/lib/shady-render-apply_test.ts
@@ -170,10 +170,12 @@ suite('shady-render @apply', () => {
         const applyProducer = document.createElement('apply-producer-ce');
         document.body.appendChild(applyProducer);
         renderShadowRoot(producerContent, applyProducer);
-        const user1 = applyProducer.shadowRoot!.querySelector('apply-user-ce1')!;
+        const user1 =
+            applyProducer.shadowRoot!.querySelector('apply-user-ce1')!;
         const userInProducerStyle1 =
             getComputedStyle(user1!.shadowRoot!.querySelector('div')!);
-        const user2 = applyProducer.shadowRoot!.querySelector('apply-user-ce2')!;
+        const user2 =
+            applyProducer.shadowRoot!.querySelector('apply-user-ce2')!;
         const userInProducerStyle2 =
             getComputedStyle(user2!.shadowRoot!.querySelector('div')!);
         assert.equal(

--- a/src/test/lib/shady-render-apply_test.ts
+++ b/src/test/lib/shady-render-apply_test.ts
@@ -127,12 +127,14 @@ suite('shady-render @apply', () => {
 
   // TODO(sorvell): remove skip when this ShadyCSS PR is merged:
   // https://github.com/webcomponents/shadycss/pull/227.
-  const testOrSkip = (window.ShadyCSS && !window.ShadyCSS.nativeCss ? test.skip : test);
-  testOrSkip('@apply styles flow to custom elements that render in connectedCallback', () => {
-
-    class E extends HTMLElement {
-      connectedCallback() {
-        const result = htmlWithApply`<style>
+  const testOrSkip =
+      (window.ShadyCSS && !window.ShadyCSS.nativeCss ? test.skip : test);
+  testOrSkip(
+      '@apply styles flow to custom elements that render in connectedCallback',
+      () => {
+        class E extends HTMLElement {
+          connectedCallback() {
+            const result = htmlWithApply`<style>
           div {
             border-top: 6px solid black;
             margin-top: 8px;
@@ -140,13 +142,13 @@ suite('shady-render @apply', () => {
           }
         </style>
         <div>Testing...</div>`;
-        renderShadowRoot(result, this);
-      }
-    }
-    customElements.define('apply-user-directive1', E);
-    customElements.define('apply-user-directive2', class extends E {});
+            renderShadowRoot(result, this);
+          }
+        }
+        customElements.define('apply-user-directive1', E);
+        customElements.define('apply-user-directive2', class extends E {});
 
-    const producerContent = htmlWithApply`
+        const producerContent = htmlWithApply`
       <style>
         apply-user-directive1 {
           --stuff-directive: {
@@ -165,29 +167,30 @@ suite('shady-render @apply', () => {
       <apply-user-directive1></apply-user-directive1>
       <apply-user-directive2></apply-user-directive2>
     `;
-    const applyProducer = document.createElement('apply-producer-directive');
-    document.body.appendChild(applyProducer);
-    renderShadowRoot(producerContent, applyProducer);
-    const user1 =
-        applyProducer.shadowRoot!.querySelector('apply-user-directive1')!;
-    const userInProducerStyle1 = getComputedStyle(
-        user1!.shadowRoot!.querySelector('div')!);
-    const user2 =
-        applyProducer.shadowRoot!.querySelector('apply-user-directive2')!;
-    const userInProducerStyle2 = getComputedStyle(
-        user2!.shadowRoot!.querySelector('div')!);
-    assert.equal(
-        userInProducerStyle1.getPropertyValue('border-top-width').trim(),
-        '10px');
-    assert.equal(
-        userInProducerStyle1.getPropertyValue('padding-top').trim(),
-        '20px');
-    assert.equal(
-        userInProducerStyle2.getPropertyValue('border-top-width').trim(),
-        '5px');
-    assert.equal(
-        userInProducerStyle2.getPropertyValue('padding-top').trim(),
-        '10px');
-    document.body.removeChild(applyProducer);
-  });
+        const applyProducer =
+            document.createElement('apply-producer-directive');
+        document.body.appendChild(applyProducer);
+        renderShadowRoot(producerContent, applyProducer);
+        const user1 =
+            applyProducer.shadowRoot!.querySelector('apply-user-directive1')!;
+        const userInProducerStyle1 =
+            getComputedStyle(user1!.shadowRoot!.querySelector('div')!);
+        const user2 =
+            applyProducer.shadowRoot!.querySelector('apply-user-directive2')!;
+        const userInProducerStyle2 =
+            getComputedStyle(user2!.shadowRoot!.querySelector('div')!);
+        assert.equal(
+            userInProducerStyle1.getPropertyValue('border-top-width').trim(),
+            '10px');
+        assert.equal(
+            userInProducerStyle1.getPropertyValue('padding-top').trim(),
+            '20px');
+        assert.equal(
+            userInProducerStyle2.getPropertyValue('border-top-width').trim(),
+            '5px');
+        assert.equal(
+            userInProducerStyle2.getPropertyValue('padding-top').trim(),
+            '10px');
+        document.body.removeChild(applyProducer);
+      });
 });

--- a/src/test/lib/shady-render-apply_test.ts
+++ b/src/test/lib/shady-render-apply_test.ts
@@ -135,48 +135,45 @@ suite('shady-render @apply', () => {
         class E extends HTMLElement {
           connectedCallback() {
             const result = htmlWithApply`<style>
-          div {
-            border-top: 6px solid black;
-            margin-top: 8px;
-            @apply --stuff-directive;
-          }
-        </style>
-        <div>Testing...</div>`;
+              div {
+                border-top: 6px solid black;
+                margin-top: 8px;
+                @apply --stuff-ce;
+              }
+            </style>
+            <div>Testing...</div>`;
             renderShadowRoot(result, this);
           }
         }
-        customElements.define('apply-user-directive1', E);
-        customElements.define('apply-user-directive2', class extends E {});
+        customElements.define('apply-user-ce1', E);
+        customElements.define('apply-user-ce2', class extends E {});
 
         const producerContent = htmlWithApply`
-      <style>
-        apply-user-directive1 {
-          --stuff-directive: {
-            border-top: 10px solid orange;
-            padding-top: 20px;
-          };
-        }
+          <style>
+            apply-user-ce1 {
+              --stuff-ce: {
+                border-top: 10px solid orange;
+                padding-top: 20px;
+              };
+            }
 
-        apply-user-directive2 {
-          --stuff-directive: {
-            border-top: 5px solid orange;
-            padding-top: 10px;
-          };
-        }
-      </style>
-      <apply-user-directive1></apply-user-directive1>
-      <apply-user-directive2></apply-user-directive2>
-    `;
-        const applyProducer =
-            document.createElement('apply-producer-directive');
+            apply-user-ce2 {
+              --stuff-ce: {
+                border-top: 5px solid orange;
+                padding-top: 10px;
+              };
+            }
+          </style>
+          <apply-user-ce1></apply-user-ce1>
+          <apply-user-ce2></apply-user-ce2>
+        `;
+        const applyProducer = document.createElement('apply-producer-ce');
         document.body.appendChild(applyProducer);
         renderShadowRoot(producerContent, applyProducer);
-        const user1 =
-            applyProducer.shadowRoot!.querySelector('apply-user-directive1')!;
+        const user1 = applyProducer.shadowRoot!.querySelector('apply-user-ce1')!;
         const userInProducerStyle1 =
             getComputedStyle(user1!.shadowRoot!.querySelector('div')!);
-        const user2 =
-            applyProducer.shadowRoot!.querySelector('apply-user-directive2')!;
+        const user2 = applyProducer.shadowRoot!.querySelector('apply-user-ce2')!;
         const userInProducerStyle2 =
             getComputedStyle(user2!.shadowRoot!.querySelector('div')!);
         assert.equal(

--- a/src/test/lib/shady-render-apply_test.ts
+++ b/src/test/lib/shady-render-apply_test.ts
@@ -119,9 +119,75 @@ suite('shady-render @apply', () => {
           document.body.removeChild(applyProducer);
         };
 
-        // test multiple times to make sure theren's no bad interaction
+        // test multiple times to make sure there's no bad interaction
         testApplyProducer();
         testApplyUser();
         testApplyProducer();
       });
+
+  // TODO(sorvell): remove skip when this ShadyCSS PR is merged:
+  // https://github.com/webcomponents/shadycss/pull/227.
+  const testOrSkip = (window.ShadyCSS && !window.ShadyCSS.nativeCss ? test.skip : test);
+  testOrSkip('@apply styles flow to custom elements that render in connectedCallback', () => {
+
+    class E extends HTMLElement {
+      connectedCallback() {
+        const result = htmlWithApply`<style>
+          div {
+            border-top: 6px solid black;
+            margin-top: 8px;
+            @apply --stuff-directive;
+          }
+        </style>
+        <div>Testing...</div>`;
+        renderShadowRoot(result, this);
+      }
+    }
+    customElements.define('apply-user-directive1', E);
+    customElements.define('apply-user-directive2', class extends E {});
+
+    const producerContent = htmlWithApply`
+      <style>
+        apply-user-directive1 {
+          --stuff-directive: {
+            border-top: 10px solid orange;
+            padding-top: 20px;
+          };
+        }
+
+        apply-user-directive2 {
+          --stuff-directive: {
+            border-top: 5px solid orange;
+            padding-top: 10px;
+          };
+        }
+      </style>
+      <apply-user-directive1></apply-user-directive1>
+      <apply-user-directive2></apply-user-directive2>
+    `;
+    const applyProducer = document.createElement('apply-producer-directive');
+    document.body.appendChild(applyProducer);
+    renderShadowRoot(producerContent, applyProducer);
+    const user1 =
+        applyProducer.shadowRoot!.querySelector('apply-user-directive1')!;
+    const userInProducerStyle1 = getComputedStyle(
+        user1!.shadowRoot!.querySelector('div')!);
+    const user2 =
+        applyProducer.shadowRoot!.querySelector('apply-user-directive2')!;
+    const userInProducerStyle2 = getComputedStyle(
+        user2!.shadowRoot!.querySelector('div')!);
+    assert.equal(
+        userInProducerStyle1.getPropertyValue('border-top-width').trim(),
+        '10px');
+    assert.equal(
+        userInProducerStyle1.getPropertyValue('padding-top').trim(),
+        '20px');
+    assert.equal(
+        userInProducerStyle2.getPropertyValue('border-top-width').trim(),
+        '5px');
+    assert.equal(
+        userInProducerStyle2.getPropertyValue('padding-top').trim(),
+        '10px');
+    document.body.removeChild(applyProducer);
+  });
 });

--- a/src/test/lib/shady-render_test.ts
+++ b/src/test/lib/shady-render_test.ts
@@ -18,7 +18,6 @@ import {renderShadowRoot} from '../test-utils/shadow-root.js';
 const assert = chai.assert;
 
 suite('shady-render', () => {
-
   test('style elements apply in shadowRoots', () => {
     const container = document.createElement('scope-1');
     document.body.appendChild(container);
@@ -91,13 +90,12 @@ suite('shady-render', () => {
   test('multiple renders re-use rendered DOM', () => {
     const container = document.createElement('scope-re-use');
     document.body.appendChild(container);
-    const renderTemplate =
-        (a: string) => {
-          const result = html`
+    const renderTemplate = (a: string) => {
+      const result = html`
             <div id="a">${a}</div>
       `;
-          renderShadowRoot(result, container);
-        };
+      renderShadowRoot(result, container);
+    };
     renderTemplate('a');
     const renderedNode = container.shadowRoot!.querySelector('#a');
     renderTemplate('b');

--- a/src/test/lib/shady-render_test.ts
+++ b/src/test/lib/shady-render_test.ts
@@ -18,6 +18,7 @@ import {renderShadowRoot} from '../test-utils/shadow-root.js';
 const assert = chai.assert;
 
 suite('shady-render', () => {
+
   test('style elements apply in shadowRoots', () => {
     const container = document.createElement('scope-1');
     document.body.appendChild(container);
@@ -85,6 +86,23 @@ suite('shady-render', () => {
     assert.equal(container2.shadowRoot!.textContent, '44-55-66');
     document.body.removeChild(container1);
     document.body.removeChild(container2);
+  });
+
+  test('multiple renders re-use rendered DOM', () => {
+    const container = document.createElement('scope-re-use');
+    document.body.appendChild(container);
+    const renderTemplate =
+        (a: string) => {
+          const result = html`
+            <div id="a">${a}</div>
+      `;
+          renderShadowRoot(result, container);
+        };
+    renderTemplate('a');
+    const renderedNode = container.shadowRoot!.querySelector('#a');
+    renderTemplate('b');
+    assert.equal(container.shadowRoot!.querySelector('#a'), renderedNode);
+    document.body.removeChild(container);
   });
 
   test('styles with css custom properties render', () => {


### PR DESCRIPTION
Fixes #518. First rendering to a scope is handled specially by (1) rendering to a fragment, (2) letting ShadyCSS scope styles on the template, (3) moving the fragment to the rendering container and making sure that container uses the part we just rendered.