### PR TITLE
Correct 'until' example

### DIFF
--- a/docs/_guide/03-template-reference.md
+++ b/docs/_guide/03-template-reference.md
@@ -351,7 +351,7 @@ import { until } from 'lit-html/directives/until.js';
 
 const content = fetch('./content.txt').then(r => r.text());
 
-html`${async(content, html`<span>Loading...</span>`)}`
+html`${until(content, html`<span>Loading...</span>`)}`
 ```
 
 ### asyncAppend and asyncReplace


### PR DESCRIPTION
One reference to 'async' that escaped the original change.