### PR TITLE
[docs] Add scripts for managing docs

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -1,0 +1,3 @@
+{
+  "lockfileVersion": 1
+}

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,0 +1,8 @@
+{
+  "private": true,
+  "scripts": {
+    "build": "jekyll build",
+    "serve": "dev_appserver.py _site/app.yaml",
+    "deploy": "npm run build && gcloud app deploy _site/app.yaml --project polymer-lit-html --no-promote"
+  }
+}


### PR DESCRIPTION
The idea is to add a package.json for all the product docs sites so that they can all use the same commands:

```
npm run build
npm run serve
npm run deploy
```

And hide the jekyll/gulp stuff behind this. If this is fine, I'll follow with PRs for the other repos.