### PR TITLE
Fix unsafeHTML

### DIFF
--- a/src/directives/unsafe-html.ts
+++ b/src/directives/unsafe-html.ts
@@ -12,7 +12,7 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import { directive, NodePart, Part } from '../lit-html.js';
+import {directive, NodePart, Part} from '../lit-html.js';
 
 /**
  * Renders the result as HTML, rather than text.
@@ -23,14 +23,15 @@ import { directive, NodePart, Part } from '../lit-html.js';
  */
 
 type CachedTemplate = {
-  template: HTMLTemplateElement;
-  fragment: DocumentFragment;
+  template: HTMLTemplateElement; fragment: DocumentFragment;
 };
 
-// Use a cache for TemplateElements so we don't have to parse the same HTML string twice
+// Use a cache for TemplateElements so we don't have to parse the same HTML
+// string twice
 const templateCache = new Map<string, HTMLTemplateElement>();
 
-// For each part, remember the TemplateElement that was last used to render in that part, and the DocumentFragment that was last set as a value.
+// For each part, remember the TemplateElement that was last used to render in
+// that part, and the DocumentFragment that was last set as a value.
 const partValues = new WeakMap<NodePart, CachedTemplate>();
 
 export const unsafeHTML = directive((value: any) => (part: Part): void => {
@@ -53,12 +54,13 @@ export const unsafeHTML = directive((value: any) => (part: Part): void => {
   /**
    * Need to render only if one of the following is true
    * - This part never rendered unsafeHTML previously
-   * - The new template is different from the previously rendered template
-   * - The current value of the part is different from the previously rendered fragment
+   * - The new template is different from the previousl template
+   * - The current value of the part is different from the previous fragment
    */
-  if (!previousValue || template !== previousValue.template || part.value !== previousValue.fragment) {
+  if (!previousValue || template !== previousValue.template ||
+      part.value !== previousValue.fragment) {
     const fragment = document.importNode(template.content, true);
     part.setValue(fragment);
-    partValues.set(part, { template, fragment });
+    partValues.set(part, {template, fragment});
   }
 });

--- a/src/directives/unsafe-html.ts
+++ b/src/directives/unsafe-html.ts
@@ -41,6 +41,7 @@ export const unsafeHTML = directive((value: any) => (part: Part): void => {
   // Cast value to String only if necessary, to improve cache lookups
   const htmlString = typeof value === 'string' ? value : String(value);
 
+  // Get a TemplateElement that represents this htmlString
   let template = templateCache.get(htmlString);
   if (!template) {
     template = document.createElement('template');
@@ -52,8 +53,8 @@ export const unsafeHTML = directive((value: any) => (part: Part): void => {
   /**
    * Need to render only if one of the following is true
    * - This part never rendered unsafeHTML previously
-   * - The new template does not match the previously rendered template
-   * - The previously rendered fragment is not the current value of the part
+   * - The new template is different from the previously rendered template
+   * - The current value of the part is different from the previously rendered fragment
    */
   if (!previousValue || template !== previousValue.template || part.value !== previousValue.fragment) {
     const fragment = document.importNode(template.content, true);

--- a/src/directives/unsafe-html.ts
+++ b/src/directives/unsafe-html.ts
@@ -12,7 +12,7 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {directive, isPrimitive, NodePart, Part} from '../lit-html.js';
+import { directive, NodePart, Part } from '../lit-html.js';
 
 /**
  * Renders the result as HTML, rather than text.
@@ -22,21 +22,42 @@ import {directive, isPrimitive, NodePart, Part} from '../lit-html.js';
  * vulnerabilities.
  */
 
-const previousValues = new WeakMap<NodePart, string>();
+type CachedTemplate = {
+  template: HTMLTemplateElement;
+  fragment: DocumentFragment;
+};
+
+// Use a cache for TemplateElements so we don't have to parse the same HTML string twice
+const templateCache = new Map<string, HTMLTemplateElement>();
+
+// For each part, remember the TemplateElement that was last used to render in that part, and the DocumentFragment that was last set as a value.
+const partValues = new WeakMap<NodePart, CachedTemplate>();
 
 export const unsafeHTML = directive((value: any) => (part: Part): void => {
   if (!(part instanceof NodePart)) {
     throw new Error('unsafeHTML can only be used in text bindings');
   }
-  // Dirty check primitive values
-  const previousValue = previousValues.get(part);
-  if (previousValue === value && isPrimitive(value)) {
-    return;
+
+  // Cast value to String only if necessary, to improve cache lookups
+  const htmlString = typeof value === 'string' ? value : String(value);
+
+  let template = templateCache.get(htmlString);
+  if (!template) {
+    template = document.createElement('template');
+    template.innerHTML = htmlString;
+    templateCache.set(htmlString, template);
   }
 
-  // Use a <template> to parse HTML into Nodes
-  const tmp = document.createElement('template');
-  tmp.innerHTML = value;
-  part.setValue(document.importNode(tmp.content, true));
-  previousValues.set(part, value);
+  const previousValue = partValues.get(part);
+  /**
+   * Need to render only if one of the following is true
+   * - This part never rendered unsafeHTML previously
+   * - The new template does not match the previously rendered template
+   * - The previously rendered fragment is not the current value of the part
+   */
+  if (!previousValue || template !== previousValue.template || part.value !== previousValue.fragment) {
+    const fragment = document.importNode(template.content, true);
+    part.setValue(fragment);
+    partValues.set(part, { template, fragment });
+  }
 });

--- a/src/test/directives/unsafe-html_test.ts
+++ b/src/test/directives/unsafe-html_test.ts
@@ -28,7 +28,7 @@ suite('unsafeHTML', () => {
 
   test('renders HTML', () => {
     render(
-        html`<div>before${unsafeHTML('<span>inner</span>after</div>')}`,
+        html`<div>before${unsafeHTML('<span>inner</span>after')}</div>`,
         container);
     assert.equal(
         stripExpressionMarkers(container.innerHTML),
@@ -70,5 +70,23 @@ suite('unsafeHTML', () => {
     value[0] = 'bbb';
     render(t(), container);
     assert.equal(stripExpressionMarkers(container.innerHTML), '<div>bbb</div>');
+  });
+
+  test('renders after other values', () => {
+    const value = '<span></span>';
+    const primitive = 'aaa';
+    const t = (content: any) => html`<div>${content}</div>`;
+
+    // Initial unsafeHTML render
+    render(t(unsafeHTML(value)), container);
+    assert.equal(stripExpressionMarkers(container.innerHTML), '<div><span></span></div>');
+
+    // Re-render with a non-unsafeHTML value
+    render(t(primitive), container);
+    assert.equal(stripExpressionMarkers(container.innerHTML), '<div>aaa</div>');
+
+    // Re-render with unsafeHTML again
+    render(t(unsafeHTML(value)), container);
+    assert.equal(stripExpressionMarkers(container.innerHTML), '<div><span></span></div>');
   });
 });

--- a/src/test/directives/unsafe-html_test.ts
+++ b/src/test/directives/unsafe-html_test.ts
@@ -79,7 +79,9 @@ suite('unsafeHTML', () => {
 
     // Initial unsafeHTML render
     render(t(unsafeHTML(value)), container);
-    assert.equal(stripExpressionMarkers(container.innerHTML), '<div><span></span></div>');
+    assert.equal(
+        stripExpressionMarkers(container.innerHTML),
+        '<div><span></span></div>');
 
     // Re-render with a non-unsafeHTML value
     render(t(primitive), container);
@@ -87,6 +89,8 @@ suite('unsafeHTML', () => {
 
     // Re-render with unsafeHTML again
     render(t(unsafeHTML(value)), container);
-    assert.equal(stripExpressionMarkers(container.innerHTML), '<div><span></span></div>');
+    assert.equal(
+        stripExpressionMarkers(container.innerHTML),
+        '<div><span></span></div>');
   });
 });


### PR DESCRIPTION
This fixes #702 - and adds a regression test for this case.

Unfortunately fixing the problem requires keeping a cache for previously rendered `HTMLTemplateElements` and `DocumentFragments`, so we can compare vs the current `Part.value`. Without this there is no way to check if the part rendered another value after the previous unsafeHTML render. This means there is some additional memory overhead, but I don't see how it can be avoided.

I added a cache for `HTMLTemplateElement` to ensure the same input string is never parsed twice. Previously, this directive would build duplicate templates if the same input was used across multiple instances. This will generally speed up execution, depending on how often similar strings are used. This also obviates the need for an 'isPrimitive' check.