### PR TITLE
Fix formatting error

### DIFF
--- a/src/polyfills/template_polyfill.ts
+++ b/src/polyfills/template_polyfill.ts
@@ -46,7 +46,8 @@ export const initTemplatePolyfill = (forced = false) => {
   };
 
   const capturedCreateElement = Document.prototype.createElement;
-  Document.prototype.createElement = function createElement(tagName: string, options?: ElementCreationOptions) {
+  Document.prototype.createElement = function createElement(
+      tagName: string, options?: ElementCreationOptions) {
     let el = capturedCreateElement.call(this, tagName, options);
     if (el.localName === 'template') {
       el = capturedCreateElement.call(this, 'div');


### PR DESCRIPTION
This fixes a formatting error on `master`. It's causing CI on master to fail, which means CI for all PRs also fails at the moment.