### PR TITLE
Use data property

### DIFF
--- a/src/lib/parts.ts
+++ b/src/lib/parts.ts
@@ -230,7 +230,7 @@ export class NodePart implements Part {
       // If we only have a single text node between the markers, we can just
       // set its value, rather than replacing it.
       // TODO(justinfagnani): Can we just check if this.value is primitive?
-      node.textContent = value;
+      (node as Text).data = value;
     } else {
       this._commitNode(document.createTextNode(
           typeof value === 'string' ? value : String(value)));


### PR DESCRIPTION
Smaller, and little faster.

Unfortunately, it dirties the type checking a bit. It'd be nice if typescript could detect `nodeType === 3` as a type guard for `Text`... Right now the best we could do is [user defined type guard](https://www.typescriptlang.org/docs/handbook/advanced-types.html#user-defined-type-guards) but that's too big.