### PR TITLE
Don't set value after committing the node

### DIFF
--- a/src/lib/parts.ts
+++ b/src/lib/parts.ts
@@ -230,12 +230,11 @@ export class NodePart implements Part {
       // If we only have a single text node between the markers, we can just
       // set its value, rather than replacing it.
       // TODO(justinfagnani): Can we just check if this.value is primitive?
-      node.textContent = value;
+      this.value = node.textContent = value;
     } else {
       this._commitNode(document.createTextNode(
           typeof value === 'string' ? value : String(value)));
     }
-    this.value = value;
   }
 
   private _commitTemplateResult(value: TemplateResult): void {


### PR DESCRIPTION
When you [commit the node](https://github.com/polymer/lit-html/blob/c173c59ca612df0ad6767428a964861ef684edef/src/lib/parts.ts#L216) it checks against `this.value` and will assign it if it's not already that value so there's no need to do it again.