### PR TITLE
Minor refactoring

### DIFF
--- a/src/directives/async-append.ts
+++ b/src/directives/async-append.ts
@@ -12,7 +12,7 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {createMarker, directive, NodePart, Part} from '../lit-html.js';
+import {createMarker, directive, NodePart, Part} from '../lit-html';
 
 /**
  * A directive that renders the items of an async iterable[1], appending new

--- a/src/directives/async-replace.ts
+++ b/src/directives/async-replace.ts
@@ -12,7 +12,7 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {directive, NodePart, Part} from '../lit-html.js';
+import {directive, NodePart, Part} from '../lit-html';
 
 /**
  * A directive that renders the items of an async iterable[1], replacing

--- a/src/directives/cache.ts
+++ b/src/directives/cache.ts
@@ -12,9 +12,9 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {TemplateInstance} from '../lib/template-instance.js';
-import {Template} from '../lib/template.js';
-import {directive, NodePart, Part, reparentNodes, TemplateResult} from '../lit-html.js';
+import {Template} from '../lib/template';
+import {TemplateInstance} from '../lib/template-instance';
+import {directive, NodePart, Part, reparentNodes, TemplateResult} from '../lit-html';
 
 type CachedTemplate = {
   instance: TemplateInstance,

--- a/src/directives/class-map.ts
+++ b/src/directives/class-map.ts
@@ -12,7 +12,7 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {AttributePart, directive, Part, PropertyPart} from '../lit-html.js';
+import {AttributePart, directive, Part, PropertyPart} from '../lit-html';
 
 
 // On IE11, classList.toggle doesn't accept a second argument.

--- a/src/directives/guard.ts
+++ b/src/directives/guard.ts
@@ -12,7 +12,7 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {directive, Part} from '../lit-html.js';
+import {directive, Part} from '../lit-html';
 
 const previousValues = new WeakMap<Part, unknown>();
 

--- a/src/directives/if-defined.ts
+++ b/src/directives/if-defined.ts
@@ -12,7 +12,7 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {AttributePart, directive, Part} from '../lit-html.js';
+import {AttributePart, directive, Part} from '../lit-html';
 
 /**
  * For AttributeParts, sets the attribute if the value is defined and removes

--- a/src/directives/repeat.ts
+++ b/src/directives/repeat.ts
@@ -12,8 +12,8 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {DirectiveFn} from '../lib/directive.js';
-import {createMarker, directive, NodePart, Part, removeNodes, reparentNodes} from '../lit-html.js';
+import {DirectiveFn} from '../lib/directive';
+import {createMarker, directive, NodePart, Part, removeNodes, reparentNodes} from '../lit-html';
 
 export type KeyFn<T> = (item: T, index: number) => any;
 export type ItemTemplate<T> = (item: T, index: number) => any;

--- a/src/directives/style-map.ts
+++ b/src/directives/style-map.ts
@@ -12,7 +12,7 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {AttributePart, directive, Part, PropertyPart} from '../lit-html.js';
+import {AttributePart, directive, Part, PropertyPart} from '../lit-html';
 
 export interface StyleInfo {
   [name: string]: string;

--- a/src/directives/unsafe-html.ts
+++ b/src/directives/unsafe-html.ts
@@ -12,8 +12,8 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {isPrimitive} from '../lib/parts.js';
-import {directive, NodePart, Part} from '../lit-html.js';
+import {isPrimitive} from '../lib/parts';
+import {directive, NodePart, Part} from '../lit-html';
 
 interface PreviousValue {
   value: any;

--- a/src/directives/until.ts
+++ b/src/directives/until.ts
@@ -12,8 +12,8 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {isPrimitive} from '../lib/parts.js';
-import {directive, Part} from '../lit-html.js';
+import {isPrimitive} from '../lib/parts';
+import {directive, Part} from '../lit-html';
 
 interface AsyncState {
   /**

--- a/src/lib/default-template-processor.ts
+++ b/src/lib/default-template-processor.ts
@@ -39,8 +39,8 @@ export class DefaultTemplateProcessor implements TemplateProcessor {
       options: RenderOptions): Part[] {
     const prefix = name[0];
     if (prefix === '.') {
-      const comitter = new PropertyCommitter(element, name.slice(1), strings);
-      return comitter.parts;
+      const committer = new PropertyCommitter(element, name.slice(1), strings);
+      return committer.parts;
     }
     if (prefix === '@') {
       return [new EventPart(element, name.slice(1), options.eventContext)];
@@ -48,8 +48,8 @@ export class DefaultTemplateProcessor implements TemplateProcessor {
     if (prefix === '?') {
       return [new BooleanAttributePart(element, name.slice(1), strings)];
     }
-    const comitter = new AttributeCommitter(element, name, strings);
-    return comitter.parts;
+    const committer = new AttributeCommitter(element, name, strings);
+    return committer.parts;
   }
   /**
    * Create parts for a text-position binding.

--- a/src/lib/default-template-processor.ts
+++ b/src/lib/default-template-processor.ts
@@ -16,10 +16,10 @@
  * @module lit-html
  */
 
-import {Part} from './part.js';
-import {AttributeCommitter, BooleanAttributePart, EventPart, NodePart, PropertyCommitter} from './parts.js';
-import {RenderOptions} from './render-options.js';
-import {TemplateProcessor} from './template-processor.js';
+import {Part} from './part';
+import {AttributeCommitter, BooleanAttributePart, EventPart, NodePart, PropertyCommitter} from './parts';
+import {RenderOptions} from './render-options';
+import {TemplateProcessor} from './template-processor';
 
 /**
  * Creates Parts when a template is instantiated.

--- a/src/lib/directive.ts
+++ b/src/lib/directive.ts
@@ -16,7 +16,7 @@
  * @module lit-html
  */
 
-import {Part} from './part.js';
+import {Part} from './part';
 
 const directives = new WeakMap<any, Boolean>();
 

--- a/src/lib/modify-template.ts
+++ b/src/lib/modify-template.ts
@@ -16,7 +16,7 @@
  * @module shady-render
  */
 
-import {isTemplatePartActive, Template, TemplatePart} from './template.js';
+import {isTemplatePartActive, Template, TemplatePart} from './template';
 
 const walkerNodeFilter = 133 /* NodeFilter.SHOW_{ELEMENT|COMMENT|TEXT} */;
 

--- a/src/lib/parts.ts
+++ b/src/lib/parts.ts
@@ -16,13 +16,13 @@
  * @module lit-html
  */
 
-import {isDirective} from './directive.js';
-import {removeNodes} from './dom.js';
-import {noChange, nothing, Part} from './part.js';
-import {RenderOptions} from './render-options.js';
-import {TemplateInstance} from './template-instance.js';
-import {TemplateResult} from './template-result.js';
-import {createMarker} from './template.js';
+import {isDirective} from './directive';
+import {removeNodes} from './dom';
+import {noChange, nothing, Part} from './part';
+import {RenderOptions} from './render-options';
+import {createMarker} from './template';
+import {TemplateInstance} from './template-instance';
+import {TemplateResult} from './template-result';
 
 export const isPrimitive = (value: any) =>
     (value === null ||

--- a/src/lib/parts.ts
+++ b/src/lib/parts.ts
@@ -33,24 +33,18 @@ export const isPrimitive = (value: any) =>
  * even if there are multiple parts for an attribute.
  */
 export class AttributeCommitter {
-  element: Element;
-  name: string;
-  strings: string[];
-  parts: AttributePart[];
+  parts: AttributePart[] = [];
   dirty = true;
 
-  constructor(element: Element, name: string, strings: string[]) {
-    this.element = element;
-    this.name = name;
-    this.strings = strings;
-    this.parts = [];
+  constructor(
+      public element: Element, public name: string, public strings: string[]) {
     for (let i = 0; i < strings.length - 1; i++) {
       this.parts[i] = this._createPart();
     }
   }
 
   /**
-   * Creates a single part. Override this to create a differnt type of part.
+   * Creates a single part. Override this to create a different type of part.
    */
   protected _createPart(): AttributePart {
     return new AttributePart(this);
@@ -90,11 +84,9 @@ export class AttributeCommitter {
 }
 
 export class AttributePart implements Part {
-  committer: AttributeCommitter;
   value: any = undefined;
 
-  constructor(comitter: AttributeCommitter) {
-    this.committer = comitter;
+  constructor(public committer: AttributeCommitter) {
   }
 
   setValue(value: any): void {
@@ -123,14 +115,12 @@ export class AttributePart implements Part {
 }
 
 export class NodePart implements Part {
-  options: RenderOptions;
   startNode!: Node;
   endNode!: Node;
   value: any = undefined;
   _pendingValue: any = undefined;
 
-  constructor(options: RenderOptions) {
-    this.options = options;
+  constructor(public options: RenderOptions) {
   }
 
   /**
@@ -318,20 +308,15 @@ export class NodePart implements Part {
  * ''. If the value is falsey, the attribute is removed.
  */
 export class BooleanAttributePart implements Part {
-  element: Element;
-  name: string;
-  strings: string[];
   value: any = undefined;
   _pendingValue: any = undefined;
 
-  constructor(element: Element, name: string, strings: string[]) {
+  constructor(
+      public element: Element, public name: string, public strings: string[]) {
     if (strings.length !== 2 || strings[0] !== '' || strings[1] !== '') {
       throw new Error(
           'Boolean attributes can only contain a single expression');
     }
-    this.element = element;
-    this.name = name;
-    this.strings = strings;
   }
 
   setValue(value: any): void {
@@ -418,18 +403,14 @@ try {
 }
 
 export class EventPart implements Part {
-  element: Element;
-  eventName: string;
-  eventContext?: EventTarget;
   value: any = undefined;
   _options?: AddEventListenerOptions;
   _pendingValue: any = undefined;
   _boundHandleEvent: (event: Event) => void;
 
-  constructor(element: Element, eventName: string, eventContext?: EventTarget) {
-    this.element = element;
-    this.eventName = eventName;
-    this.eventContext = eventContext;
+  constructor(
+      public element: Element, public eventName: string,
+      public eventContext?: EventTarget) {
     this._boundHandleEvent = (e) => this.handleEvent(e);
   }
 

--- a/src/lib/render-options.ts
+++ b/src/lib/render-options.ts
@@ -16,7 +16,7 @@
  * @module lit-html
  */
 
-import {TemplateFactory} from './template-factory.js';
+import {TemplateFactory} from './template-factory';
 
 export interface RenderOptions {
   templateFactory: TemplateFactory;

--- a/src/lib/render.ts
+++ b/src/lib/render.ts
@@ -16,11 +16,11 @@
  * @module lit-html
  */
 
-import {removeNodes} from './dom.js';
-import {NodePart} from './parts.js';
-import {RenderOptions} from './render-options.js';
-import {templateFactory} from './template-factory.js';
-import {TemplateResult} from './template-result.js';
+import {removeNodes} from './dom';
+import {NodePart} from './parts';
+import {RenderOptions} from './render-options';
+import {templateFactory} from './template-factory';
+import {TemplateResult} from './template-result';
 
 export const parts = new WeakMap<Node, NodePart>();
 

--- a/src/lib/shady-render.ts
+++ b/src/lib/shady-render.ts
@@ -24,16 +24,16 @@
  * Do not remove this comment; it keeps typedoc from misplacing the module
  * docs.
  */
-import {removeNodes} from './dom.js';
-import {insertNodeIntoTemplate, removeNodesFromTemplate} from './modify-template.js';
-import {RenderOptions} from './render-options.js';
-import {parts, render as litRender} from './render.js';
-import {templateCaches} from './template-factory.js';
-import {TemplateInstance} from './template-instance.js';
-import {TemplateResult} from './template-result.js';
-import {marker, Template} from './template.js';
+import {removeNodes} from './dom';
+import {insertNodeIntoTemplate, removeNodesFromTemplate} from './modify-template';
+import {parts, render as litRender} from './render';
+import {RenderOptions} from './render-options';
+import {marker, Template} from './template';
+import {templateCaches} from './template-factory';
+import {TemplateInstance} from './template-instance';
+import {TemplateResult} from './template-result';
 
-export {html, svg, TemplateResult} from '../lit-html.js';
+export {html, svg, TemplateResult} from '../lit-html';
 
 // Get a key to lookup in `templateCaches`.
 const getTemplateCacheKey = (type: string, scopeName: string) =>

--- a/src/lib/template-factory.ts
+++ b/src/lib/template-factory.ts
@@ -16,8 +16,8 @@
  * @module lit-html
  */
 
-import {TemplateResult} from './template-result.js';
-import {marker, Template} from './template.js';
+import {marker, Template} from './template';
+import {TemplateResult} from './template-result';
 
 /**
  * A function type that creates a Template from a TemplateResult.

--- a/src/lib/template-instance.ts
+++ b/src/lib/template-instance.ts
@@ -28,16 +28,10 @@ import {isTemplatePartActive, Template} from './template.js';
  */
 export class TemplateInstance {
   _parts: Array<Part|undefined> = [];
-  processor: TemplateProcessor;
-  options: RenderOptions;
-  template: Template;
 
   constructor(
-      template: Template, processor: TemplateProcessor,
-      options: RenderOptions) {
-    this.template = template;
-    this.processor = processor;
-    this.options = options;
+      public template: Template, public processor: TemplateProcessor,
+      public options: RenderOptions) {
   }
 
   update(values: any[]) {

--- a/src/lib/template-instance.ts
+++ b/src/lib/template-instance.ts
@@ -16,11 +16,11 @@
  * @module lit-html
  */
 
-import {isCEPolyfill} from './dom.js';
-import {Part} from './part.js';
-import {RenderOptions} from './render-options.js';
-import {TemplateProcessor} from './template-processor.js';
-import {isTemplatePartActive, Template} from './template.js';
+import {isCEPolyfill} from './dom';
+import {Part} from './part';
+import {RenderOptions} from './render-options';
+import {isTemplatePartActive, Template} from './template';
+import {TemplateProcessor} from './template-processor';
 
 /**
  * An instance of a `Template` that can be attached to the DOM and updated

--- a/src/lib/template-processor.ts
+++ b/src/lib/template-processor.ts
@@ -16,9 +16,9 @@
  * @module lit-html
  */
 
-import {Part} from './part.js';
-import {NodePart} from './parts.js';
-import {RenderOptions} from './render-options.js';
+import {Part} from './part';
+import {NodePart} from './parts';
+import {RenderOptions} from './render-options';
 
 export interface TemplateProcessor {
   /**

--- a/src/lib/template-result.ts
+++ b/src/lib/template-result.ts
@@ -16,9 +16,9 @@
  * @module lit-html
  */
 
-import {reparentNodes} from './dom.js';
-import {TemplateProcessor} from './template-processor.js';
-import {boundAttributeSuffix, lastAttributeNameRegex, marker, nodeMarker} from './template.js';
+import {reparentNodes} from './dom';
+import {boundAttributeSuffix, lastAttributeNameRegex, marker, nodeMarker} from './template';
+import {TemplateProcessor} from './template-processor';
 
 /**
  * The return type of `html`, which holds a Template and the values from

--- a/src/lib/template-result.ts
+++ b/src/lib/template-result.ts
@@ -25,18 +25,9 @@ import {boundAttributeSuffix, lastAttributeNameRegex, marker, nodeMarker} from '
  * interpolated expressions.
  */
 export class TemplateResult {
-  strings: TemplateStringsArray;
-  values: any[];
-  type: string;
-  processor: TemplateProcessor;
-
   constructor(
-      strings: TemplateStringsArray, values: any[], type: string,
-      processor: TemplateProcessor) {
-    this.strings = strings;
-    this.values = values;
-    this.type = type;
-    this.processor = processor;
+      public strings: TemplateStringsArray, public values: any[],
+      public type: string, public processor: TemplateProcessor) {
   }
 
   /**

--- a/src/lib/template.ts
+++ b/src/lib/template.ts
@@ -42,10 +42,8 @@ export const boundAttributeSuffix = '$lit$';
  */
 export class Template {
   parts: TemplatePart[] = [];
-  element: HTMLTemplateElement;
 
-  constructor(result: TemplateResult, element: HTMLTemplateElement) {
-    this.element = element;
+  constructor(result: TemplateResult, public element: HTMLTemplateElement) {
     let index = -1;
     let partIndex = 0;
     const nodesToRemove: Node[] = [];

--- a/src/lib/template.ts
+++ b/src/lib/template.ts
@@ -16,7 +16,7 @@
  * @module lit-html
  */
 
-import {TemplateResult} from './template-result.js';
+import {TemplateResult} from './template-result';
 
 /**
  * An expression marker with embedded unique key to avoid collision with

--- a/src/lit-html.ts
+++ b/src/lit-html.ts
@@ -30,22 +30,22 @@
  * Do not remove this comment; it keeps typedoc from misplacing the module
  * docs.
  */
-import {defaultTemplateProcessor} from './lib/default-template-processor.js';
-import {SVGTemplateResult, TemplateResult} from './lib/template-result.js';
+import {defaultTemplateProcessor} from './lib/default-template-processor';
+import {SVGTemplateResult, TemplateResult} from './lib/template-result';
 
-export {DefaultTemplateProcessor, defaultTemplateProcessor} from './lib/default-template-processor.js';
-export {directive, DirectiveFn, isDirective} from './lib/directive.js';
+export {DefaultTemplateProcessor, defaultTemplateProcessor} from './lib/default-template-processor';
+export {directive, DirectiveFn, isDirective} from './lib/directive';
 // TODO(justinfagnani): remove line when we get NodePart moving methods
-export {removeNodes, reparentNodes} from './lib/dom.js';
-export {noChange, nothing, Part} from './lib/part.js';
-export {AttributeCommitter, AttributePart, BooleanAttributePart, EventPart, isPrimitive, NodePart, PropertyCommitter, PropertyPart} from './lib/parts.js';
-export {RenderOptions} from './lib/render-options.js';
-export {parts, render} from './lib/render.js';
-export {templateCaches, templateFactory} from './lib/template-factory.js';
-export {TemplateInstance} from './lib/template-instance.js';
-export {TemplateProcessor} from './lib/template-processor.js';
-export {SVGTemplateResult, TemplateResult} from './lib/template-result.js';
-export {createMarker, isTemplatePartActive, Template} from './lib/template.js';
+export {removeNodes, reparentNodes} from './lib/dom';
+export {noChange, nothing, Part} from './lib/part';
+export {AttributeCommitter, AttributePart, BooleanAttributePart, EventPart, isPrimitive, NodePart, PropertyCommitter, PropertyPart} from './lib/parts';
+export {parts, render} from './lib/render';
+export {RenderOptions} from './lib/render-options';
+export {createMarker, isTemplatePartActive, Template} from './lib/template';
+export {templateCaches, templateFactory} from './lib/template-factory';
+export {TemplateInstance} from './lib/template-instance';
+export {TemplateProcessor} from './lib/template-processor';
+export {SVGTemplateResult, TemplateResult} from './lib/template-result';
 
 /**
  * Interprets a template literal as an HTML template that can efficiently

--- a/src/test/directives/async-append_test.ts
+++ b/src/test/directives/async-append_test.ts
@@ -12,11 +12,11 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {asyncAppend} from '../../directives/async-append.js';
-import {render} from '../../lib/render.js';
-import {html} from '../../lit-html.js';
-import {TestAsyncIterable} from '../lib/test-async-iterable.js';
-import {stripExpressionMarkers} from '../test-utils/strip-markers.js';
+import {asyncAppend} from '../../directives/async-append';
+import {render} from '../../lib/render';
+import {html} from '../../lit-html';
+import {TestAsyncIterable} from '../lib/test-async-iterable';
+import {stripExpressionMarkers} from '../test-utils/strip-markers';
 
 const assert = chai.assert;
 

--- a/src/test/directives/async-replace_test.ts
+++ b/src/test/directives/async-replace_test.ts
@@ -12,11 +12,11 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {asyncReplace} from '../../directives/async-replace.js';
-import {render} from '../../lib/render.js';
-import {html} from '../../lit-html.js';
-import {TestAsyncIterable} from '../lib/test-async-iterable.js';
-import {stripExpressionMarkers} from '../test-utils/strip-markers.js';
+import {asyncReplace} from '../../directives/async-replace';
+import {render} from '../../lib/render';
+import {html} from '../../lit-html';
+import {TestAsyncIterable} from '../lib/test-async-iterable';
+import {stripExpressionMarkers} from '../test-utils/strip-markers';
 
 const assert = chai.assert;
 

--- a/src/test/directives/cache_test.ts
+++ b/src/test/directives/cache_test.ts
@@ -12,10 +12,10 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {cache} from '../../directives/cache.js';
-import {render} from '../../lib/render.js';
-import {html} from '../../lit-html.js';
-import {stripExpressionMarkers} from '../test-utils/strip-markers.js';
+import {cache} from '../../directives/cache';
+import {render} from '../../lib/render';
+import {html} from '../../lit-html';
+import {stripExpressionMarkers} from '../test-utils/strip-markers';
 
 const assert = chai.assert;
 

--- a/src/test/directives/class-map_test.ts
+++ b/src/test/directives/class-map_test.ts
@@ -15,9 +15,9 @@
 /// <reference path="../../../node_modules/@types/mocha/index.d.ts" />
 /// <reference path="../../../node_modules/@types/chai/index.d.ts" />
 
-import {ClassInfo, classMap} from '../../directives/class-map.js';
-import {render} from '../../lib/render.js';
-import {html} from '../../lit-html.js';
+import {ClassInfo, classMap} from '../../directives/class-map';
+import {render} from '../../lib/render';
+import {html} from '../../lit-html';
 
 const assert = chai.assert;
 

--- a/src/test/directives/guard_test.ts
+++ b/src/test/directives/guard_test.ts
@@ -15,10 +15,10 @@
 /// <reference path="../../../node_modules/@types/mocha/index.d.ts" />
 /// <reference path="../../../node_modules/@types/chai/index.d.ts" />
 
-import {guard} from '../../directives/guard.js';
-import {render} from '../../lib/render.js';
-import {html} from '../../lit-html.js';
-import {stripExpressionMarkers} from '../test-utils/strip-markers.js';
+import {guard} from '../../directives/guard';
+import {render} from '../../lib/render';
+import {html} from '../../lit-html';
+import {stripExpressionMarkers} from '../test-utils/strip-markers';
 
 const assert = chai.assert;
 

--- a/src/test/directives/if-defined_test.ts
+++ b/src/test/directives/if-defined_test.ts
@@ -12,10 +12,10 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {ifDefined} from '../../directives/if-defined.js';
-import {render} from '../../lib/render.js';
-import {html} from '../../lit-html.js';
-import {stripExpressionMarkers} from '../test-utils/strip-markers.js';
+import {ifDefined} from '../../directives/if-defined';
+import {render} from '../../lib/render';
+import {html} from '../../lit-html';
+import {stripExpressionMarkers} from '../test-utils/strip-markers';
 
 const assert = chai.assert;
 

--- a/src/test/directives/repeat_test.ts
+++ b/src/test/directives/repeat_test.ts
@@ -12,12 +12,12 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {guard} from '../../directives/guard.js';
-import {repeat} from '../../directives/repeat.js';
-import {until} from '../../directives/until.js';
-import {render} from '../../lib/render.js';
-import {html} from '../../lit-html.js';
-import {stripExpressionMarkers} from '../test-utils/strip-markers.js';
+import {guard} from '../../directives/guard';
+import {repeat} from '../../directives/repeat';
+import {until} from '../../directives/until';
+import {render} from '../../lib/render';
+import {html} from '../../lit-html';
+import {stripExpressionMarkers} from '../test-utils/strip-markers';
 
 const assert = chai.assert;
 

--- a/src/test/directives/style-map_test.ts
+++ b/src/test/directives/style-map_test.ts
@@ -12,9 +12,9 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {StyleInfo, styleMap} from '../../directives/style-map.js';
-import {render} from '../../lib/render.js';
-import {html} from '../../lit-html.js';
+import {StyleInfo, styleMap} from '../../directives/style-map';
+import {render} from '../../lib/render';
+import {html} from '../../lit-html';
 
 const ua = window.navigator.userAgent;
 const isChrome41 = ua.indexOf('Chrome/41') > 0;

--- a/src/test/directives/unsafe-html_test.ts
+++ b/src/test/directives/unsafe-html_test.ts
@@ -12,10 +12,10 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {unsafeHTML} from '../../directives/unsafe-html.js';
-import {render} from '../../lib/render.js';
-import {html} from '../../lit-html.js';
-import {stripExpressionMarkers} from '../test-utils/strip-markers.js';
+import {unsafeHTML} from '../../directives/unsafe-html';
+import {render} from '../../lib/render';
+import {html} from '../../lit-html';
+import {stripExpressionMarkers} from '../test-utils/strip-markers';
 
 const assert = chai.assert;
 

--- a/src/test/directives/until_test.ts
+++ b/src/test/directives/until_test.ts
@@ -12,11 +12,11 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {until} from '../../directives/until.js';
-import {render} from '../../lib/render.js';
-import {html} from '../../lit-html.js';
-import {Deferred} from '../test-utils/deferred.js';
-import {stripExpressionMarkers} from '../test-utils/strip-markers.js';
+import {until} from '../../directives/until';
+import {render} from '../../lib/render';
+import {html} from '../../lit-html';
+import {Deferred} from '../test-utils/deferred';
+import {stripExpressionMarkers} from '../test-utils/strip-markers';
 
 const assert = chai.assert;
 

--- a/src/test/lib/incompatible-shady-render_test.ts
+++ b/src/test/lib/incompatible-shady-render_test.ts
@@ -12,7 +12,7 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {html, render} from '../../lib/shady-render.js';
+import {html, render} from '../../lib/shady-render';
 
 const assert = chai.assert;
 

--- a/src/test/lib/modify-template_test.ts
+++ b/src/test/lib/modify-template_test.ts
@@ -12,10 +12,10 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {insertNodeIntoTemplate, removeNodesFromTemplate} from '../../lib/modify-template.js';
-import {render} from '../../lib/render.js';
-import {html, templateFactory} from '../../lit-html.js';
-import {stripExpressionMarkers} from '../test-utils/strip-markers.js';
+import {insertNodeIntoTemplate, removeNodesFromTemplate} from '../../lib/modify-template';
+import {render} from '../../lib/render';
+import {html, templateFactory} from '../../lit-html';
+import {stripExpressionMarkers} from '../test-utils/strip-markers';
 
 const assert = chai.assert;
 

--- a/src/test/lib/parts_test.ts
+++ b/src/test/lib/parts_test.ts
@@ -12,8 +12,8 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {AttributeCommitter, AttributePart, createMarker, DefaultTemplateProcessor, EventPart, html, NodePart, render, templateFactory, TemplateResult} from '../../lit-html.js';
-import {stripExpressionMarkers} from '../test-utils/strip-markers.js';
+import {AttributeCommitter, AttributePart, createMarker, DefaultTemplateProcessor, EventPart, html, NodePart, render, templateFactory, TemplateResult} from '../../lit-html';
+import {stripExpressionMarkers} from '../test-utils/strip-markers';
 
 const assert = chai.assert;
 

--- a/src/test/lib/render_test.ts
+++ b/src/test/lib/render_test.ts
@@ -12,8 +12,8 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {AttributePart, directive, html, noChange, NodePart, nothing, Part, render, svg, templateFactory} from '../../lit-html.js';
-import {stripExpressionMarkers} from '../test-utils/strip-markers.js';
+import {AttributePart, directive, html, noChange, NodePart, nothing, Part, render, svg, templateFactory} from '../../lit-html';
+import {stripExpressionMarkers} from '../test-utils/strip-markers';
 
 const assert = chai.assert;
 

--- a/src/test/lib/shady-render-apply_test.ts
+++ b/src/test/lib/shady-render-apply_test.ts
@@ -14,8 +14,8 @@
 
 // Rename the html tag so that CSS linting doesn't warn on the non-standard
 // @apply syntax
-import {html as htmlWithApply} from '../../lib/shady-render.js';
-import {renderShadowRoot} from '../test-utils/shadow-root.js';
+import {html as htmlWithApply} from '../../lib/shady-render';
+import {renderShadowRoot} from '../test-utils/shadow-root';
 
 const assert = chai.assert;
 

--- a/src/test/lib/shady-render_test.ts
+++ b/src/test/lib/shady-render_test.ts
@@ -12,8 +12,8 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {html} from '../../lit-html.js';
-import {renderShadowRoot} from '../test-utils/shadow-root.js';
+import {html} from '../../lit-html';
+import {renderShadowRoot} from '../test-utils/shadow-root';
 
 const assert = chai.assert;
 

--- a/src/test/lib/template-factory_test.ts
+++ b/src/test/lib/template-factory_test.ts
@@ -12,7 +12,7 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {html, templateFactory} from '../../lit-html.js';
+import {html, templateFactory} from '../../lit-html';
 
 const assert = chai.assert;
 

--- a/src/test/lib/template-result_test.ts
+++ b/src/test/lib/template-result_test.ts
@@ -12,8 +12,8 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {marker} from '../../lib/template.js';
-import {html} from '../../lit-html.js';
+import {marker} from '../../lib/template';
+import {html} from '../../lit-html';
 
 const assert = chai.assert;
 

--- a/src/test/lib/template_test.ts
+++ b/src/test/lib/template_test.ts
@@ -12,8 +12,8 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {Template} from '../../lib/template.js';
-import {html, TemplateResult} from '../../lit-html.js';
+import {Template} from '../../lib/template';
+import {html, TemplateResult} from '../../lit-html';
 
 const assert = chai.assert;
 

--- a/src/test/lit-html_test.ts
+++ b/src/test/lit-html_test.ts
@@ -12,15 +12,15 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import * as LibDefaultTemplateProcessor from '../lib/default-template-processor.js';
-import * as LibDirective from '../lib/directive.js';
-import * as LibPart from '../lib/part.js';
-import * as LibParts from '../lib/parts.js';
-import * as LibRender from '../lib/render.js';
-import * as LibTemplateFactory from '../lib/template-factory.js';
-import * as LibTemplateInstance from '../lib/template-instance.js';
-import * as LibTemplateResult from '../lib/template-result.js';
-import * as LitHtml from '../lit-html.js';
+import * as LibDefaultTemplateProcessor from '../lib/default-template-processor';
+import * as LibDirective from '../lib/directive';
+import * as LibPart from '../lib/part';
+import * as LibParts from '../lib/parts';
+import * as LibRender from '../lib/render';
+import * as LibTemplateFactory from '../lib/template-factory';
+import * as LibTemplateInstance from '../lib/template-instance';
+import * as LibTemplateResult from '../lib/template-result';
+import * as LitHtml from '../lit-html';
 
 const assert = chai.assert;
 

--- a/src/test/test-utils/shadow-root.ts
+++ b/src/test/test-utils/shadow-root.ts
@@ -11,8 +11,8 @@
  * subject to an additional IP rights grant found at
  * http://polymer.github.io/PATENTS.txt
  */
-import {render} from '../../lib/shady-render.js';
-import {TemplateResult} from '../../lit-html.js';
+import {render} from '../../lib/shady-render';
+import {TemplateResult} from '../../lit-html';
 
 /**
  * A helper for creating a shadowRoot on an element.


### PR DESCRIPTION
- uses the TS `constructor(public prop: Type)` shortcuts,
- drops file extension in import (seems like formatting re-ordered some of the import after that).