### PR TITLE
[shady-render] Make compatible with new ShadyCSS API

### DIFF
--- a/src/lib/shady-render.ts
+++ b/src/lib/shady-render.ts
@@ -131,8 +131,9 @@ const prepareTemplateStyles =
       const styles = renderedDOM.querySelectorAll('style');
       // If there are no styles, skip unnecessary work
       if (styles.length === 0) {
-        // ensure prepareTemplateStyles is called to support adding any
-        // styles via `prepareAdoptedCssText`
+        // Ensure prepareTemplateStyles is called to support adding
+        // styles via `prepareAdoptedCssText` since that requires that
+        // `prepareTemplateStyles` is called.
         window.ShadyCSS!.prepareTemplateStyles(template.element, scopeName);
         return;
       }

--- a/src/lib/shady-render.ts
+++ b/src/lib/shady-render.ts
@@ -129,8 +129,11 @@ const prepareTemplateStyles =
       shadyRenderSet.add(scopeName);
       // Move styles out of rendered DOM and store.
       const styles = renderedDOM.querySelectorAll('style');
-      // If there are no styles, there's no work to do.
+      // If there are no styles, skip unnecessary work
       if (styles.length === 0) {
+        // ensure prepareTemplateStyles is called to support adding any
+        // styles via `prepareAdoptedCssText`
+        window.ShadyCSS!.prepareTemplateStyles(template.element, scopeName);
         return;
       }
       const condensedStyle = document.createElement('style');


### PR DESCRIPTION
The  `prepareAcoptedCssText` API requires that `prepareTemplateStyles` is always called.