### PR TITLE
Enable a resin-like sanitization mechanism.

### DIFF
--- a/src/lib/parts.ts
+++ b/src/lib/parts.ts
@@ -74,6 +74,16 @@ export type DOMSanitizer =
  */
 let sanitizeDOMValue: DOMSanitizer|undefined;
 
+/** Sets the global DOM sanitization callback. */
+export const __testOnlySetSanitizeDOMValueExperimentalMayChangeWithoutWarning = (newSanitizer: DOMSanitizer) => {
+  if (sanitizeDOMValue !== undefined) {
+    throw new Error(
+        `Attempted to overwrite existing lit-html security policy.` +
+        ` setSanitizeDOMValue should be called at most once.`);
+  }
+  sanitizeDOMValue = newSanitizer;
+};
+
 export const __testOnlyClearSanitizerDoNotCallOrElse = () => {
   sanitizeDOMValue = undefined;
 };

--- a/src/lib/parts.ts
+++ b/src/lib/parts.ts
@@ -134,7 +134,7 @@ export class AttributeCommitter {
     // it together into a string without calling String() on the array.
     if (l === 1 && strings[0] === '' && strings[1] === '' && parts[0] !== undefined) {
       const v = parts[0].value;
-      if (!Array.isArray(v)) {
+      if (!isIterable(v)) {
         return v;
       }
     }

--- a/src/lib/parts.ts
+++ b/src/lib/parts.ts
@@ -74,16 +74,6 @@ export type DOMSanitizer =
  */
 let sanitizeDOMValue: DOMSanitizer|undefined;
 
-/** Sets the global DOM sanitization callback. */
-export const setSanitizeDOMValue = (newSanitizer: DOMSanitizer) => {
-  if (sanitizeDOMValue !== undefined) {
-    throw new Error(
-        `Attempted to overwrite existing lit-html security policy.` +
-        ` setSanitizeDOMValue should be called at most once.`);
-  }
-  sanitizeDOMValue = newSanitizer;
-};
-
 export const __testOnlyClearSanitizerDoNotCallOrElse = () => {
   sanitizeDOMValue = undefined;
 };

--- a/src/lib/parts.ts
+++ b/src/lib/parts.ts
@@ -122,7 +122,7 @@ export class AttributeCommitter {
     // String(value)
     // The exception is if v is an array, in which case we do want to smash
     // it together into a string without calling String() on the array.
-    if (l === 1 && strings[0] === '' && strings[1] === '' && parts[0]) {
+    if (l === 1 && strings[0] === '' && strings[1] === '' && parts[0] !== undefined) {
       const v = parts[0].value;
       if (!Array.isArray(v)) {
         return v;

--- a/src/lib/parts.ts
+++ b/src/lib/parts.ts
@@ -106,8 +106,10 @@ export class AttributeCommitter {
     // String(value)
     if (l === 1 && strings[0] === '' && strings[1] === '' && parts[0]) {
       const v = parts[0].value;
-      if (Array.isArray(v) && v.length === 1) {
-        return v[0];
+      if (Array.isArray(v)) {
+        if (v.length === 1) {
+          return v[0];
+        }
       } else {
         return v;
       }

--- a/src/lib/parts.ts
+++ b/src/lib/parts.ts
@@ -75,14 +75,15 @@ export type DOMSanitizer =
 let sanitizeDOMValue: DOMSanitizer|undefined;
 
 /** Sets the global DOM sanitization callback. */
-export const __testOnlySetSanitizeDOMValueExperimentalMayChangeWithoutWarning = (newSanitizer: DOMSanitizer) => {
-  if (sanitizeDOMValue !== undefined) {
-    throw new Error(
-        `Attempted to overwrite existing lit-html security policy.` +
-        ` setSanitizeDOMValue should be called at most once.`);
-  }
-  sanitizeDOMValue = newSanitizer;
-};
+export const __testOnlySetSanitizeDOMValueExperimentalMayChangeWithoutWarning =
+    (newSanitizer: DOMSanitizer) => {
+      if (sanitizeDOMValue !== undefined) {
+        throw new Error(
+            `Attempted to overwrite existing lit-html security policy.` +
+            ` setSanitizeDOMValue should be called at most once.`);
+      }
+      sanitizeDOMValue = newSanitizer;
+    };
 
 export const __testOnlyClearSanitizerDoNotCallOrElse = () => {
   sanitizeDOMValue = undefined;
@@ -132,7 +133,8 @@ export class AttributeCommitter {
     // String(value)
     // The exception is if v is an array, in which case we do want to smash
     // it together into a string without calling String() on the array.
-    if (l === 1 && strings[0] === '' && strings[1] === '' && parts[0] !== undefined) {
+    if (l === 1 && strings[0] === '' && strings[1] === '' &&
+        parts[0] !== undefined) {
       const v = parts[0].value;
       if (!isIterable(v)) {
         return v;

--- a/src/lib/parts.ts
+++ b/src/lib/parts.ts
@@ -330,9 +330,12 @@ export class NodePart implements Part {
       // set its value, rather than replacing it.
       let renderedValue = value;
       if (sanitizeDOMValue) {
-        renderedValue = sanitizeDOMValue(renderedValue, 'data', 'property', node);
+        renderedValue =
+            sanitizeDOMValue(renderedValue, 'data', 'property', node);
       }
-      (node as Text).data = typeof renderedValue === 'string' ? renderedValue : String(renderedValue);
+      (node as Text).data = typeof renderedValue === 'string' ?
+          renderedValue :
+          String(renderedValue);
     } else {
       // When setting text content, for security purposes it matters a lot what
       // the parent is. For example, <style> and <script> need to be handled
@@ -342,9 +345,12 @@ export class NodePart implements Part {
       this.__commitNode(textNode);
       let renderedValue = value;
       if (sanitizeDOMValue) {
-        renderedValue = sanitizeDOMValue(renderedValue, 'textContent', 'property', textNode) as string;
+        renderedValue =
+            sanitizeDOMValue(
+                renderedValue, 'textContent', 'property', textNode) as string;
       }
-      textNode.data = typeof renderedValue === 'string' ? renderedValue : String(renderedValue);
+      textNode.data = typeof renderedValue === 'string' ? renderedValue :
+                                                          String(renderedValue);
     }
     this.value = value;
   }

--- a/src/lit-html.ts
+++ b/src/lit-html.ts
@@ -38,7 +38,7 @@ export {directive, DirectiveFn, isDirective} from './lib/directive.js';
 // TODO(justinfagnani): remove line when we get NodePart moving methods
 export {removeNodes, reparentNodes} from './lib/dom.js';
 export {noChange, nothing, Part} from './lib/part.js';
-export {AttributeCommitter, AttributePart, BooleanAttributePart, EventPart, isIterable, isPrimitive, NodePart, PropertyCommitter, PropertyPart} from './lib/parts.js';
+export {AttributeCommitter, AttributePart, BooleanAttributePart, EventPart, isIterable, isPrimitive, NodePart, PropertyCommitter, PropertyPart, setSanitizeDOMValue} from './lib/parts.js';
 export {RenderOptions} from './lib/render-options.js';
 export {parts, render} from './lib/render.js';
 export {templateCaches, templateFactory} from './lib/template-factory.js';

--- a/src/lit-html.ts
+++ b/src/lit-html.ts
@@ -38,7 +38,7 @@ export {directive, DirectiveFn, isDirective} from './lib/directive.js';
 // TODO(justinfagnani): remove line when we get NodePart moving methods
 export {removeNodes, reparentNodes} from './lib/dom.js';
 export {noChange, nothing, Part} from './lib/part.js';
-export {AttributeCommitter, AttributePart, BooleanAttributePart, EventPart, isIterable, isPrimitive, NodePart, PropertyCommitter, PropertyPart, setSanitizeDOMValue} from './lib/parts.js';
+export {AttributeCommitter, AttributePart, BooleanAttributePart, EventPart, isIterable, isPrimitive, NodePart, PropertyCommitter, PropertyPart} from './lib/parts.js';
 export {RenderOptions} from './lib/render-options.js';
 export {parts, render} from './lib/render.js';
 export {templateCaches, templateFactory} from './lib/template-factory.js';

--- a/src/test/lib/parts_test.ts
+++ b/src/test/lib/parts_test.ts
@@ -12,9 +12,9 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
+import {__testOnlySetSanitizeDOMValueExperimentalMayChangeWithoutWarning} from '../../lib/parts';
 import {__testOnlyClearSanitizerDoNotCallOrElse} from '../../lib/parts.js';
 import {AttributeCommitter, AttributePart, createMarker, DefaultTemplateProcessor, EventPart, html, NodePart, render, templateFactory, TemplateResult} from '../../lit-html.js';
-import {__testOnlySetSanitizeDOMValueExperimentalMayChangeWithoutWarning} from '../../lib/parts';
 import {stripExpressionMarkers} from '../test-utils/strip-markers.js';
 
 const assert = chai.assert;

--- a/src/test/lib/parts_test.ts
+++ b/src/test/lib/parts_test.ts
@@ -13,7 +13,8 @@
  */
 
 import {__testOnlyClearSanitizerDoNotCallOrElse} from '../../lib/parts.js';
-import {AttributeCommitter, AttributePart, createMarker, DefaultTemplateProcessor, EventPart, html, NodePart, render, setSanitizeDOMValue, templateFactory, TemplateResult} from '../../lit-html.js';
+import {AttributeCommitter, AttributePart, createMarker, DefaultTemplateProcessor, EventPart, html, NodePart, render, templateFactory, TemplateResult} from '../../lit-html.js';
+import {__testOnlySetSanitizeDOMValueExperimentalMayChangeWithoutWarning} from '../../lib/parts';
 import {stripExpressionMarkers} from '../test-utils/strip-markers.js';
 
 const assert = chai.assert;
@@ -666,7 +667,7 @@ suite('setSanitizeDOMValue', () => {
 
 
   setup(() => {
-    setSanitizeDOMValue(
+    __testOnlySetSanitizeDOMValueExperimentalMayChangeWithoutWarning(
         (value: unknown,
          name: string,
          type: 'property'|'attribute'|'text',

--- a/src/test/lib/parts_test.ts
+++ b/src/test/lib/parts_test.ts
@@ -12,6 +12,7 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
+import {__testOnlyClearSanitizerDoNotCallOrElse} from '../../lib/parts.js';
 import {AttributeCommitter, AttributePart, createMarker, DefaultTemplateProcessor, EventPart, html, NodePart, render, setSanitizeDOMValue, templateFactory, TemplateResult} from '../../lit-html.js';
 import {stripExpressionMarkers} from '../test-utils/strip-markers.js';
 
@@ -680,7 +681,7 @@ suite('setSanitizeDOMValue', () => {
   });
 
   teardown(() => {
-    setSanitizeDOMValue(undefined as any);
+    __testOnlyClearSanitizerDoNotCallOrElse();
     sanitizerCalls.length = 0;
   });
 

--- a/src/test/lib/parts_test.ts
+++ b/src/test/lib/parts_test.ts
@@ -695,7 +695,7 @@ suite('setSanitizeDOMValue', () => {
     assert.equal(stripExpressionMarkers(container.innerHTML), '<div>foo</div>');
 
     assert.deepEqual(sanitizerCalls, [
-      {value: 'foo', name: 'data', type: 'property', nodeName: '#text'},
+      {value: 'foo', name: 'textContent', type: 'property', nodeName: '#text'},
       {value: safeFoo, name: 'data', type: 'property', nodeName: '#text'}
     ]);
   });
@@ -713,7 +713,7 @@ suite('setSanitizeDOMValue', () => {
         '<div>hello big world</div>');
 
     assert.deepEqual(sanitizerCalls, [
-      {value: 'big', name: 'data', type: 'property', nodeName: '#text'},
+      {value: 'big', name: 'textContent', type: 'property', nodeName: '#text'},
       {value: safeBig, name: 'data', type: 'property', nodeName: '#text'}
     ]);
   });

--- a/src/test/lib/parts_test.ts
+++ b/src/test/lib/parts_test.ts
@@ -12,10 +12,11 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {AttributeCommitter, AttributePart, createMarker, DefaultTemplateProcessor, EventPart, html, NodePart, render, templateFactory, TemplateResult} from '../../lit-html.js';
+import {AttributeCommitter, AttributePart, createMarker, DefaultTemplateProcessor, EventPart, html, NodePart, render, setSanitizeDOMValue, templateFactory, TemplateResult} from '../../lit-html.js';
 import {stripExpressionMarkers} from '../test-utils/strip-markers.js';
 
 const assert = chai.assert;
+chai.config.truncateThreshold = 0;  // ask chai to produce diffs
 
 // tslint:disable:no-any OK in test code.
 
@@ -639,5 +640,131 @@ suite('Parts', () => {
         assert.isTrue(onceCalled, 'onceCalled');
       }
     });
+  });
+});
+
+
+suite('setSanitizeDOMValue', () => {
+  const sanitizerCalls: Array<{
+    value: unknown,
+    name: string,
+    type: 'property' | 'attribute' | 'text',
+    nodeName: string
+  }> = [];
+  let container: HTMLDivElement;
+  class FakeSanitizedWrapper {
+    sanitizeTo: string;
+    constructor(sanitizeTo: string) {
+      this.sanitizeTo = sanitizeTo;
+    }
+
+    toString() {
+      return `FakeSanitizedWrapper(${this.sanitizeTo})`;
+    }
+  }
+
+
+  setup(() => {
+    setSanitizeDOMValue(
+        (value: unknown,
+         name: string,
+         type: 'property'|'attribute'|'text',
+         node: Node) => {
+          sanitizerCalls.push({value, name, type, nodeName: node.nodeName});
+          if (value instanceof FakeSanitizedWrapper) {
+            return value.sanitizeTo;
+          }
+          return `safeString`;
+        });
+    container = document.createElement('div');
+  });
+
+  teardown(() => {
+    setSanitizeDOMValue(undefined as any);
+    sanitizerCalls.length = 0;
+  });
+
+
+  test('sanitizes text content when the text is alone', () => {
+    render(html`<div>${'foo'}</div>`, container);
+    assert.equal(
+        stripExpressionMarkers(container.innerHTML), '<div>safeString</div>');
+
+    const safeFoo = new FakeSanitizedWrapper('foo');
+    render(html`<div>${safeFoo}</div>`, container);
+    assert.equal(stripExpressionMarkers(container.innerHTML), '<div>foo</div>');
+
+    assert.deepEqual(sanitizerCalls, [
+      {value: 'foo', name: 'data', type: 'property', nodeName: '#text'},
+      {value: safeFoo, name: 'data', type: 'property', nodeName: '#text'}
+    ]);
+  });
+
+  test('sanitizes text content when the text is interpolated', () => {
+    render(html`<div>hello ${'big'} world</div>`, container);
+    assert.equal(
+        stripExpressionMarkers(container.innerHTML),
+        '<div>hello safeString world</div>');
+
+    const safeBig = new FakeSanitizedWrapper('big');
+    render(html`<div>hello ${safeBig} world</div>`, container);
+    assert.equal(
+        stripExpressionMarkers(container.innerHTML),
+        '<div>hello big world</div>');
+
+    assert.deepEqual(sanitizerCalls, [
+      {value: 'big', name: 'data', type: 'property', nodeName: '#text'},
+      {value: safeBig, name: 'data', type: 'property', nodeName: '#text'}
+    ]);
+  });
+
+  test('sanitizes full attribute values', () => {
+    render(html`<div attrib=${'bad'}></div>`, container);
+    assert.equal(
+        stripExpressionMarkers(container.innerHTML),
+        '<div attrib="safeString"></div>');
+
+    const safe = new FakeSanitizedWrapper('good');
+    render(html`<div attrib=${safe}></div>`, container);
+    assert.equal(
+        stripExpressionMarkers(container.innerHTML),
+        '<div attrib="good"></div>');
+
+    assert.deepEqual(sanitizerCalls, [
+      {value: 'bad', name: 'attrib', type: 'attribute', nodeName: 'DIV'},
+      {value: safe, name: 'attrib', type: 'attribute', nodeName: 'DIV'}
+    ]);
+  });
+
+  test('sanitizes concatonated attributes after contatonation', () => {
+    render(html`<div attrib="hello ${'big'} world"></div>`, container);
+    assert.equal(
+        stripExpressionMarkers(container.innerHTML),
+        '<div attrib="safeString"></div>');
+
+    assert.deepEqual(sanitizerCalls, [
+      {
+        value: 'hello big world',
+        name: 'attrib',
+        type: 'attribute',
+        nodeName: 'DIV'
+      },
+    ]);
+  });
+
+  test('sanitizes properties', () => {
+    render(html`<div .foo=${'bad'}></div>`, container);
+    assert.equal(stripExpressionMarkers(container.innerHTML), '<div></div>');
+    assert.equal((container.querySelector('div')! as any).foo, 'safeString');
+
+    const safe = new FakeSanitizedWrapper('good');
+    render(html`<div .foo=${safe}></div>`, container);
+    assert.equal(stripExpressionMarkers(container.innerHTML), '<div></div>');
+    assert.equal((container.querySelector('div')! as any).foo, 'good');
+
+    assert.deepEqual(sanitizerCalls, [
+      {value: 'bad', name: 'foo', type: 'property', nodeName: 'DIV'},
+      {value: safe, name: 'foo', type: 'property', nodeName: 'DIV'},
+    ]);
   });
 });

--- a/src/test/lit-html_test.ts
+++ b/src/test/lit-html_test.ts
@@ -58,9 +58,11 @@ suite('index.js', () => {
   });
 
   test('exports everything from lib/parts.js', () => {
-    Object.keys(LibParts).forEach((key) => {
-      assert.property(LitHtml, key);
-    });
+    Object.keys(LibParts)
+        .filter((k) => !k.startsWith('__testOnly'))
+        .forEach((key) => {
+          assert.property(LitHtml, key);
+        });
   });
 
   test('exports everything from lib/directive.js', () => {

--- a/src/test/lit-html_test.ts
+++ b/src/test/lit-html_test.ts
@@ -59,7 +59,7 @@ suite('index.js', () => {
 
   test('exports everything from lib/parts.js', () => {
     Object.keys(LibParts)
-        .filter((k) => !k.startsWith('__testOnly'))
+        .filter((k) => !/^__testOnly/.test(k))
         .forEach((key) => {
           assert.property(LitHtml, key);
         });


### PR DESCRIPTION
This adds a global DOM sanitization function which is settable via the setSanitizeDOMValue call.

If set, this function is called whenever lit-html would write an attribute, property, or text to the dom, with all of the information necessary to determine if the write is safe.

This API is analogous to the Polymer function of the same name, and it pairs nicely with https://github.com/Polymer/polymer-resin