### PR TITLE
Remove status disclaimer now 1.0.0 has shipped

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,11 +41,6 @@ render(helloTemplate('Kevin'), document.body);
 $ npm install lit-html
 ```
 
-## Status
-
-`lit-html` is under active development and has not yet had a 1.0 release. The
-internal API may still change somewhat. The `html` and `render` API is stable.
-
 ## Contributing
 
 Please see [CONTRIBUTING.md](./CONTRIBUTING.md).


### PR DESCRIPTION
I removed the section entirely but if you want to reword instead given latest status feel free.