### PR TITLE
Revamp template polyfill

### DIFF
--- a/src/polyfills/template_polyfill.ts
+++ b/src/polyfills/template_polyfill.ts
@@ -24,6 +24,10 @@ import {removeNodes, reparentNodes} from '../lib/dom.js';
  * polyfill: https://github.com/webcomponents/template
  */
 export const initTemplatePolyfill = (forced = false) => {
+  // Minimal polyfills (like this one) may provide only a subset of Template's
+  // functionality. So, we explicitly check that at least content is present to
+  // prevent installing patching with multiple polyfills, which might happen if
+  // multiple versions of lit-html were included on a page.
   if (!forced && 'content' in document.createElement('template')) {
     return;
   }
@@ -39,9 +43,8 @@ export const initTemplatePolyfill = (forced = false) => {
     Object.defineProperties(template, {
       content: {
         ...descriptor,
-        get() {
-          return content;
-        },
+        writable: false,
+        value: content,
       },
       innerHTML: {
         ...descriptor,

--- a/src/polyfills/template_polyfill.ts
+++ b/src/polyfills/template_polyfill.ts
@@ -12,6 +12,8 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
+import {removeNodes, reparentNodes} from '../lib/dom.js';
+
 /**
  * A lightweight <template> polyfill that supports minimum features to cover
  * lit-html use cases. It provides an alternate route in case <template> is not
@@ -22,37 +24,42 @@
  * polyfill: https://github.com/webcomponents/template
  */
 export const initTemplatePolyfill = (forced = false) => {
-  if (typeof HTMLTemplateElement !== 'undefined' && !forced) {
+  if (!forced && 'content' in document.createElement('template')) {
     return;
   }
   const contentDoc = document.implementation.createHTMLDocument('template');
+  const body = contentDoc.body;
+  const descriptor = {
+    enumerable: true,
+    configurable: true,
+  };
 
-  // tslint:disable-next-line:no-any
-  const upgrade = (template: any) => {
-    template.content = contentDoc.createDocumentFragment();
-    Object.defineProperty(template, 'innerHTML', {
-      set: function(text) {
-        contentDoc.body.innerHTML = text;
-        const content = (this as HTMLTemplateElement).content;
-        while (content.firstChild) {
-          content.removeChild(content.firstChild);
-        }
-        const body = contentDoc.body;
-        while (body.firstChild) {
-          content.appendChild(body.firstChild);
-        }
+  const upgrade = (template: HTMLTemplateElement) => {
+    const content = contentDoc.createDocumentFragment();
+    Object.defineProperties(template, {
+      content: {
+        ...descriptor,
+        get() {
+          return content;
+        },
       },
-      configurable: true
+      innerHTML: {
+        ...descriptor,
+        set: function(text) {
+          body.innerHTML = text;
+          removeNodes(content, content.firstChild);
+          reparentNodes(content, body.firstChild);
+        },
+      },
     });
   };
 
   const capturedCreateElement = Document.prototype.createElement;
   Document.prototype.createElement = function createElement(
       tagName: string, options?: ElementCreationOptions) {
-    let el = capturedCreateElement.call(this, tagName, options);
+    const el = capturedCreateElement.call(this, tagName, options);
     if (el.localName === 'template') {
-      el = capturedCreateElement.call(this, 'div');
-      upgrade(el);
+      upgrade(el as HTMLTemplateElement);
     }
     return el;
   };


### PR DESCRIPTION
Does a few things:

- Minimal poyfills no longer collide
  - Since lit doesn't create a HTMLTemplateElement class, checking for its existence doesn't prevent a second polyfilling (imagine two lit-html versions being included on the page)
- Makes `content` non-writable
- Makes `innerHTML` enumerable
  - Element class methods/accessors are, strangely, all enumerable
- Uses `removeNodes` and `reparentNodes` helpers
- Reuses the original template element when upgrading it, instead of creating a div