### PR TITLE
classMap syntax punctuation

### DIFF
--- a/docs/_guide/05-template-reference.md
+++ b/docs/_guide/05-template-reference.md
@@ -359,7 +359,7 @@ import {classMap} from 'lit-html/directives/class-map.js';
 
 let classes = { highlight: true, enabled: true, hidden: false };
 
-html`<div class=${classMap(classes)>Classy text</div>`;
+html`<div class=${classMap(classes)}>Classy text</div>`;
 // renders as <div class="highlight enabled">Classy text</div>
 ```
 
@@ -368,7 +368,7 @@ Note that you can only use `classMap` in an attribute binding for the `class` at
 
 ```js
 // DON'T DO THIS
-html`<div class="someClass ${classMap(moreClasses}">Broken div</div>`;
+html`<div class="someClass ${classMap(moreClasses)}">Broken div</div>`;
 ```
 
 


### PR DESCRIPTION
Adds some missing punctuation of the `classMap` documentation.