### PR TITLE
Update docs list of browsers that support js modules

### DIFF
--- a/docs/_guide/01-getting-started.md
+++ b/docs/_guide/01-getting-started.md
@@ -37,7 +37,7 @@ You can try out lit-html without installing anything using an online editor. Bel
 ## Importing
 
 lit-html is written in and distributed as standard JavaScript modules.
-Modules are increasingly supported in JavaScript environments and are shipping in Chrome, Opera and Safari, and will soon be in Firefox and Edge.
+Modules are increasingly supported in JavaScript environments and have shipped in Chrome, Firefox, Edge, Safari, and Opera.
 
 To use lit-html, import it via a path:
 


### PR DESCRIPTION
This PR updates the getting started docs list of browsers that have shipped support for js modules (see https://caniuse.com/#feat=es6-module).

Closes #818 