### PR TITLE
Use duck-typing to test if container is ShadowRoot

### DIFF
--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -15,9 +15,3 @@ interface Window {
   ShadyCSS?: ShadyCSS;
   ShadyDOM?: ShadyDOM;
 }
-
-/** Allows code to check `instanceof ShadowRoot`. */
-declare interface ShadowRootConstructor {
-  new(): ShadowRoot;
-}
-declare const ShadowRoot: ShadowRootConstructor;

--- a/src/lib/shady-render.ts
+++ b/src/lib/shady-render.ts
@@ -240,12 +240,13 @@ export interface ShadyRenderOptions extends Partial<RenderOptions> {
  */
 export const render =
     (result: TemplateResult,
-     container: Element|DocumentFragment,
+     container: Element|DocumentFragment|ShadowRoot,
      options: ShadyRenderOptions) => {
       const scopeName = options.scopeName;
       const hasRendered = parts.has(container);
-      const needsScoping = container instanceof ShadowRoot &&
-          compatibleShadyCSSVersion && result instanceof TemplateResult;
+      const needsScoping = compatibleShadyCSSVersion &&
+          container.nodeType === 11 /* Node.DOCUMENT_FRAGMENT_NODE */ &&
+          !!(container as ShadowRoot).host && result instanceof TemplateResult;
       // Handle first render to a scope specially...
       const firstScopeRender = needsScoping && !shadyRenderSet.has(scopeName);
       // On first scope render, render into a fragment; this cannot be a single


### PR DESCRIPTION
The easiest difference to detect between a `ShadowRoot` and a `DocumentFragment` is the `host` element. Conveniently, this works in both v0 and v1.