### PR TITLE
Cache length of non-array iterables

### DIFF
--- a/src/lib/shady-render.ts
+++ b/src/lib/shady-render.ts
@@ -129,8 +129,9 @@ const prepareTemplateStyles =
       shadyRenderSet.add(scopeName);
       // Move styles out of rendered DOM and store.
       const styles = renderedDOM.querySelectorAll('style');
+      const {length} = styles;
       // If there are no styles, skip unnecessary work
-      if (styles.length === 0) {
+      if (length === 0) {
         // Ensure prepareTemplateStyles is called to support adding
         // styles via `prepareAdoptedCssText` since that requires that
         // `prepareTemplateStyles` is called.
@@ -143,7 +144,7 @@ const prepareTemplateStyles =
       // part indices.
       // NOTE: collecting styles is inefficient for browsers but ShadyCSS
       // currently does this anyway. When it does not, this should be changed.
-      for (let i = 0; i < styles.length; i++) {
+      for (let i = 0; i < length; i++) {
         const style = styles[i];
         style.parentNode!.removeChild(style);
         condensedStyle.textContent! += style.textContent;

--- a/src/lib/template.ts
+++ b/src/lib/template.ts
@@ -68,13 +68,14 @@ export class Template {
         if (node.nodeType === 1 /* Node.ELEMENT_NODE */) {
           if ((node as Element).hasAttributes()) {
             const attributes = (node as Element).attributes;
+            const {length} = attributes;
             // Per
             // https://developer.mozilla.org/en-US/docs/Web/API/NamedNodeMap,
             // attributes are not guaranteed to be returned in document order.
             // In particular, Edge/IE can return them out of order, so we cannot
             // assume a correspondance between part index and attribute index.
             let count = 0;
-            for (let i = 0; i < attributes.length; i++) {
+            for (let i = 0; i < length; i++) {
               if (attributes[i].value.indexOf(marker) >= 0) {
                 count++;
               }


### PR DESCRIPTION
We can marginally speed up for-loops over non-arrays (in this case, c++
backed `NamedNodeMap` and `NodeList`).

NamedNodeMap: https://jsbench.github.io/#e730df94c251a459f9213abdafe1c34c
NodeList: https://jsbench.github.io/#f638cacc866a1b2d6e517e6cfa900d6b