### PR TITLE
Adopt+upgrade template fragments after processing for parts

### DIFF
--- a/src/test/lib/render_test.ts
+++ b/src/test/lib/render_test.ts
@@ -966,6 +966,15 @@ suite('render()', () => {
     }
     customElements.define('property-tester', PropertySetterElement);
 
+    class MutatesInConstructorElement extends HTMLElement {
+      constructor() {
+        super();
+        this.innerHTML = '<div></div>';
+      }
+    }
+    customElements.define(
+        'mutates-in-constructor', MutatesInConstructorElement);
+
     teardown(() => {
       if (container.parentElement === document.body) {
         document.body.removeChild(container);
@@ -1033,6 +1042,19 @@ suite('render()', () => {
           assert.equal(instance.value, 'foo');
           assert.isTrue(instance.calledSetter);
         });
+
+    test('does not upgrade elements until after parts are established', () => {
+      render(
+          html`
+            <mutates-in-constructor></mutates-in-constructor>
+            <span>${'test'}</span>
+      `,
+          container);
+      assert.equal(stripExpressionMarkers(container.innerHTML), `
+            <mutates-in-constructor><div></div></mutates-in-constructor>
+            <span>test</span>
+      `);
+    });
   });
 
   suite('updates', () => {


### PR DESCRIPTION
Importing the node can cause any custom elements to upgrade, and non-compliant custom elements can cause DOM mutations.

If this happens before we process the template parts, our `part.index`s walking will be broken. So, it has to wait till afterwards.

But we still have to return upgraded elements before the template part's interact with the DOM. Luckily, we just adopt and upgrade them after the processing.

Fixes #561.