### PR TITLE
Cache only on the TemplateStringsArray

### DIFF
--- a/src/lib/parts.ts
+++ b/src/lib/parts.ts
@@ -21,7 +21,7 @@ import {removeNodes} from './dom.js';
 import {noChange, nothing, Part} from './part.js';
 import {RenderOptions} from './render-options.js';
 import {TemplateInstance} from './template-instance.js';
-import {TemplateResult} from './template-result.js';
+import {TemplateResult, templateResultsEqual} from './template-result.js';
 import {createMarker} from './template.js';
 
 // https://tc39.github.io/ecma262/#sec-typeof-operator
@@ -262,7 +262,7 @@ export class NodePart implements Part {
   private _commitTemplateResult(value: TemplateResult): void {
     const template = this.options.templateFactory(value);
     if (this.value instanceof TemplateInstance &&
-        this.value.template === template) {
+        templateResultsEqual(this.value.template.result, value)) {
       this.value.update(value.values);
     } else {
       // Make sure we propagate the template processor from the TemplateResult

--- a/src/lib/shady-render.ts
+++ b/src/lib/shady-render.ts
@@ -28,12 +28,17 @@ import {removeNodes} from './dom.js';
 import {insertNodeIntoTemplate, removeNodesFromTemplate} from './modify-template.js';
 import {RenderOptions} from './render-options.js';
 import {parts, render as litRender} from './render.js';
-import {templateCaches} from './template-factory.js';
 import {TemplateInstance} from './template-instance.js';
 import {TemplateResult} from './template-result.js';
 import {marker, Template} from './template.js';
 
 export {html, svg, TemplateResult} from '../lit-html.js';
+
+export type templateCache = {
+  stringsArray: WeakMap<TemplateStringsArray, Template>;
+  keyString: Map<string, Template>;
+};
+export const templateCaches = new Map<string, templateCache>();
 
 // Get a key to lookup in `templateCaches`.
 const getTemplateCacheKey = (type: string, scopeName: string) =>
@@ -75,11 +80,10 @@ const shadyTemplateFactory = (scopeName: string) =>
       const key = result.strings.join(marker);
       template = templateCache.keyString.get(key);
       if (template === undefined) {
-        const element = result.getTemplateElement();
+        template = new Template(result);
         if (compatibleShadyCSSVersion) {
-          window.ShadyCSS!.prepareTemplateDom(element, scopeName);
+          window.ShadyCSS!.prepareTemplateDom(template.element, scopeName);
         }
-        template = new Template(result, element);
         templateCache.keyString.set(key, template);
       }
       templateCache.stringsArray.set(result.strings, template);

--- a/src/lib/template-result.ts
+++ b/src/lib/template-result.ts
@@ -100,3 +100,22 @@ export class SVGTemplateResult extends TemplateResult {
     return template;
   }
 }
+
+export const templateResultsEqual =
+    (a: TemplateResult, b: TemplateResult): boolean => {
+      if (a === b) {
+        return true;
+      }
+      // Some environments (:ahem: Safari) are buggy...
+      const aStrings = a.strings;
+      const bStrings = b.strings;
+      if (aStrings.length !== bStrings.length) {
+        return false;
+      }
+      for (let i = 0; i < aStrings.length; i++) {
+        if (aStrings[i] !== bStrings[i]) {
+          return false;
+        }
+      }
+      return true;
+    };

--- a/src/lit-html.ts
+++ b/src/lit-html.ts
@@ -44,7 +44,7 @@ export {parts, render} from './lib/render.js';
 export {templateCaches, templateFactory} from './lib/template-factory.js';
 export {TemplateInstance} from './lib/template-instance.js';
 export {TemplateProcessor} from './lib/template-processor.js';
-export {SVGTemplateResult, TemplateResult} from './lib/template-result.js';
+export {SVGTemplateResult, TemplateResult, templateResultsEqual} from './lib/template-result.js';
 export {createMarker, isTemplatePartActive, Template} from './lib/template.js';
 
 declare global {

--- a/src/test/lib/template_test.ts
+++ b/src/test/lib/template_test.ts
@@ -22,7 +22,7 @@ suite('Template', () => {
     const countNodes =
         (result: TemplateResult,
          getNodes: (f: DocumentFragment) => NodeList) => {
-          const template = new Template(result, result.getTemplateElement());
+          const template = new Template(result);
           return getNodes(template.element.content).length;
         };
 
@@ -46,7 +46,7 @@ suite('Template', () => {
         ${3}
         <span a="${4}">${5}</span>
       </div>`;
-    const parts = new Template(result, result.getTemplateElement()).parts;
+    const parts = new Template(result).parts;
     assert.equal(parts.length, 5);
   });
 
@@ -63,7 +63,7 @@ suite('Template', () => {
         <p>${9}</p>
         <div aThing="${10}"></div>
       </div>`;
-    const template = new Template(result, result.getTemplateElement());
+    const template = new Template(result);
     const parts = template.parts as Array<{name: string}>;
     const names = parts.map((p) => p.name);
     const expectedAttributeNames = [


### PR DESCRIPTION
This is a refactoring of #579.

The `keyString` caching from #579 permantly caches every `Template`, which holds its `<template>`. This isn't ideal. So, we can't use the `TemplateStringsArray` string values as a caching key.

The issue here is that we want to prevent expensive computations as much as possible. With rendering (and re-rendering when changing to a new template), there are two big computations:

1. `<template>` creation and finding `TemplatePart`s
2. Thrashing a DOM tree

`#1` is due to creating a new `Template`. `#2` is due to creating a `TemplateInstance` from that `Template` and committing it to a container, which could have this exact DOM tree already rendered.

The current code uses the identity equality of `TemplateStringsArray` to get the same `Template` every time, preventing `#1`. It then uses the identity equality of the `Template` instance to avoid a `#2`'s thrash.

- - -

This PR works around these issues by deferring the heavy computations until as late as possible.

First, I've made `Template` instances cheap to create. They now hold onto the `TemplateResult`, and do no further work until necessary. This allows me to only cache based on the `TemplateStringsArray`. Even if Safari forgets to properly cache it, creating a new `Template` doesn't hurt much.

Second, I've changed the re-render check to use deep equality of the `Template`. Because the `Template` now holds onto the `TemplateStringsArray`, I can just grab those and check if they're identity equal (good browsers) or string value equal (Safari).

If we determine the two `Template`s are equal, we can prevent the trash just like normal. If they aren't equal, we then do the two heavy computations.

This leads to an almost ideal caching situation. Unfortunately:

- a `TemplateInstance` holds the `Template`
- a `Template` holds the `TemplateResult`
- a `TemplateResult` holds the `TemplateStringsArray`
- a `TemplateStringsArray` weakly holds the `Template` (via the `WeakMap`)

So we still have a retain cycle. But, once a `NodePart` rerenders with any other value, that cycle is broken. That's not too bad, and it's the best we can do.