### PR TITLE
shady-render: fix warning formatting

### DIFF
--- a/src/lib/shady-render.ts
+++ b/src/lib/shady-render.ts
@@ -45,8 +45,8 @@ if (typeof window.ShadyCSS === 'undefined') {
   compatibleShadyCSSVersion = false;
 } else if (typeof window.ShadyCSS.prepareTemplateDom === 'undefined') {
   console.warn(
-      `Incompatible ShadyCSS version detected.` +
-      `Please update to at least @webcomponents/webcomponentsjs@2.0.2 and` +
+      `Incompatible ShadyCSS version detected. ` +
+      `Please update to at least @webcomponents/webcomponentsjs@2.0.2 and ` +
       `@webcomponents/shadycss@1.3.1.`);
   compatibleShadyCSSVersion = false;
 }


### PR DESCRIPTION
This fixes spaces inside the warning that gets printed for incompatible ShadyCSS versions.

Before and after:

<img width="950" alt="2019-02-26 3 58 41" src="https://user-images.githubusercontent.com/291301/53379502-d5f66980-397a-11e9-82a8-9d9bb7649c69.png">
