### PR TITLE
Fix rendering comment binding followed by attribute

### DIFF
--- a/src/lib/template.ts
+++ b/src/lib/template.ts
@@ -181,6 +181,7 @@ export class Template {
             // TODO (justinfagnani): consider whether it's even worth it to
             // make bindings in comments work
             this.parts.push({type: 'node', index: -1});
+            partIndex++;
           }
         }
       }

--- a/src/test/lib/render_test.ts
+++ b/src/test/lib/render_test.ts
@@ -315,6 +315,14 @@ suite('render()', () => {
       assert.equal(container.innerText, 'AC');
     });
 
+    test('renders comments with multiple bindings followed by attr', () => {
+      const t = html`
+        <!-- <div class="${'foo'}">${'bar'}</div> -->
+        <p baz=${'qux'}></p>`;
+      render(t, container);
+      assert.equal(container.querySelector('p')!.getAttribute('baz'), 'qux');
+    });
+
     test('does not break with an attempted dynamic start tag', () => {
       // this won't work, but we'd like it to not throw an exception or break
       // other bindings

--- a/src/test/lib/render_test.ts
+++ b/src/test/lib/render_test.ts
@@ -268,6 +268,14 @@ suite('render()', () => {
       assert.equal(container.querySelector('p')!.textContent, 'bar');
     });
 
+    test('renders comments with bindings followed by attr', () => {
+      const t = html`
+        <!-- ${'foo'} -->
+        <p bar=${'baz'}></p>`;
+      render(t, container);
+      assert.equal(container.querySelector('p')!.getAttribute('bar'), 'baz');
+    });
+
     test('renders comments with multiple bindings', () => {
       const t = html`
         <!-- <div class="${'foo'}">${'bar'}</div> -->
@@ -317,7 +325,7 @@ suite('render()', () => {
 
     test('renders comments with multiple bindings followed by attr', () => {
       const t = html`
-        <!-- <div class="${'foo'}">${'bar'}</div> -->
+        <!-- ${'foo'} ${'bar'} -->
         <p baz=${'qux'}></p>`;
       render(t, container);
       assert.equal(container.querySelector('p')!.getAttribute('baz'), 'qux');


### PR DESCRIPTION
We forgot to update the `partIndex`, so when the attribute tried to
execute the `lastAttributeNameRegex` on the last string (determined by
the `partIndex`), it would fail to match anything.

I'm guessing this will fix #613.