### PR TITLE
Remove unnecessary type assertions

### DIFF
--- a/src/directives/repeat.ts
+++ b/src/directives/repeat.ts
@@ -420,8 +420,8 @@ export const repeat =
                 while (newHead <= newTail) {
                   // For all remaining additions, we insert before last new
                   // tail, since old pointers are no longer valid
-                  const newPart = createAndInsertPart(
-                      containerPart, newParts[newTail + 1]);
+                  const newPart =
+                      createAndInsertPart(containerPart, newParts[newTail + 1]);
                   updatePart(newPart, newValues[newHead]);
                   newParts[newHead++] = newPart;
                 }

--- a/src/directives/repeat.ts
+++ b/src/directives/repeat.ts
@@ -421,7 +421,7 @@ export const repeat =
                   // For all remaining additions, we insert before last new
                   // tail, since old pointers are no longer valid
                   const newPart = createAndInsertPart(
-                      containerPart, newParts[newTail + 1]!);
+                      containerPart, newParts[newTail + 1]);
                   updatePart(newPart, newValues[newHead]);
                   newParts[newHead++] = newPart;
                 }

--- a/src/lib/parts.ts
+++ b/src/lib/parts.ts
@@ -321,7 +321,7 @@ export class NodePart implements Part {
     if (partIndex < itemParts.length) {
       // Truncate the parts array so _value reflects the current state
       itemParts.length = partIndex;
-      this.clear(itemPart && itemPart!.endNode);
+      this.clear(itemPart && itemPart.endNode);
     }
   }
 

--- a/src/lib/template.ts
+++ b/src/lib/template.ts
@@ -113,11 +113,11 @@ export class Template {
           }
         }
         if ((node as Element).tagName === 'TEMPLATE') {
-          stack.push(node!);
+          stack.push(node);
           walker.currentNode = (node as HTMLTemplateElement).content;
         }
       } else if (node.nodeType === 3 /* Node.TEXT_NODE */) {
-        const data = (node as Text).data!;
+        const data = (node as Text).data;
         if (data.indexOf(marker) >= 0) {
           const parent = node.parentNode!;
           const strings = data.split(markerRegex);
@@ -166,7 +166,7 @@ export class Template {
           partIndex++;
         } else {
           let i = -1;
-          while ((i = (node as Comment).data!.indexOf(marker, i + 1)) !== -1) {
+          while ((i = (node as Comment).data.indexOf(marker, i + 1)) !== -1) {
             // Comment node has a binding marker inside, make an inactive part
             // The binding won't work, but subsequent bindings will
             // TODO (justinfagnani): consider whether it's even worth it to

--- a/src/test/directives/until_test.ts
+++ b/src/test/directives/until_test.ts
@@ -224,7 +224,8 @@ suite('until', () => {
     const deferred1 = new Deferred<any>();
     const deferred2 = new Deferred<any>();
 
-    const t = () => html`<div>${until(deferred1.promise, deferred2.promise)}</div>`;
+    const t = () =>
+        html`<div>${until(deferred1.promise, deferred2.promise)}</div>`;
 
     // First render with neither Promise resolved
     render(t(), container);
@@ -245,7 +246,8 @@ suite('until', () => {
     const deferred1 = new Deferred<any>();
     const deferred2 = new Deferred<any>();
 
-    const t = () => html`<div>${until(deferred1.promise, deferred2.promise)}</div>`;
+    const t = () =>
+        html`<div>${until(deferred1.promise, deferred2.promise)}</div>`;
 
     // First render with neither Promise resolved
     render(t(), container);

--- a/src/test/directives/until_test.ts
+++ b/src/test/directives/until_test.ts
@@ -32,14 +32,11 @@ suite('until', () => {
   });
 
   test('renders a Promise when it resolves', async () => {
-    let resolve: (v: any) => void;
-    const promise = new Promise((res, _) => {
-      resolve = res;
-    });
-    render(html`<div>${until(promise)}</div>`, container);
+    const deferred = new Deferred<any>();
+    render(html`<div>${until(deferred.promise)}</div>`, container);
     assert.equal(stripExpressionMarkers(container.innerHTML), '<div></div>');
-    resolve!('foo');
-    await promise;
+    deferred.resolve('foo');
+    await deferred.promise;
     assert.equal(stripExpressionMarkers(container.innerHTML), '<div>foo</div>');
   });
 
@@ -200,86 +197,68 @@ suite('until', () => {
   });
 
   test('renders racing Promises across renders correctly', async () => {
-    let resolve1: (v: any) => void;
-    const promise1 = new Promise((res, _) => {
-      resolve1 = res;
-    });
-    let resolve2: (v: any) => void;
-    const promise2 = new Promise((res, _) => {
-      resolve2 = res;
-    });
+    const deferred1 = new Deferred<any>();
+    const deferred2 = new Deferred<any>();
 
     const t = (promise: any) => html`<div>${until(promise)}</div>`;
 
     // First render, first Promise, no value
-    render(t(promise1), container);
+    render(t(deferred1.promise), container);
     assert.equal(stripExpressionMarkers(container.innerHTML), '<div></div>');
 
     // Second render, second Promise, still no value
-    render(t(promise2), container);
+    render(t(deferred2.promise), container);
     assert.equal(stripExpressionMarkers(container.innerHTML), '<div></div>');
 
     // Resolve the first Promise, should not update the container
-    resolve1!('foo');
-    await promise1;
+    deferred1.resolve('foo');
+    await deferred1.promise;
     assert.equal(stripExpressionMarkers(container.innerHTML), '<div></div>');
     // Resolve the second Promise, should update the container
-    resolve2!('bar');
-    await promise2;
+    deferred2.resolve('bar');
+    await deferred2.promise;
     assert.equal(stripExpressionMarkers(container.innerHTML), '<div>bar</div>');
   });
 
   test('renders Promises resolving in high-to-low priority', async () => {
-    let resolve1: (v: any) => void;
-    const promise1 = new Promise((res, _) => {
-      resolve1 = res;
-    });
-    let resolve2: (v: any) => void;
-    const promise2 = new Promise((res, _) => {
-      resolve2 = res;
-    });
+    const deferred1 = new Deferred<any>();
+    const deferred2 = new Deferred<any>();
 
-    const t = () => html`<div>${until(promise1, promise2)}</div>`;
+    const t = () => html`<div>${until(deferred1.promise, deferred2.promise)}</div>`;
 
     // First render with neither Promise resolved
     render(t(), container);
     assert.equal(stripExpressionMarkers(container.innerHTML), '<div></div>');
 
     // Resolve the primary Promise, updates the DOM
-    resolve1!('foo');
-    await promise1;
+    deferred1.resolve('foo');
+    await deferred1.promise;
     assert.equal(stripExpressionMarkers(container.innerHTML), '<div>foo</div>');
 
     // Resolve the secondary Promise, should not update the container
-    resolve2!('bar');
-    await promise2;
+    deferred2.resolve('bar');
+    await deferred2.promise;
     assert.equal(stripExpressionMarkers(container.innerHTML), '<div>foo</div>');
   });
 
   test('renders Promises resolving in low-to-high priority', async () => {
-    let resolve1: (v: any) => void;
-    const promise1 = new Promise((res, _) => {
-      resolve1 = res;
-    });
-    let resolve2: (v: any) => void;
-    const promise2 = new Promise((res, _) => {
-      resolve2 = res;
-    });
+    const deferred1 = new Deferred<any>();
+    const deferred2 = new Deferred<any>();
 
-    const t = () => html`<div>${until(promise1, promise2)}</div>`;
+    const t = () => html`<div>${until(deferred1.promise, deferred2.promise)}</div>`;
 
     // First render with neither Promise resolved
     render(t(), container);
     assert.equal(stripExpressionMarkers(container.innerHTML), '<div></div>');
 
     // Resolve the secondary Promise, updates the DOM
-    resolve2!('bar');
-    await promise2;
+    deferred2.resolve('bar');
+    await deferred2.promise;
     assert.equal(stripExpressionMarkers(container.innerHTML), '<div>bar</div>');
 
     // Resolve the primary Promise, updates the DOM
-    resolve1!('foo');
-    await promise1;
+    deferred1.resolve('foo');
+    await deferred1.promise;
     assert.equal(stripExpressionMarkers(container.innerHTML), '<div>foo</div>');
   });
 
@@ -302,10 +281,7 @@ suite('until', () => {
   });
 
   test('renders low-priority content when arguments change', async () => {
-    let resolve1: (v: any) => void;
-    const promise1 = new Promise((res, _) => {
-      resolve1 = res;
-    });
+    const deferred1 = new Deferred<any>();
     const promise2 = Promise.resolve('bar');
 
     const t = (p1: any, p2: any) => html`<div>${until(p1, p2)}</div>`;
@@ -320,47 +296,41 @@ suite('until', () => {
         stripExpressionMarkers(container.innerHTML), '<div>string</div>');
 
     // Then render new Promises with the low-priority Promise already resolved
-    render(t(promise1, promise2), container);
+    render(t(deferred1.promise, promise2), container);
     // Because they're Promises, nothing happens synchronously
     assert.equal(
         stripExpressionMarkers(container.innerHTML), '<div>string</div>');
     await 0;
     // Low-priority renders
     assert.equal(stripExpressionMarkers(container.innerHTML), '<div>bar</div>');
-    resolve1!('foo');
-    await promise1;
+    deferred1.resolve('foo');
+    await deferred1.promise;
     // High-priority renders
     assert.equal(stripExpressionMarkers(container.innerHTML), '<div>foo</div>');
   });
 
   test('renders Promises resolving after changing priority', async () => {
-    let resolve1: (v: any) => void;
-    const promise1 = new Promise((res, _) => {
-      resolve1 = res;
-    });
-    let resolve2: (v: any) => void;
-    const promise2 = new Promise((res, _) => {
-      resolve2 = res;
-    });
+    const deferred1 = new Deferred<any>();
+    const deferred2 = new Deferred<any>();
 
     const t = (p1: any, p2: any) => html`<div>${until(p1, p2)}</div>`;
 
     // First render with neither Promise resolved
-    render(t(promise1, promise2), container);
+    render(t(deferred1.promise, deferred2.promise), container);
     assert.equal(stripExpressionMarkers(container.innerHTML), '<div></div>');
 
     // Change priorities
-    render(t(promise2, promise1), container);
+    render(t(deferred2.promise, deferred1.promise), container);
     assert.equal(stripExpressionMarkers(container.innerHTML), '<div></div>');
 
     // Resolve the primary Promise, updates the DOM
-    resolve1!('foo');
-    await promise1;
+    deferred1.resolve('foo');
+    await deferred1.promise;
     assert.equal(stripExpressionMarkers(container.innerHTML), '<div>foo</div>');
 
     // Resolve the secondary Promise, also updates the DOM
-    resolve2!('bar');
-    await promise2;
+    deferred2.resolve('bar');
+    await deferred2.promise;
     assert.equal(stripExpressionMarkers(container.innerHTML), '<div>bar</div>');
   });
 });

--- a/src/test/lib/modify-template_test.ts
+++ b/src/test/lib/modify-template_test.ts
@@ -74,7 +74,7 @@ suite('add/remove nodes from template', () => {
     const template = templateFactory(result);
     const fragment1 = document.createDocumentFragment();
     fragment1.appendChild(document.createElement('div'));
-    (fragment1.firstChild as HTMLElement)!.innerHTML = '<span>1</span>';
+    (fragment1.firstChild as HTMLElement).innerHTML = '<span>1</span>';
     insertNodeIntoTemplate(
         template, fragment1, template.element.content.firstChild);
     const fragment2 = document.createDocumentFragment();

--- a/src/test/lib/render_test.ts
+++ b/src/test/lib/render_test.ts
@@ -558,7 +558,7 @@ suite('render()', () => {
       render(html`<div @click=${listener}></div>`, container, {eventContext});
       const div = container.querySelector('div')!;
       div.click();
-      if (event ===  undefined) {
+      if (event === undefined) {
         throw new Error(`Event listener never fired!`);
       }
       assert.equal(thisValue, eventContext);

--- a/src/test/lib/render_test.ts
+++ b/src/test/lib/render_test.ts
@@ -549,7 +549,7 @@ suite('render()', () => {
 
     test('adds event listener functions, calls with right this value', () => {
       let thisValue;
-      let event: Event;
+      let event: Event|undefined = undefined;
       const listener = function(this: any, e: any) {
         event = e;
         thisValue = this;
@@ -558,14 +558,17 @@ suite('render()', () => {
       render(html`<div @click=${listener}></div>`, container, {eventContext});
       const div = container.querySelector('div')!;
       div.click();
+      if (event ===  undefined) {
+        throw new Error(`Event listener never fired!`);
+      }
       assert.equal(thisValue, eventContext);
 
       // MouseEvent is not a function in IE, so the event cannot be an instance
       // of it
       if (typeof MouseEvent === 'function') {
-        assert.instanceOf(event!, MouseEvent);
+        assert.instanceOf(event, MouseEvent);
       } else {
-        assert.isDefined((event! as MouseEvent).initMouseEvent);
+        assert.isDefined((event as MouseEvent).initMouseEvent);
       }
     });
 

--- a/src/test/lib/shady-render-apply_test.ts
+++ b/src/test/lib/shady-render-apply_test.ts
@@ -97,13 +97,13 @@ suite('shady-render @apply', () => {
           document.body.appendChild(applyProducer);
           renderShadowRoot(producerContent, applyProducer);
           const usersInProducer =
-              applyProducer.shadowRoot!.querySelectorAll('apply-user')!;
+              applyProducer.shadowRoot!.querySelectorAll('apply-user');
           renderShadowRoot(applyUserContent, usersInProducer[0]);
           renderShadowRoot(applyUserContent, usersInProducer[1]);
           const userInProducerStyle1 = getComputedStyle(
-              usersInProducer[0]!.shadowRoot!.querySelector('div')!);
+              usersInProducer[0].shadowRoot!.querySelector('div')!);
           const userInProducerStyle2 = getComputedStyle(
-              usersInProducer[1]!.shadowRoot!.querySelector('div')!);
+              usersInProducer[1].shadowRoot!.querySelector('div')!);
           assert.equal(
               userInProducerStyle1.getPropertyValue('border-top-width').trim(),
               '10px');
@@ -173,11 +173,11 @@ suite('shady-render @apply', () => {
         const user1 =
             applyProducer.shadowRoot!.querySelector('apply-user-ce1')!;
         const userInProducerStyle1 =
-            getComputedStyle(user1!.shadowRoot!.querySelector('div')!);
+            getComputedStyle(user1.shadowRoot!.querySelector('div')!);
         const user2 =
             applyProducer.shadowRoot!.querySelector('apply-user-ce2')!;
         const userInProducerStyle2 =
-            getComputedStyle(user2!.shadowRoot!.querySelector('div')!);
+            getComputedStyle(user2.shadowRoot!.querySelector('div')!);
         assert.equal(
             userInProducerStyle1.getPropertyValue('border-top-width').trim(),
             '10px');

--- a/src/test/lib/shady-render_test.ts
+++ b/src/test/lib/shady-render_test.ts
@@ -154,7 +154,7 @@ suite('shady-render', () => {
         const e = (container.shadowRoot!).querySelector('scope-4a-sub')!;
         renderShadowRoot(shadowContent, e);
         assert.equal(
-            getComputedStyle(e!).getPropertyValue('border-top-width').trim(),
+            getComputedStyle(e).getPropertyValue('border-top-width').trim(),
             '2px');
         document.body.removeChild(container);
       });
@@ -187,15 +187,15 @@ suite('shady-render', () => {
             container);
         const elements =
             (container.shadowRoot!).querySelectorAll('scope-4b-sub');
-        renderShadowRoot(nestedContent, elements[0]!);
-        renderShadowRoot(nestedContent, elements[1]!);
+        renderShadowRoot(nestedContent, elements[0]);
+        renderShadowRoot(nestedContent, elements[1]);
         assert.equal(
-            getComputedStyle(elements[0]!)
+            getComputedStyle(elements[0])
                 .getPropertyValue('border-top-width')
                 .trim(),
             '2px');
         assert.equal(
-            getComputedStyle(elements[1]!)
+            getComputedStyle(elements[1])
                 .getPropertyValue('border-top-width')
                 .trim(),
             '2px');

--- a/src/test/test-utils/shadow-root.ts
+++ b/src/test/test-utils/shadow-root.ts
@@ -21,5 +21,5 @@ export const renderShadowRoot = (result: TemplateResult, element: Element) => {
   if (!element.shadowRoot) {
     element.attachShadow({mode: 'open'});
   }
-  render(result, element.shadowRoot!, {scopeName: element.localName!});
+  render(result, element.shadowRoot!, {scopeName: element.localName});
 };

--- a/tslint.json
+++ b/tslint.json
@@ -15,6 +15,7 @@
     "no-trailing-whitespace": true,
     "no-var-keyword": true,
     "no-any": true,
+    "no-unnecessary-type-assertion": true,
     "one-line": [
       true,
       "check-open-brace",


### PR DESCRIPTION
This is the result of turning on the no-unnecessary-type-assertion tslint pass and running `--fix`, then fixing up a few tests using `Deferred` and adding an additional assertion in places where TypeScript couldn't infer that a variable was always assigned before being read.

I like this lint pass because it makes the code a bit easier to read and understand. I will admit though that I'm proposing this change because we use this lint pass downstream, and it's annoying seeing the lint warnings.