### PR TITLE
 Rework TemplateInstance cloning

### DIFF
--- a/src/directives/async-append.ts
+++ b/src/directives/async-append.ts
@@ -84,7 +84,7 @@ export const asyncAppend = directive(
         // Check to see if we have a previous item and Part
         if (itemPart !== undefined) {
           // Create a new node to separate the previous and next Parts
-          itemStartNode = createMarker();
+          itemStartNode = createMarker('');
           // itemPart is currently the Part for the previous item. Set
           // it's endNode to the node we'll use for the next Part's
           // startNode.

--- a/src/directives/repeat.ts
+++ b/src/directives/repeat.ts
@@ -25,8 +25,8 @@ const createAndInsertPart =
       const container = containerPart.startNode.parentNode as Node;
       const beforeNode = beforePart === undefined ? containerPart.endNode :
                                                     beforePart.startNode;
-      const startNode = container.insertBefore(createMarker(), beforeNode);
-      container.insertBefore(createMarker(), beforeNode);
+      const startNode = container.insertBefore(createMarker(''), beforeNode);
+      container.insertBefore(createMarker(''), beforeNode);
       const newPart = new NodePart(containerPart.options);
       newPart.insertAfterNode(startNode);
       return newPart;

--- a/src/lib/modify-template.ts
+++ b/src/lib/modify-template.ts
@@ -16,124 +16,58 @@
  * @module shady-render
  */
 
-import {isTemplatePartActive, Template, TemplatePart} from './template.js';
-
-const walkerNodeFilter = 133 /* NodeFilter.SHOW_{ELEMENT|COMMENT|TEXT} */;
+import {partMarker, Template, TemplatePart} from './template.js';
 
 /**
- * Removes the list of nodes from a Template safely. In addition to removing
- * nodes from the Template, the Template part indices are updated to match
- * the mutated Template DOM.
- *
- * As the template is walked the removal state is tracked and
- * part indices are adjusted as needed.
- *
- * div
- *   div#1 (remove) <-- start removing (removing node is div#1)
- *     div
- *       div#2 (remove)  <-- continue removing (removing node is still div#1)
- *         div
- * div <-- stop removing since previous sibling is the removing node (div#1,
- * removed 4 nodes)
+ * Removes all style elements from the template. In addition to removing
+ * elements, the Template's parts array is updated to match the mutated
+ * Template DOM.
  */
-export function removeNodesFromTemplate(
-    template: Template, nodesToRemove: Set<Node>) {
-  const {element: {content}, parts} = template;
-  const walker =
-      document.createTreeWalker(content, walkerNodeFilter, null, false);
-  let partIndex = nextActiveIndexInTemplateParts(parts);
-  let part = parts[partIndex];
-  let nodeIndex = -1;
-  let removeCount = 0;
-  const nodesToRemoveInTemplate = [];
-  let currentRemovingNode: Node|null = null;
-  while (walker.nextNode()) {
-    nodeIndex++;
-    const node = walker.currentNode as Element;
-    // End removal if stepped past the removing node
-    if (node.previousSibling === currentRemovingNode) {
-      currentRemovingNode = null;
-    }
-    // A node to remove was found in the template
-    if (nodesToRemove.has(node)) {
-      nodesToRemoveInTemplate.push(node);
-      // Track node we're removing
-      if (currentRemovingNode === null) {
-        currentRemovingNode = node;
-      }
-    }
-    // When removing, increment count by which to adjust subsequent part indices
-    if (currentRemovingNode !== null) {
-      removeCount++;
-    }
-    while (part !== undefined && part.index === nodeIndex) {
-      // If part is in a removed node deactivate it by setting index to -1 or
-      // adjust the index as needed.
-      part.index = currentRemovingNode !== null ? -1 : part.index - removeCount;
-      // go to the next active part.
-      partIndex = nextActiveIndexInTemplateParts(parts, partIndex);
-      part = parts[partIndex];
-    }
-  }
-  nodesToRemoveInTemplate.forEach((n) => n.parentNode!.removeChild(n));
-}
-
-const countNodes = (node: Node) => {
-  let count = (node.nodeType === 11 /* Node.DOCUMENT_FRAGMENT_NODE */) ? 0 : 1;
-  const walker = document.createTreeWalker(node, walkerNodeFilter, null, false);
-  while (walker.nextNode()) {
-    count++;
-  }
-  return count;
-};
-
-const nextActiveIndexInTemplateParts =
-    (parts: TemplatePart[], startIndex: number = -1) => {
-      for (let i = startIndex + 1; i < parts.length; i++) {
-        const part = parts[i];
-        if (isTemplatePartActive(part)) {
-          return i;
-        }
-      }
-      return -1;
-    };
-
-/**
- * Inserts the given node into the Template, optionally before the given
- * refNode. In addition to inserting the node into the Template, the Template
- * part indices are updated to match the mutated Template DOM.
- */
-export function insertNodeIntoTemplate(
-    template: Template, node: Node, refNode: Node|null = null) {
-  const {element: {content}, parts} = template;
-  // If there's no refNode, then put node at end of template.
-  // No part indices need to be shifted in this case.
-  if (refNode === null || refNode === undefined) {
-    content.appendChild(node);
+export function removeStylesFromTemplate(template: Template) {
+  const {parts, element: {content}} = template;
+  const styles = content.querySelectorAll('style');
+  const {length} = styles;
+  if (length === 0) {
     return;
   }
-  const walker =
-      document.createTreeWalker(content, walkerNodeFilter, null, false);
-  let partIndex = nextActiveIndexInTemplateParts(parts);
-  let insertCount = 0;
-  let walkerIndex = -1;
-  while (walker.nextNode()) {
-    walkerIndex++;
-    const walkerNode = walker.currentNode as Element;
-    if (walkerNode === refNode) {
-      insertCount = countNodes(node);
-      refNode.parentNode!.insertBefore(node, refNode);
+
+  const walker = document.createTreeWalker(
+      document, 128 /* NodeFilter.SHOW_COMMENT */, null, false);
+
+  for (let i = 0; i < length; i++) {
+    const style = styles[i];
+    const {previousSibling, parentNode} = style;
+
+    parentNode!.removeChild(style);
+
+    // Is the previousSibling a part marker comment? If so, we need to remove
+    // it.
+    if (isPartMarker(previousSibling)) {
+      removePartForMarker(parts, previousSibling);
+      parentNode!.removeChild(previousSibling);
     }
-    while (partIndex !== -1 && parts[partIndex].index === walkerIndex) {
-      // If we've inserted the node, simply adjust all subsequent parts
-      if (insertCount > 0) {
-        while (partIndex !== -1) {
-          parts[partIndex].index += insertCount;
-          partIndex = nextActiveIndexInTemplateParts(parts, partIndex);
-        }
-        return;
+
+    // If there are any part markers for text nodes (the only possible binding
+    // in a style element), we need to update those indices in the parts array,
+    // too.
+    walker.currentNode = style;
+    while (walker.nextNode()) {
+      const comment = walker.currentNode as Comment;
+      if (isPartMarker(comment)) {
+        removePartForMarker(parts, comment);
       }
-      partIndex = nextActiveIndexInTemplateParts(parts, partIndex);
     }
   }
 }
+
+const removePartForMarker =
+    (parts: Array<TemplatePart|undefined>, comment: Comment) => {
+      // The part marker signifies the NodePart's index in the 16 low bits.
+      const packed = parseInt(comment.data.slice(partMarker.length), 10);
+      parts[packed & 0xffff] = undefined;
+    };
+
+const isPartMarker = (comment: Node|null): comment is Comment => {
+  return comment !== null && comment.nodeType === 8 /* Node.COMMENT_NODE */ &&
+      (comment as Comment).data.slice(0, partMarker.length) === partMarker;
+};

--- a/src/lib/parts.ts
+++ b/src/lib/parts.ts
@@ -159,8 +159,8 @@ export class NodePart implements Part {
    * This part must be empty, as its contents are not automatically moved.
    */
   appendInto(container: Node) {
-    this.startNode = container.appendChild(createMarker());
-    this.endNode = container.appendChild(createMarker());
+    this.startNode = container.appendChild(createMarker(''));
+    this.endNode = container.appendChild(createMarker(''));
   }
 
   /**
@@ -181,8 +181,8 @@ export class NodePart implements Part {
    * This part must be empty, as its contents are not automatically moved.
    */
   appendIntoPart(part: NodePart) {
-    part.__insert(this.startNode = createMarker());
-    part.__insert(this.endNode = createMarker());
+    part.__insert(this.startNode = createMarker(''));
+    part.__insert(this.endNode = createMarker(''));
   }
 
   /**
@@ -191,7 +191,7 @@ export class NodePart implements Part {
    * This part must be empty, as its contents are not automatically moved.
    */
   insertAfterPart(ref: NodePart) {
-    ref.__insert(this.startNode = createMarker());
+    ref.__insert(this.startNode = createMarker(''));
     this.endNode = ref.endNode;
     ref.endNode = this.startNode;
   }

--- a/src/lib/shady-render.ts
+++ b/src/lib/shady-render.ts
@@ -25,7 +25,7 @@
  * docs.
  */
 import {removeNodes} from './dom.js';
-import {insertNodeIntoTemplate, removeNodesFromTemplate} from './modify-template.js';
+import {removeStylesFromTemplate} from './modify-template.js';
 import {RenderOptions} from './render-options.js';
 import {parts, render as litRender} from './render.js';
 import {templateCaches} from './template-factory.js';
@@ -96,13 +96,7 @@ const removeStylesFromLitTemplates = (scopeName: string) => {
     const templates = templateCaches.get(getTemplateCacheKey(type, scopeName));
     if (templates !== undefined) {
       templates.keyString.forEach((template) => {
-        const {element: {content}} = template;
-        // IE 11 doesn't support the iterable param Set constructor
-        const styles = new Set<Element>();
-        Array.from(content.querySelectorAll('style')).forEach((s: Element) => {
-          styles.add(s);
-        });
-        removeNodesFromTemplate(template, styles);
+        removeStylesFromTemplate(template);
       });
     }
   });
@@ -163,14 +157,8 @@ const prepareTemplateStyles =
       }
       // Remove styles from nested templates in this scope.
       removeStylesFromLitTemplates(scopeName);
-      // And then put the condensed style into the "root" template passed in as
-      // `template`.
-      const content = templateElement.content;
-      if (!!template) {
-        insertNodeIntoTemplate(template, condensedStyle, content.firstChild);
-      } else {
-        content.insertBefore(condensedStyle, content.firstChild);
-      }
+      const {content} = templateElement;
+      content.insertBefore(condensedStyle, content.firstChild);
       // Note, it's important that ShadyCSS gets the template that `lit-html`
       // will actually render so that it can update the style inside when
       // needed (e.g. @apply native Shadow DOM case).
@@ -180,19 +168,6 @@ const prepareTemplateStyles =
         // When in native Shadow DOM, ensure the style created by ShadyCSS is
         // included in initially rendered output (`renderedDOM`).
         renderedDOM.insertBefore(style.cloneNode(true), renderedDOM.firstChild);
-      } else if (!!template) {
-        // When no style is left in the template, parts will be broken as a
-        // result. To fix this, we put back the style node ShadyCSS removed
-        // and then tell lit to remove that node from the template.
-        // There can be no style in the template in 2 cases (1) when Shady DOM
-        // is in use, ShadyCSS removes all styles, (2) when native Shadow DOM
-        // is in use ShadyCSS removes the style if it contains no content.
-        // NOTE, ShadyCSS creates its own style so we can safely add/remove
-        // `condensedStyle` here.
-        content.insertBefore(condensedStyle, content.firstChild);
-        const removes = new Set<Node>();
-        removes.add(condensedStyle);
-        removeNodesFromTemplate(template, removes);
       }
     };
 

--- a/src/lib/template-instance.ts
+++ b/src/lib/template-instance.ts
@@ -20,7 +20,7 @@ import {isCEPolyfill} from './dom.js';
 import {Part} from './part.js';
 import {RenderOptions} from './render-options.js';
 import {TemplateProcessor} from './template-processor.js';
-import {isTemplatePartActive, Template, TemplatePart} from './template.js';
+import {partMarker, Template, templateMarker} from './template.js';
 
 /**
  * An instance of a `Template` that can be attached to the DOM and updated
@@ -98,56 +98,85 @@ export class TemplateInstance {
         this.template.element.content.cloneNode(true) as DocumentFragment :
         document.importNode(this.template.element.content, true);
 
-    const stack: Node[] = [];
-    const parts = this.template.parts;
     // Edge needs all 4 parameters present; IE11 needs 3rd parameter to be null
     const walker = document.createTreeWalker(
-        fragment,
-        133 /* NodeFilter.SHOW_{ELEMENT|COMMENT|TEXT} */,
-        null,
-        false);
-    let partIndex = 0;
-    let nodeIndex = 0;
-    let part: TemplatePart;
-    let node = walker.nextNode();
-    // Loop through all the nodes and parts of a template
-    while (partIndex < parts.length) {
-      part = parts[partIndex];
-      if (!isTemplatePartActive(part)) {
-        this.__parts.push(undefined);
-        partIndex++;
+        fragment, 128 /* NodeFilter.SHOW_COMMENT */, null, false);
+    const stack: Element[] = [];
+    const {parts} = this.template;
+
+    // Count the active number of parts. This will allow us to early exit after
+    // finding the last part, instead of exhausting the entire tree.
+    let partCount = 0;
+    for (let i = 0; i < parts.length; i++) {
+      if (parts[i] !== undefined) {
+        partCount++;
+      }
+    }
+
+    while (partCount > 0) {
+      const comment = walker.nextNode() as Comment;
+
+      if (comment === null) {
+        // We've exhausted the content inside a nested template element.
+        // Because we still have parts (the outer for-loop), we know:
+        // * There is a template in the stack
+        // * The walker will find a nextNode outside the template
+        walker.currentNode = stack.pop()!;
         continue;
       }
 
-      // Progress the tree walker until we find our next part's node.
-      // Note that multiple parts may share the same node (attribute parts
-      // on a single element), so this loop may not run at all.
-      while (nodeIndex < part.index) {
-        nodeIndex++;
-        if (node!.nodeName === 'TEMPLATE') {
-          stack.push(node!);
-          walker.currentNode = (node as HTMLTemplateElement).content;
-        }
-        if ((node = walker.nextNode()) === null) {
-          // We've exhausted the content inside a nested template element.
-          // Because we still have parts (the outer for-loop), we know:
-          // - There is a template in the stack
-          // - The walker will find a nextNode outside the template
-          walker.currentNode = stack.pop()!;
-          node = walker.nextNode();
-        }
+      const {data} = comment;
+      if (data === '') {
+        continue;
       }
 
-      // We've arrived at our part's node.
-      if (part.type === 'node') {
-        const part = this.processor.handleTextExpression(this.options);
-        part.insertAfterNode(node!.previousSibling!);
-        this.__parts.push(part);
-      } else {
-        this.__parts.push(...this.processor.handleAttributeExpressions(
-            node as Element, part.name, part.strings, this.options));
+      // Does this comment start with the part marker?
+      if (data.slice(0, partMarker.length) === partMarker) {
+        // The part marker packs the part index in the 16 low bits and
+        // attribute count (if it's an attribute binding) in the 16 high bits.
+        const packed = parseInt(data.slice(partMarker.length), 10);
+        let partIndex = packed & 0xffff;
+        let attributeCount = packed >>> 16;
+
+        // We know the part marker comes directly before the node we care
+        // about. The marker itself is dead weight after this, so we can remove
+        // it by advancing the walker to the real node.
+        const nextNode = comment.nextSibling!;
+        walker.currentNode = nextNode;
+        comment.parentNode!.removeChild(comment);
+
+        if (attributeCount === 0) {
+          // A Node TemplatePart. The part marker was inserted between the
+          // startNode and the endNode, meaning nextNode is the endNode.
+          const part = this.processor.handleTextExpression(this.options);
+          part.insertAfterNode(nextNode.previousSibling!);
+          this.__parts[partIndex] = part;
+          partCount--;
+        } else {
+          // An Attribute TemplatePart. The part marker is directly before the
+          // element with the attribute bindings, and the attributeCount tells
+          // us how many attributes were bound. Note that each bound attribute
+          // can have multiple bindings.
+          while (attributeCount-- > 0) {
+            const part = parts[partIndex] as
+                {name: string, strings: ReadonlyArray<string>};
+            const attrs = this.processor.handleAttributeExpressions(
+                nextNode as Element, part.name, part.strings, this.options);
+            for (let p = 0; p < attrs.length; p++) {
+              this.__parts[partIndex++] = attrs[p];
+            }
+            partCount -= attrs.length;
+          }
+        }
+      } else if (data === templateMarker) {
+        // A template marker comes directly after the template element. By
+        // advancing the walker to the template's content, we're able to remove
+        // the marker.
+        const template = comment.previousSibling! as HTMLTemplateElement;
+        walker.currentNode = template.content;
+        comment.parentNode!.removeChild(comment);
+        stack.push(template);
       }
-      partIndex++;
     }
 
     if (isCEPolyfill) {

--- a/src/lit-html.ts
+++ b/src/lit-html.ts
@@ -45,7 +45,7 @@ export {templateCaches, templateFactory} from './lib/template-factory.js';
 export {TemplateInstance} from './lib/template-instance.js';
 export {TemplateProcessor} from './lib/template-processor.js';
 export {SVGTemplateResult, TemplateResult} from './lib/template-result.js';
-export {createMarker, isTemplatePartActive, Template} from './lib/template.js';
+export {createMarker, Template} from './lib/template.js';
 
 declare global {
   interface Window {

--- a/src/test/lib/modify-template_test.ts
+++ b/src/test/lib/modify-template_test.ts
@@ -12,7 +12,7 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {insertNodeIntoTemplate, removeNodesFromTemplate} from '../../lib/modify-template.js';
+import {removeStylesFromTemplate} from '../../lib/modify-template.js';
 import {render} from '../../lib/render.js';
 import {html, templateFactory} from '../../lit-html.js';
 import {stripExpressionMarkers} from '../test-utils/strip-markers.js';
@@ -21,167 +21,44 @@ const assert = chai.assert;
 
 // tslint:disable:no-any OK in test code.
 
-suite('add/remove nodes from template', () => {
+suite('removing nodes from template', () => {
   let container: HTMLElement;
 
   setup(() => {
     container = document.createElement('div');
   });
 
-  test(
-      'inserting nodes into template between parts renders/updates result',
-      () => {
-        const getResult = (a: any, b: any, c: any) => html`
-        <div foo="${a}">
-          ${b}
-          <p>${c}</p>
-        </div>`;
-        const result = getResult('bar', 'baz', 'qux');
-        const template = templateFactory(result);
-        const div1 = document.createElement('div');
-        div1.innerHTML = '<span>1</span>';
-        insertNodeIntoTemplate(
-            template, div1, template.element.content.firstChild);
-        const div2 = document.createElement('div');
-        div2.innerHTML = '<span>2</span>';
-        insertNodeIntoTemplate(
-            template, div2, template.element.content.querySelector('p'));
-        const div3 = document.createElement('div');
-        div3.innerHTML = '<span>3</span>';
-        insertNodeIntoTemplate(template, div3);
-        render(result, container);
-        assert.equal(
-            stripExpressionMarkers(container.innerHTML),
-            `<div><span>1</span></div>
-        <div foo="bar">
-          baz
-          <div><span>2</span></div><p>qux</p>
-        </div><div><span>3</span></div>`);
-        render(getResult('a', 'b', 'c'), container);
-        assert.equal(
-            stripExpressionMarkers(container.innerHTML),
-            `<div><span>1</span></div>
-        <div foo="a">
-          b
-          <div><span>2</span></div><p>c</p>
-        </div><div><span>3</span></div>`);
-      });
+  test('removing style with attribute bindings renders/updates result', () => {
+    const getResult = (a: any, b: any, c: any) => html
+    `<style bound="${a}"></style><div foo="${b}">${c}</div>`;
 
-  test('inserting documentFragment into template', () => {
-    const getResult = (a: any, b: any, c: any) =>
-        html`<div foo="${a}">${b}<p>${c}</p></div>`;
-    const result = getResult('bar', 'baz', 'qux');
+    const result = getResult('a', 'b', 'c');
     const template = templateFactory(result);
-    const fragment1 = document.createDocumentFragment();
-    fragment1.appendChild(document.createElement('div'));
-    (fragment1.firstChild as HTMLElement).innerHTML = '<span>1</span>';
-    insertNodeIntoTemplate(
-        template, fragment1, template.element.content.firstChild);
-    const fragment2 = document.createDocumentFragment();
-    insertNodeIntoTemplate(
-        template, fragment2, template.element.content.querySelector('p'));
+    removeStylesFromTemplate(template);
+
     render(result, container);
     assert.equal(
-        stripExpressionMarkers(container.innerHTML),
-        `<div><span>1</span></div><div foo="bar">baz<p>qux</p></div>`);
-    render(getResult('a', 'b', 'c'), container);
+        stripExpressionMarkers(container.innerHTML), `<div foo="b">c</div>`);
+
+    render(getResult('d', 'e', 'f'), container);
     assert.equal(
-        stripExpressionMarkers(container.innerHTML),
-        `<div><span>1</span></div><div foo="a">b<p>c</p></div>`);
+        stripExpressionMarkers(container.innerHTML), `<div foo="e">f</div>`);
   });
 
-  test(
-      'removing nodes in template between parts renders/updates result', () => {
-        const getResult = (a: any, b: any, c: any) =>
-            html`<div name="remove"><span>remove</span></div>
-        <div foo="${a}"><div name="remove"><span>remove</span></div>
-          ${b}
-          <div name="remove"><span name="remove">remove</span></div><p>${c}</p>
-        </div><div name="remove"><span name="remove"><span name="remove">remove</span></span></div>`;
-        const result = getResult('bar', 'baz', 'qux');
-        const template = templateFactory(result);
-        const nodeSet = new Set<Node>();
-        const nodesToRemove =
-            template.element.content.querySelectorAll('[name="remove"]');
-        for (const node of Array.from(nodesToRemove)) {
-          nodeSet.add(node);
-        }
-        removeNodesFromTemplate(template, nodeSet);
-        render(result, container);
-        assert.equal(stripExpressionMarkers(container.innerHTML), `
-        <div foo="bar">
-          baz
-          <p>qux</p>
-        </div>`);
-        render(getResult('a', 'b', 'c'), container);
-        assert.equal(stripExpressionMarkers(container.innerHTML), `
-        <div foo="a">
-          b
-          <p>c</p>
-        </div>`);
-      });
+  test('removing style with text bindings renders/updates result', () => {
+    const getResult = (a: any, b: any, c: any) => html
+    `<style>${a}</style><div foo="${b}">${c}</div>`;
 
-  test(
-      'removing nodes in template containing parts renders/updates result',
-      () => {
-        const getResult = (a: any, b: any, c: any, r1: any, r2: any, r3: any) =>
-            html`<div name="remove"><span>${r1}</span></div>
-        <div foo="${a}"><div name="remove"><span>${r2}</span></div>
-          ${b}
-          <div name="remove"><span name="remove">${r3}</span></div><p>${c}</p>
-        </div><div name="remove"><span name="remove"><span name="remove">remove</span></span></div>`;
-        const result = getResult('bar', 'baz', 'qux', 'r1', 'r2', 'r3');
-        const template = templateFactory(result);
-        const nodeSet = new Set<Node>();
-        const nodesToRemove =
-            template.element.content.querySelectorAll('[name="remove"]');
-        for (const node of Array.from(nodesToRemove)) {
-          nodeSet.add(node);
-        }
-        removeNodesFromTemplate(template, nodeSet);
-        render(result, container);
-        assert.equal(stripExpressionMarkers(container.innerHTML), `
-        <div foo="bar">
-          baz
-          <p>qux</p>
-        </div>`);
-        render(getResult('a', 'b', 'c', 'rr1', 'rr2', 'rr3'), container);
-        assert.equal(stripExpressionMarkers(container.innerHTML), `
-        <div foo="a">
-          b
-          <p>c</p>
-        </div>`);
-      });
+    const result = getResult('a', 'b', 'c');
+    const template = templateFactory(result);
+    removeStylesFromTemplate(template);
 
-  test(
-      'removing nodes in template containing parts with in-active parts renders/updates result',
-      () => {
-        const getResult = (a: any, b: any, c: any, r1: any, r2: any, r3: any) =>
-            html`<div name="remove"><span>${r1}</span></div>
-        <div foo="${a}"><div name="remove"><span>${r2}</span></div>
-          ${b}
-          <div name="remove"><span name="remove">${r3}</span></div><p>${c}</p>
-        </div><div name="remove"><span name="remove"><span name="remove">remove</span></span></div>`;
-        const result = getResult('bar', 'baz', 'qux', 'r1', 'r2', 'r3');
-        const template = templateFactory(result);
-        let node;
-        while (node =
-                   template.element.content.querySelector('[name="remove"]')) {
-          const nodeSet = new Set<Node>();
-          nodeSet.add(node);
-          removeNodesFromTemplate(template, nodeSet);
-        }
-        render(result, container);
-        assert.equal(stripExpressionMarkers(container.innerHTML), `
-        <div foo="bar">
-          baz
-          <p>qux</p>
-        </div>`);
-        render(getResult('a', 'b', 'c', 'rr1', 'rr2', 'rr3'), container);
-        assert.equal(stripExpressionMarkers(container.innerHTML), `
-        <div foo="a">
-          b
-          <p>c</p>
-        </div>`);
-      });
+    render(result, container);
+    assert.equal(
+        stripExpressionMarkers(container.innerHTML), `<div foo="b">c</div>`);
+
+    render(getResult('d', 'e', 'f'), container);
+    assert.equal(
+        stripExpressionMarkers(container.innerHTML), `<div foo="e">f</div>`);
+  });
 });

--- a/src/test/lib/parts_test.ts
+++ b/src/test/lib/parts_test.ts
@@ -90,8 +90,8 @@ suite('Parts', () => {
 
     setup(() => {
       container = document.createElement('div');
-      startNode = createMarker();
-      endNode = createMarker();
+      startNode = createMarker('');
+      endNode = createMarker('');
       container.appendChild(startNode);
       container.appendChild(endNode);
       part = new NodePart({templateFactory});
@@ -436,7 +436,7 @@ suite('Parts', () => {
       test(
           'inserts part and sets values between ref node and its next sibling',
           () => {
-            const testEndNode = createMarker();
+            const testEndNode = createMarker('');
             container.appendChild(testEndNode);
             const testPart = new NodePart({templateFactory});
             testPart.insertAfterNode(endNode);

--- a/src/test/lib/template_test.ts
+++ b/src/test/lib/template_test.ts
@@ -28,15 +28,15 @@ suite('Template', () => {
 
     assert.equal(
         countNodes(html`<div>${0}</div>`, (c) => c.childNodes[0].childNodes),
-        2);
-    assert.equal(countNodes(html`${0}`, (c) => c.childNodes), 2);
-    assert.equal(countNodes(html`a${0}`, (c) => c.childNodes), 2);
-    assert.equal(countNodes(html`${0}a`, (c) => c.childNodes), 2);
-    assert.equal(countNodes(html`${0}${0}`, (c) => c.childNodes), 3);
-    assert.equal(countNodes(html`a${0}${0}`, (c) => c.childNodes), 3);
-    assert.equal(countNodes(html`${0}b${0}`, (c) => c.childNodes), 3);
-    assert.equal(countNodes(html`${0}${0}c`, (c) => c.childNodes), 3);
-    assert.equal(countNodes(html`a${0}b${0}c`, (c) => c.childNodes), 3);
+        3);
+    assert.equal(countNodes(html`${0}`, (c) => c.childNodes), 3);
+    assert.equal(countNodes(html`a${0}`, (c) => c.childNodes), 3);
+    assert.equal(countNodes(html`${0}a`, (c) => c.childNodes), 3);
+    assert.equal(countNodes(html`${0}${0}`, (c) => c.childNodes), 5);
+    assert.equal(countNodes(html`a${0}${0}`, (c) => c.childNodes), 5);
+    assert.equal(countNodes(html`${0}b${0}`, (c) => c.childNodes), 5);
+    assert.equal(countNodes(html`${0}${0}c`, (c) => c.childNodes), 5);
+    assert.equal(countNodes(html`a${0}b${0}c`, (c) => c.childNodes), 5);
   });
 
   test('parses parts for multiple expressions', () => {


### PR DESCRIPTION
Instead of traversing over every single `Element`, `Comment`, and `Text` node, this looks only for comment nodes that mark part positions. This likely allows us to skip **tons** of nodes in the walker (I'm assuming comments are the least used nodes in a page).

Additionally, I'm using a comment node to mark the spot after a template element, so that we know to go back and traverse the template.

By paying about 120 bytes, we can anywhere between a 2-10x speedup (for every browser) with this: https://jsbench.github.io/#d26f5d42b64a4c21dda947adcaaa1570

Additionally, this allows me to delete a significant amount of code from the shady-render module. We're no longer tied to walking nodes by `nodeIndex`, so we don't need to update every later part's `index` when we remove a single node, so removal is pretty trivial. We also don't need to pay for an expensive insertion function anymore.