### PR TITLE
Early exit template creation

### DIFF
--- a/src/lib/template-instance.ts
+++ b/src/lib/template-instance.ts
@@ -132,7 +132,7 @@ export class TemplateInstance {
           // We've exhausted the content inside a nested template element.
           // Because we still have parts (the outer for-loop), we know:
           // - There is a template in the stack
-          // - The walker will find a nextNode outside the temlpate
+          // - The walker will find a nextNode outside the template
           walker.currentNode = stack.pop()!;
           node = walker.nextNode();
         }


### PR DESCRIPTION
We know how many parts are in the template by the number of values that the `TemplateResult` is holding. So, when we've found that many parts, we can stop traversing the template tree and go back to rendering that DOM.

This makes the [stack](https://github.com/Polymer/lit-html/pull/828) based traversal even more appealing. 😃