### PR TITLE
Fix tests in Chrome 41

### DIFF
--- a/src/polyfills/template_polyfill.ts
+++ b/src/polyfills/template_polyfill.ts
@@ -43,8 +43,9 @@ export const initTemplatePolyfill = (forced = false) => {
     Object.defineProperties(template, {
       content: {
         ...descriptor,
-        writable: false,
-        value: content,
+        get() {
+          return content;
+        },
       },
       innerHTML: {
         ...descriptor,

--- a/src/test/lib/render_test.ts
+++ b/src/test/lib/render_test.ts
@@ -972,7 +972,7 @@ suite('render()', () => {
     class MutatesInConstructorElement extends HTMLElement {
       constructor() {
         super();
-        this.innerHTML = '<div></div>';
+        this.appendChild(document.createElement('div'));
       }
     }
     customElements.define(
@@ -1053,10 +1053,7 @@ suite('render()', () => {
             <span>${'test'}</span>
       `,
           container);
-      assert.equal(stripExpressionMarkers(container.innerHTML), `
-            <mutates-in-constructor><div></div></mutates-in-constructor>
-            <span>test</span>
-      `);
+      assert.equal(container.querySelector('span')!.textContent, 'test');
     });
   });
 


### PR DESCRIPTION
- Use getter to override `HTMLTemplateElement.content`
  - It doesn't like to override the `content` if it's a data descriptor. A getter works fine, strangely.
- Use appendChild to avoid an infinite loop in ShadyDOM

Fixes #851.