### PR TITLE
Add test for rendering attribute-like parts

### DIFF
--- a/src/test/lib/render_test.ts
+++ b/src/test/lib/render_test.ts
@@ -120,6 +120,13 @@ suite('render()', () => {
           stripExpressionMarkers(container.innerHTML), '<div>foo </div>');
     });
 
+    test('renders parts that look like attributes', () => {
+      render(html`<div>foo bar=${'baz'}</div>`, container);
+      assert.equal(
+          stripExpressionMarkers(container.innerHTML),
+          '<div>foo bar=baz</div>');
+    });
+
     test('renders multiple parts per element, preserving whitespace', () => {
       render(html`<div>${'foo'} ${'bar'}</div>`, container);
       assert.equal(


### PR DESCRIPTION
This is currently broken: 

```js
render(html`<div>foo bar=${ "baz" }</div>`, document.body);

// Produces
 > "foo bar$lit$=baz"
```