### PR TITLE
Add test for comment bindings

### DIFF
--- a/src/test/lib/render_test.ts
+++ b/src/test/lib/render_test.ts
@@ -269,6 +269,12 @@ suite('render()', () => {
       assert.equal(container.querySelector('p')!.textContent, 'baz');
     });
 
+    test('does not inject text from comments with bindings', () => {
+      const t = html`<p>${'foo'}<!-- ${'baz'} -->${'bar'}</p>`;
+      render(t, container);
+      assert.equal(container.querySelector('p')!.textContent, 'foobar');
+    });
+
     test('does not break with an attempted dynamic start tag', () => {
       // this won't work, but we'd like it to not throw an exception or break
       // other bindings


### PR DESCRIPTION
This adds a test that is currently failing due to incorrect processing of bindings in comments:

```
html`<p>${'foo'}<!-- ${'baz'} -->${'bar'}</p>`;

// renders: <p>foo -->bar</p>
```

Reproduction:
https://codepen.io/ruphin/pen/jJVrXd?editors=1010