### PR TITLE
Bump tachometer version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -783,9 +783,9 @@
       "dev": true
     },
     "@types/cookies": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/@types/cookies/-/cookies-0.7.1.tgz",
-      "integrity": "sha512-ku6IvbucEyuC6i4zAVK/KnuzWNXdbFd1HkXlNLg/zhWDGTtQT5VhumiPruB/BHW34PWVFwyfwGftDQHfWNxu3Q==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@types/cookies/-/cookies-0.7.2.tgz",
+      "integrity": "sha512-jnihWgshWystcJKrz8C9hV+Ot9lqOUyAh2RF+o3BEo6K6AS2l4zYCb9GYaBuZ3C6Il59uIGqpE3HvCun4KKeJA==",
       "dev": true,
       "requires": {
         "@types/connect": "*",
@@ -9037,9 +9037,9 @@
       }
     },
     "systeminformation": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-4.1.4.tgz",
-      "integrity": "sha512-kYwSfnSUVjMiw+MHRZkokWx7q8v3ZaanZky40NNxpSfMmAw8kOQbEwmNiAqBa9ynFJX9G+OGWx2wRF72XdWmPQ==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-4.1.6.tgz",
+      "integrity": "sha512-8Q8wPRvnZX0WRxPVVGN6Q/51GeDBhqruNhFzAjoCPaf4/l0hxTLj8XPjeAME8/Y9I5Y4bdA4fx0QjxvuFhlD8A==",
       "dev": true
     },
     "table": {
@@ -9120,9 +9120,9 @@
       }
     },
     "tachometer": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/tachometer/-/tachometer-0.1.0.tgz",
-      "integrity": "sha512-rrogaahy7IRzfwJrAeTLnV/bLBUhdigYwV5dwsaByrMSIMzhKlaPB9BYPNxP4B2fyLQ0sR9Fe6WnqamrJAUcxw==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/tachometer/-/tachometer-0.2.0.tgz",
+      "integrity": "sha512-aQEDERDLZJmpF4Ii6DbykPNPjTgTa88iTx8p7e5v7IwnqLp4g4vHr7vwpKRYe4zT1Mfx8uNq3hNj6Bfgu/KvMw==",
       "dev": true,
       "requires": {
         "@types/ansi-escape-sequences": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "rollup": "^0.64.1",
     "rollup-plugin-filesize": "^4.0.1",
     "rollup-plugin-terser": "^1.0.1",
-    "tachometer": "^0.1.0",
+    "tachometer": "^0.2.0",
     "tslint": "^5.11.0",
     "typescript": "^3.4.1",
     "uglify-es": "^3.3.5",

--- a/travis-bench.sh
+++ b/travis-bench.sh
@@ -55,5 +55,4 @@ npx tach \
   --package-version=lit-html/this=lit-html@github:${THIS} \
   --package-version=lit-html/parent=lit-html@github:${PARENT} \
   --package-version=lit-html/published=lit-html@* \
-  --baseline=version=this \
   --github-check=$GITHUB_CHECK


### PR DESCRIPTION
Results are now more useful, and use markdown:

https://github.com/Polymer/lit-html/runs/111364626

The most interesting thing to look at is the "this" row, which shows that this commit is indistinguishable from master ("parent"), and is a little faster than NPM published. You can also see now see that master is already a little faster than NPM (which is why this commit is too). Could probably still do with some improvements to readability, but at least the useful numbers are now shown if you know where to look.