### PR TITLE
Set NodePart initial value to nothing, only clear if current value is nothing

### DIFF
--- a/src/lib/parts.ts
+++ b/src/lib/parts.ts
@@ -146,8 +146,8 @@ export class NodePart implements Part {
   readonly options: RenderOptions;
   startNode!: Node;
   endNode!: Node;
-  value: unknown = undefined;
-  private __pendingValue: unknown = undefined;
+  value: unknown = nothing;
+  private __pendingValue: unknown = nothing;
 
   constructor(options: RenderOptions) {
     this.options = options;
@@ -183,6 +183,10 @@ export class NodePart implements Part {
   appendIntoPart(part: NodePart) {
     part.__insert(this.startNode = createMarker());
     part.__insert(this.endNode = createMarker());
+    // Make sure the value isn't `nothing`, so it can be cleared later
+    if (part.value === nothing) {
+      part.value = undefined;
+    }
   }
 
   /**
@@ -221,8 +225,8 @@ export class NodePart implements Part {
     } else if (isIterable(value)) {
       this.__commitIterable(value);
     } else if (value === nothing) {
-      this.value = nothing;
       this.clear();
+      this.value = nothing;
     } else {
       // Fallback, will render the string representation
       this.__commitText(value);
@@ -289,8 +293,8 @@ export class NodePart implements Part {
     // render. If _value is not an array, clear this part and make a new
     // array for NodeParts.
     if (!Array.isArray(this.value)) {
-      this.value = [];
       this.clear();
+      this.value = [];
     }
 
     // Lets us keep track of how many items we stamped so we can clear leftover
@@ -326,8 +330,10 @@ export class NodePart implements Part {
   }
 
   clear(startNode: Node = this.startNode) {
-    removeNodes(
-        this.startNode.parentNode!, startNode.nextSibling!, this.endNode);
+    if (this.value !== nothing) {
+      removeNodes(
+          this.startNode.parentNode!, startNode.nextSibling!, this.endNode);
+    }
   }
 }
 

--- a/src/test/lib/parts_test.ts
+++ b/src/test/lib/parts_test.ts
@@ -423,6 +423,7 @@ suite('Parts', () => {
               endNode,
             ]);
 
+            // Test that the parent part can then use another value
             const parentText = document.createTextNode('');
             part.setValue(parentText);
             part.commit();
@@ -464,7 +465,7 @@ suite('Parts', () => {
       });
 
       test('clears a range', () => {
-        container.insertBefore(document.createTextNode('foo'), endNode);
+        part.setValue(document.createTextNode('foo'));
         part.clear();
         assert.deepEqual(
             Array.from(container.childNodes), [startNode, endNode]);


### PR DESCRIPTION
This guards against accessing `Node.parentNode` and `Node.nextSibling` in some very common cases including initial render. The binding cost is high enough that avoiding the accesses should have a noticeable, is small, effect on performance.

This is a subset of #895 which should be a win in all cases, where #895's use of Range isn't fully vetted yet.