### PR TITLE
Allow `render` to accept any type.

### DIFF
--- a/src/lib/parts.ts
+++ b/src/lib/parts.ts
@@ -245,7 +245,8 @@ export class NodePart implements Part {
   private __commitText(value: unknown): void {
     const node = this.startNode.nextSibling!;
     value = value == null ? '' : value;
-    const valueAsString: string = typeof value === 'string' ? value : String(value);
+    const valueAsString: string =
+        typeof value === 'string' ? value : String(value);
     if (node === this.endNode.previousSibling &&
         node.nodeType === 3 /* Node.TEXT_NODE */) {
       // If we only have a single text node between the markers, we can just

--- a/src/lib/parts.ts
+++ b/src/lib/parts.ts
@@ -245,15 +245,15 @@ export class NodePart implements Part {
   private __commitText(value: unknown): void {
     const node = this.startNode.nextSibling!;
     value = value == null ? '' : value;
+    const valueAsString: string = typeof value === 'string' ? value : String(value);
     if (node === this.endNode.previousSibling &&
         node.nodeType === 3 /* Node.TEXT_NODE */) {
       // If we only have a single text node between the markers, we can just
       // set its value, rather than replacing it.
       // TODO(justinfagnani): Can we just check if this.value is primitive?
-      (node as Text).data = value as string;
+      (node as Text).data = valueAsString;
     } else {
-      this.__commitNode(document.createTextNode(
-          typeof value === 'string' ? value : String(value)));
+      this.__commitNode(document.createTextNode(valueAsString));
     }
     this.value = value;
   }

--- a/src/lib/render.ts
+++ b/src/lib/render.ts
@@ -24,13 +24,13 @@ import {templateFactory} from './template-factory.js';
 export const parts = new WeakMap<Node, NodePart>();
 
 /**
- * Renders a template to a container.
+ * Renders a template or value to a container.
  *
  * To update a container with new values, reevaluate the template literal and
  * call `render` with the new result.
  *
- * @param result a TemplateResult created by evaluating a template tag like
- *     `html` or `svg`.
+ * @param result Any value renderable by NodePart - typically a TemplateResult
+ *     created by evaluating a template tag like `html` or `svg`.
  * @param container A DOM parent to render to. The entire contents are either
  *     replaced, or efficiently updated if the same result type was previous
  *     rendered there.

--- a/src/lib/render.ts
+++ b/src/lib/render.ts
@@ -20,7 +20,6 @@ import {removeNodes} from './dom.js';
 import {NodePart} from './parts.js';
 import {RenderOptions} from './render-options.js';
 import {templateFactory} from './template-factory.js';
-import {TemplateResult} from './template-result.js';
 
 export const parts = new WeakMap<Node, NodePart>();
 
@@ -40,7 +39,7 @@ export const parts = new WeakMap<Node, NodePart>();
  *     container, as those changes will not effect previously rendered DOM.
  */
 export const render =
-    (result: TemplateResult,
+    (result: unknown,
      container: Element|DocumentFragment,
      options?: Partial<RenderOptions>) => {
       let part = parts.get(container);

--- a/src/lib/render.ts
+++ b/src/lib/render.ts
@@ -24,7 +24,7 @@ import {templateFactory} from './template-factory.js';
 export const parts = new WeakMap<Node, NodePart>();
 
 /**
- * Renders a template or value to a container.
+ * Renders a template result or other value to a container.
  *
  * To update a container with new values, reevaluate the template literal and
  * call `render` with the new result.

--- a/src/lib/shady-render.ts
+++ b/src/lib/shady-render.ts
@@ -241,7 +241,7 @@ export interface ShadyRenderOptions extends Partial<RenderOptions> {
  * supported.
  */
 export const render =
-    (result: TemplateResult,
+    (result: unknown,
      container: Element|DocumentFragment|ShadowRoot,
      options: ShadyRenderOptions) => {
       const scopeName = options.scopeName;

--- a/src/test/lib/parts_test.ts
+++ b/src/test/lib/parts_test.ts
@@ -135,9 +135,7 @@ suite('Parts', () => {
         const sym = Symbol('description!');
         part.setValue(sym);
         part.commit();
-        assert.equal(
-            stripExpressionMarkers(container.innerHTML),
-            String(sym));
+        assert.equal(stripExpressionMarkers(container.innerHTML), String(sym));
       });
 
       test('accepts a symbol on subsequent renders', () => {
@@ -153,9 +151,7 @@ suite('Parts', () => {
         const sym2 = Symbol('description!');
         part.setValue(sym2);
         part.commit();
-        assert.equal(
-            stripExpressionMarkers(container.innerHTML),
-            String(sym2));
+        assert.equal(stripExpressionMarkers(container.innerHTML), String(sym2));
       });
 
       test('accepts an object', () => {

--- a/src/test/lib/parts_test.ts
+++ b/src/test/lib/parts_test.ts
@@ -124,6 +124,44 @@ suite('Parts', () => {
         assert.equal(stripExpressionMarkers(container.innerHTML), '');
       });
 
+      test('accepts a symbol', () => {
+        part.setValue(Symbol());
+        part.commit();
+        assert.equal(stripExpressionMarkers(container.innerHTML), 'Symbol()');
+      });
+
+      test('accepts a symbol with a description', () => {
+        part.setValue(Symbol('description!'));
+        part.commit();
+        assert.equal(stripExpressionMarkers(container.innerHTML), 'Symbol(description!)');
+      });
+
+      test('accepts a symbol on subsequent renders', () => {
+        part.setValue(Symbol());
+        part.commit();
+        assert.equal(stripExpressionMarkers(container.innerHTML), 'Symbol()');
+
+        // If the previously rendered value caused a single text node to be
+        // created, then subsequent renders will try to update the existing text
+        // node by setting `.data`. If the new value is a symbol and it isn't
+        // explicitly converted with `String`, then this would throw.
+        part.setValue(Symbol('description!'));
+        part.commit();
+        assert.equal(stripExpressionMarkers(container.innerHTML), 'Symbol(description!)');
+      });
+
+      test('accepts an object', () => {
+        part.setValue({});
+        part.commit();
+        assert.equal(stripExpressionMarkers(container.innerHTML), '[object Object]');
+      });
+
+      test('accepts an object with a `toString` method', () => {
+        part.setValue({toString() { return 'toString!'; }});
+        part.commit();
+        assert.equal(stripExpressionMarkers(container.innerHTML), 'toString!');
+      });
+
       test('accepts a function', () => {
         const f = () => {
           throw new Error();

--- a/src/test/lib/parts_test.ts
+++ b/src/test/lib/parts_test.ts
@@ -133,7 +133,9 @@ suite('Parts', () => {
       test('accepts a symbol with a description', () => {
         part.setValue(Symbol('description!'));
         part.commit();
-        assert.equal(stripExpressionMarkers(container.innerHTML), 'Symbol(description!)');
+        assert.equal(
+            stripExpressionMarkers(container.innerHTML),
+            'Symbol(description!)');
       });
 
       test('accepts a symbol on subsequent renders', () => {
@@ -147,17 +149,24 @@ suite('Parts', () => {
         // explicitly converted with `String`, then this would throw.
         part.setValue(Symbol('description!'));
         part.commit();
-        assert.equal(stripExpressionMarkers(container.innerHTML), 'Symbol(description!)');
+        assert.equal(
+            stripExpressionMarkers(container.innerHTML),
+            'Symbol(description!)');
       });
 
       test('accepts an object', () => {
         part.setValue({});
         part.commit();
-        assert.equal(stripExpressionMarkers(container.innerHTML), '[object Object]');
+        assert.equal(
+            stripExpressionMarkers(container.innerHTML), '[object Object]');
       });
 
       test('accepts an object with a `toString` method', () => {
-        part.setValue({toString() { return 'toString!'; }});
+        part.setValue({
+          toString() {
+            return 'toString!';
+          }
+        });
         part.commit();
         assert.equal(stripExpressionMarkers(container.innerHTML), 'toString!');
       });

--- a/src/test/lib/parts_test.ts
+++ b/src/test/lib/parts_test.ts
@@ -125,33 +125,37 @@ suite('Parts', () => {
       });
 
       test('accepts a symbol', () => {
-        part.setValue(Symbol());
+        const sym = Symbol();
+        part.setValue(sym);
         part.commit();
-        assert.equal(stripExpressionMarkers(container.innerHTML), 'Symbol()');
+        assert.equal(stripExpressionMarkers(container.innerHTML), String(sym));
       });
 
       test('accepts a symbol with a description', () => {
-        part.setValue(Symbol('description!'));
+        const sym = Symbol('description!');
+        part.setValue(sym);
         part.commit();
         assert.equal(
             stripExpressionMarkers(container.innerHTML),
-            'Symbol(description!)');
+            String(sym));
       });
 
       test('accepts a symbol on subsequent renders', () => {
-        part.setValue(Symbol());
+        const sym1 = Symbol();
+        part.setValue(sym1);
         part.commit();
-        assert.equal(stripExpressionMarkers(container.innerHTML), 'Symbol()');
+        assert.equal(stripExpressionMarkers(container.innerHTML), String(sym1));
 
         // If the previously rendered value caused a single text node to be
         // created, then subsequent renders will try to update the existing text
         // node by setting `.data`. If the new value is a symbol and it isn't
         // explicitly converted with `String`, then this would throw.
-        part.setValue(Symbol('description!'));
+        const sym2 = Symbol('description!');
+        part.setValue(sym2);
         part.commit();
         assert.equal(
             stripExpressionMarkers(container.innerHTML),
-            'Symbol(description!)');
+            String(sym2));
       });
 
       test('accepts an object', () => {

--- a/src/test/lib/render_test.ts
+++ b/src/test/lib/render_test.ts
@@ -1406,4 +1406,35 @@ suite('render()', () => {
       assert(container.innerHTML, '<div></div>');
     });
   });
+
+  // `render` directly passes the given value to `NodePart#setValue`, so these
+  // tests are really just a sanity check that they are accepted by `render`.
+  // Tests about rendering behavior for specific values should generally be
+  // grouped with those of `NodePart#setValue` and `#commit`.
+  suite('accepts types other than TemplateResult', () => {
+    test('accepts undefined', () => {
+      render(undefined, container);
+      assert.equal(stripExpressionMarkers(container.innerHTML), '');
+    });
+
+    test('accepts a string', () => {
+      render('test', container);
+      assert.equal(stripExpressionMarkers(container.innerHTML), 'test');
+    });
+
+    test('accepts an object', () => {
+      render({}, container);
+      assert.equal(stripExpressionMarkers(container.innerHTML), '[object Object]');
+    });
+
+    test('accepts an object with `toString`', () => {
+      render({toString() { return 'toString!'; }}, container);
+      assert.equal(stripExpressionMarkers(container.innerHTML), 'toString!');
+    });
+
+    test('accepts an symbol', () => {
+      render(Symbol('description!'), container);
+      assert.equal(stripExpressionMarkers(container.innerHTML), 'Symbol(description!)');
+    });
+  });
 });

--- a/src/test/lib/render_test.ts
+++ b/src/test/lib/render_test.ts
@@ -1442,8 +1442,7 @@ suite('render()', () => {
     test('accepts an symbol', () => {
       const sym = Symbol('description!');
       render(sym, container);
-      assert.equal(
-          stripExpressionMarkers(container.innerHTML), String(sym));
+      assert.equal(stripExpressionMarkers(container.innerHTML), String(sym));
     });
   });
 });

--- a/src/test/lib/render_test.ts
+++ b/src/test/lib/render_test.ts
@@ -1424,17 +1424,25 @@ suite('render()', () => {
 
     test('accepts an object', () => {
       render({}, container);
-      assert.equal(stripExpressionMarkers(container.innerHTML), '[object Object]');
+      assert.equal(
+          stripExpressionMarkers(container.innerHTML), '[object Object]');
     });
 
     test('accepts an object with `toString`', () => {
-      render({toString() { return 'toString!'; }}, container);
+      render(
+          {
+            toString() {
+              return 'toString!';
+            }
+          },
+          container);
       assert.equal(stripExpressionMarkers(container.innerHTML), 'toString!');
     });
 
     test('accepts an symbol', () => {
       render(Symbol('description!'), container);
-      assert.equal(stripExpressionMarkers(container.innerHTML), 'Symbol(description!)');
+      assert.equal(
+          stripExpressionMarkers(container.innerHTML), 'Symbol(description!)');
     });
   });
 });

--- a/src/test/lib/render_test.ts
+++ b/src/test/lib/render_test.ts
@@ -1440,9 +1440,10 @@ suite('render()', () => {
     });
 
     test('accepts an symbol', () => {
-      render(Symbol('description!'), container);
+      const sym = Symbol('description!');
+      render(sym, container);
       assert.equal(
-          stripExpressionMarkers(container.innerHTML), 'Symbol(description!)');
+          stripExpressionMarkers(container.innerHTML), String(sym));
     });
   });
 });


### PR DESCRIPTION
`render` uses `NodePart` to render the given value and `NodePart#setValue` accepts `unknown`. This change propagates the `unknown` to `render`, which only accepts `TemplateResult` currently but doesn't make use of the specificity.

This also fixes a bug where a `NodePart` that is currently rendered as a single text node will throw if  asked to render a symbol next.

---
Part of changes for Polymer/lit-element#618.