### PR TITLE
Revert "Allow `render` to accept any type. (#904)"

### DIFF
--- a/src/lib/parts.ts
+++ b/src/lib/parts.ts
@@ -245,16 +245,15 @@ export class NodePart implements Part {
   private __commitText(value: unknown): void {
     const node = this.startNode.nextSibling!;
     value = value == null ? '' : value;
-    const valueAsString: string =
-        typeof value === 'string' ? value : String(value);
     if (node === this.endNode.previousSibling &&
         node.nodeType === 3 /* Node.TEXT_NODE */) {
       // If we only have a single text node between the markers, we can just
       // set its value, rather than replacing it.
       // TODO(justinfagnani): Can we just check if this.value is primitive?
-      (node as Text).data = valueAsString;
+      (node as Text).data = value as string;
     } else {
-      this.__commitNode(document.createTextNode(valueAsString));
+      this.__commitNode(document.createTextNode(
+          typeof value === 'string' ? value : String(value)));
     }
     this.value = value;
   }

--- a/src/lib/render.ts
+++ b/src/lib/render.ts
@@ -20,17 +20,18 @@ import {removeNodes} from './dom.js';
 import {NodePart} from './parts.js';
 import {RenderOptions} from './render-options.js';
 import {templateFactory} from './template-factory.js';
+import {TemplateResult} from './template-result.js';
 
 export const parts = new WeakMap<Node, NodePart>();
 
 /**
- * Renders a template result or other value to a container.
+ * Renders a template to a container.
  *
  * To update a container with new values, reevaluate the template literal and
  * call `render` with the new result.
  *
- * @param result Any value renderable by NodePart - typically a TemplateResult
- *     created by evaluating a template tag like `html` or `svg`.
+ * @param result a TemplateResult created by evaluating a template tag like
+ *     `html` or `svg`.
  * @param container A DOM parent to render to. The entire contents are either
  *     replaced, or efficiently updated if the same result type was previous
  *     rendered there.
@@ -39,7 +40,7 @@ export const parts = new WeakMap<Node, NodePart>();
  *     container, as those changes will not effect previously rendered DOM.
  */
 export const render =
-    (result: unknown,
+    (result: TemplateResult,
      container: Element|DocumentFragment,
      options?: Partial<RenderOptions>) => {
       let part = parts.get(container);

--- a/src/lib/shady-render.ts
+++ b/src/lib/shady-render.ts
@@ -241,7 +241,7 @@ export interface ShadyRenderOptions extends Partial<RenderOptions> {
  * supported.
  */
 export const render =
-    (result: unknown,
+    (result: TemplateResult,
      container: Element|DocumentFragment|ShadowRoot,
      options: ShadyRenderOptions) => {
       const scopeName = options.scopeName;

--- a/src/test/lib/parts_test.ts
+++ b/src/test/lib/parts_test.ts
@@ -124,53 +124,6 @@ suite('Parts', () => {
         assert.equal(stripExpressionMarkers(container.innerHTML), '');
       });
 
-      test('accepts a symbol', () => {
-        const sym = Symbol();
-        part.setValue(sym);
-        part.commit();
-        assert.equal(stripExpressionMarkers(container.innerHTML), String(sym));
-      });
-
-      test('accepts a symbol with a description', () => {
-        const sym = Symbol('description!');
-        part.setValue(sym);
-        part.commit();
-        assert.equal(stripExpressionMarkers(container.innerHTML), String(sym));
-      });
-
-      test('accepts a symbol on subsequent renders', () => {
-        const sym1 = Symbol();
-        part.setValue(sym1);
-        part.commit();
-        assert.equal(stripExpressionMarkers(container.innerHTML), String(sym1));
-
-        // If the previously rendered value caused a single text node to be
-        // created, then subsequent renders will try to update the existing text
-        // node by setting `.data`. If the new value is a symbol and it isn't
-        // explicitly converted with `String`, then this would throw.
-        const sym2 = Symbol('description!');
-        part.setValue(sym2);
-        part.commit();
-        assert.equal(stripExpressionMarkers(container.innerHTML), String(sym2));
-      });
-
-      test('accepts an object', () => {
-        part.setValue({});
-        part.commit();
-        assert.equal(
-            stripExpressionMarkers(container.innerHTML), '[object Object]');
-      });
-
-      test('accepts an object with a `toString` method', () => {
-        part.setValue({
-          toString() {
-            return 'toString!';
-          }
-        });
-        part.commit();
-        assert.equal(stripExpressionMarkers(container.innerHTML), 'toString!');
-      });
-
       test('accepts a function', () => {
         const f = () => {
           throw new Error();

--- a/src/test/lib/render_test.ts
+++ b/src/test/lib/render_test.ts
@@ -1406,43 +1406,4 @@ suite('render()', () => {
       assert(container.innerHTML, '<div></div>');
     });
   });
-
-  // `render` directly passes the given value to `NodePart#setValue`, so these
-  // tests are really just a sanity check that they are accepted by `render`.
-  // Tests about rendering behavior for specific values should generally be
-  // grouped with those of `NodePart#setValue` and `#commit`.
-  suite('accepts types other than TemplateResult', () => {
-    test('accepts undefined', () => {
-      render(undefined, container);
-      assert.equal(stripExpressionMarkers(container.innerHTML), '');
-    });
-
-    test('accepts a string', () => {
-      render('test', container);
-      assert.equal(stripExpressionMarkers(container.innerHTML), 'test');
-    });
-
-    test('accepts an object', () => {
-      render({}, container);
-      assert.equal(
-          stripExpressionMarkers(container.innerHTML), '[object Object]');
-    });
-
-    test('accepts an object with `toString`', () => {
-      render(
-          {
-            toString() {
-              return 'toString!';
-            }
-          },
-          container);
-      assert.equal(stripExpressionMarkers(container.innerHTML), 'toString!');
-    });
-
-    test('accepts an symbol', () => {
-      const sym = Symbol('description!');
-      render(sym, container);
-      assert.equal(stripExpressionMarkers(container.innerHTML), String(sym));
-    });
-  });
 });


### PR DESCRIPTION
https://github.com/Polymer/lit-html/pull/910 doesn't seem like it will be as quick a fix as expected when I started so we should probably roll #904 back in master and group them into #910 instead.

This reverts commit 5a88cc20bd047e4b6b941dfe7a9203debe90c367. 