### PR TITLE
Fix: html tag will now always throw on invalid escape sequences

### DIFF
--- a/src/lib/template-result.ts
+++ b/src/lib/template-result.ts
@@ -52,7 +52,7 @@ export class TemplateResult {
       // For each binding we want to determine the kind of marker to insert
       // into the template source before it's parsed by the browser's HTML
       // parser. The marker type is based on whether the expression is in an
-      // attribute, text, or comment poisition.
+      // attribute, text, or comment position.
       //   * For node-position bindings we insert a comment with the marker
       //     sentinel as its text content, like <!--{{lit-guid}}-->.
       //   * For attribute bindings we insert just the marker sentinel for the
@@ -92,7 +92,7 @@ export class TemplateResult {
             marker;
       }
     }
-    html += this.strings[l];
+    html += this.strings[l].toString();
     return html;
   }
 

--- a/src/lib/template-result.ts
+++ b/src/lib/template-result.ts
@@ -47,52 +47,60 @@ export class TemplateResult {
     let html = '';
     let isCommentBinding = false;
 
-    for (let i = 0; i < l; i++) {
+    for (let i = 0; i <= l; i++) {
       const s = this.strings[i];
-      // For each binding we want to determine the kind of marker to insert
-      // into the template source before it's parsed by the browser's HTML
-      // parser. The marker type is based on whether the expression is in an
-      // attribute, text, or comment position.
-      //   * For node-position bindings we insert a comment with the marker
-      //     sentinel as its text content, like <!--{{lit-guid}}-->.
-      //   * For attribute bindings we insert just the marker sentinel for the
-      //     first binding, so that we support unquoted attribute bindings.
-      //     Subsequent bindings can use a comment marker because multi-binding
-      //     attributes must be quoted.
-      //   * For comment bindings we insert just the marker sentinel so we don't
-      //     close the comment.
-      //
-      // The following code scans the template source, but is *not* an HTML
-      // parser. We don't need to track the tree structure of the HTML, only
-      // whether a binding is inside a comment, and if not, if it appears to be
-      // the first binding in an attribute.
-      const commentOpen = s.lastIndexOf('<!--');
-      // We're in comment position if we have a comment open with no following
-      // comment close. Because <-- can appear in an attribute value there can
-      // be false positives.
-      isCommentBinding = (commentOpen > -1 || isCommentBinding) &&
-          s.indexOf('-->', commentOpen + 1) === -1;
-      // Check to see if we have an attribute-like sequence preceeding the
-      // expression. This can match "name=value" like structures in text,
-      // comments, and attribute values, so there can be false-positives.
-      const attributeMatch = lastAttributeNameRegex.exec(s);
-      if (attributeMatch === null) {
-        // We're only in this branch if we don't have a attribute-like
-        // preceeding sequence. For comments, this guards against unusual
-        // attribute values like <div foo="<!--${'bar'}">. Cases like
-        // <!-- foo=${'bar'}--> are handled correctly in the attribute branch
-        // below.
-        html += s + (isCommentBinding ? marker : nodeMarker);
+
+      if (s === undefined) {
+        throw new Error(`Invalid escape sequence in ${this.strings.raw[i]}`);
+      }
+
+      if (i === l) {
+        html += s;
       } else {
-        // For attributes we use just a marker sentinel, and also append a
-        // $lit$ suffix to the name to opt-out of attribute-specific parsing
-        // that IE and Edge do for style and certain SVG attributes.
-        html += s.substr(0, attributeMatch.index) + attributeMatch[1] +
-            attributeMatch[2] + boundAttributeSuffix + attributeMatch[3] +
-            marker;
+        // For each binding we want to determine the kind of marker to insert
+        // into the template source before it's parsed by the browser's HTML
+        // parser. The marker type is based on whether the expression is in an
+        // attribute, text, or comment position.
+        //   * For node-position bindings we insert a comment with the marker
+        //     sentinel as its text content, like <!--{{lit-guid}}-->.
+        //   * For attribute bindings we insert just the marker sentinel for the
+        //     first binding, so that we support unquoted attribute bindings.
+        //     Subsequent bindings can use a comment marker because
+        //     multi-binding attributes must be quoted.
+        //   * For comment bindings we insert just the marker sentinel so we
+        //     don't close the comment.
+        //
+        // The following code scans the template source, but is *not* an HTML
+        // parser. We don't need to track the tree structure of the HTML, only
+        // whether a binding is inside a comment, and if not, if it appears to
+        // be the first binding in an attribute.
+        const commentOpen = s.lastIndexOf('<!--');
+        // We're in comment position if we have a comment open with no following
+        // comment close. Because <-- can appear in an attribute value there can
+        // be false positives.
+        isCommentBinding = (commentOpen > -1 || isCommentBinding) &&
+            s.indexOf('-->', commentOpen + 1) === -1;
+        // Check to see if we have an attribute-like sequence preceeding the
+        // expression. This can match "name=value" like structures in text,
+        // comments, and attribute values, so there can be false-positives.
+        const attributeMatch = lastAttributeNameRegex.exec(s);
+        if (attributeMatch === null) {
+          // We're only in this branch if we don't have a attribute-like
+          // preceeding sequence. For comments, this guards against unusual
+          // attribute values like <div foo="<!--${'bar'}">. Cases like
+          // <!-- foo=${'bar'}--> are handled correctly in the attribute branch
+          // below.
+          html += s + (isCommentBinding ? marker : nodeMarker);
+        } else {
+          // For attributes we use just a marker sentinel, and also append a
+          // $lit$ suffix to the name to opt-out of attribute-specific parsing
+          // that IE and Edge do for style and certain SVG attributes.
+          html += s.substr(0, attributeMatch.index) + attributeMatch[1] +
+              attributeMatch[2] + boundAttributeSuffix + attributeMatch[3] +
+              marker;
+        }
       }
     }
-    html += this.strings[l].toString();
     return html;
   }
 

--- a/src/test/lib/template-result_test.ts
+++ b/src/test/lib/template-result_test.ts
@@ -32,4 +32,11 @@ suite('TemplateResult', () => {
     const templateHTML = html`<div style="color: ${'red'}"></div>`.getHTML();
     assert.equal(templateHTML, `<div style$lit$="color: ${marker}"></div>`);
   });
+
+  test('invalid escape sequences always throw an error', () => {
+    assert.throw(() => html`<style> .foo:before { content: "\0025a0"; } </style>`.getHTML());
+    assert.throw(() => html`\0025a0${'bar'}\0025a0`.getHTML());
+    assert.throw(() => html`\0025a0${'bar'}foo`.getHTML());
+    assert.throw(() => html`foo${'foo'}\0025a0`.getHTML());
+  });
 });

--- a/src/test/lib/template-result_test.ts
+++ b/src/test/lib/template-result_test.ts
@@ -12,6 +12,7 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
+import {TemplateResult} from '../../lib/shady-render.js';
 import {marker} from '../../lib/template.js';
 import {html} from '../../lit-html.js';
 
@@ -34,9 +35,13 @@ suite('TemplateResult', () => {
   });
 
   test('invalid escape sequences always throw an error', () => {
-    assert.throw(() => html`<style> .foo:before { content: "\0025a0"; } </style>`.getHTML());
-    assert.throw(() => html`\0025a0${'bar'}\0025a0`.getHTML());
-    assert.throw(() => html`\0025a0${'bar'}foo`.getHTML());
-    assert.throw(() => html`foo${'foo'}\0025a0`.getHTML());
+    function throws(template: TemplateResult) {
+      assert.throw(() => template.getHTML());
+    }
+
+    throws(html`<style> .foo:before { content: "\0025a0"; } </style>`);
+    throws(html`\0025a0${'bar'}\0025a0`);
+    throws(html`\0025a0${'bar'}foo`);
+    throws(html`foo${'foo'}\0025a0`);
   });
 });


### PR DESCRIPTION
This fixes that TemplateResult's `getHTML` returned `undefined` if the template strings array contains `undefined`. The new behavior is that `getHTML` always throw a reference error in that case.

`undefined` in the template strings array usually happens if the template literal contains invalid escape sequences. This doesn't affect raw strings but `html` doesn't use these and changing this would be a breaking change.

I intentionally choose to make the error a standard reference error. A more detailed error message will help developers find the cause (it's not obvious that (and which) escape sequences are at fault) but this will be at the cost of file size.
I will be happy to add a better error message if the maintainers of lit-html think it's worth it.

---

This fixes #348.