### PR TITLE
Run tachometer as separate Travis job, and temporarily pin to Firefox 66

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,16 +8,26 @@ addons:
 cache:
   directories:
   - node_modules
-before_script:
-- >-
-  npm run format && git diff --exit-code || (echo -e '\n\033[31mERROR:\033[0m
-  Project is not formatted. Please run "npm run format".' && false)
-- npm run build
-script:
-- xvfb-run wct --npm
-- if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then wct -s 'windows 10/microsoftedge@17' -s 'windows 10/microsoftedge@15' -s 'macos 10.13/safari@11' -s 'macos 10.12/safari@10' -s 'windows 8.1/internet explorer@11' -s 'Linux/chrome@41' --npm; fi
-- ./travis-bench.sh
 env:
   global:
   - secure: mNT4DpaOzcY+Z8JmXhVdbYBRt1gJG7kVMfe0Kd3HSRwQwAltW1JWhnRWQgW526xi/EFuYkIy1Ec4Hhc0pZ+t+ngXrHgtVPV6te7nQzBhBUNFZv72nDagk8YxQBTcSHMEVRa7c4NXlCW66hM0WWDVy7PACs7NuGj25qegFUulbjNEmYfwF8VMsfyB8/X6NJff8ZQTWEACwODJIBY2l0ogxI2jbUjTnrVNvtjd4IV1gnmi2AvY0RwRs/grigP4oMPcD/5tleUBjlojqq3U/DjMCoaoCge7fPnRZ2O1GHVHPOlAlFWa6DGvsXBiPNqlzchAQtkCKCnNJ1xM8UNlR0EYQCWBSsXO+wmAFoB1UexumHObsaCzLTL2yYXByCzKVNlGkCMppZUp+b+T3Vu039TEF1dCXf4XpQOouNb9pdlR0tkWUOF08hENzeAkHBFO1nw3kt+smm/b/6QXHe0H+X2GN3uKRX/TMYYgR3cckD4cQ9DeaXlJ/6tJtoVkOyNLL1LOHVtS7MTL2oUBJnj29cjOaUoCg/aVEt+g7brysj8Eb7itZctc/GwL/cWqIIKCuUUAuRJYgrBx3AQH9GjMtNAsrMtoVEmcOIK1lBLLmeduZXDogTevTMbGtyToATAQbLX/a2TxUBM5AZLE/dMiUnmZMVEMZ4anp2VhrmzflrbRcBI=
   - secure: UMzIg/aYKoDeMQqDyXcxpX0a1gWwmtCo+tx1zF0xhyoEPz3DNNV7axdqnqhiU9jPf7T5mGK4WWNDYWeFKMooD9J2rCgSxOPZHNDpcwQlC7KNHMKHXlMPLDzh1XborrSABowwj+Osq2Nmy7u1+aRtJDpcZ/PrYpsdHOx1wp+8aeO7ho8IFtgtDbdoQ7NUHXA4JtmORq4DH5MFyetrU70JSjwziL1T7H3kHkstjptMx4b5VszepcwFqsYXX+l0LxD1xYPcSc0QanwThYJLJb1JQSkqaDVphrMo+p7XdDVva9ExXvWfMOwJDRBvYP24sqBcYHei78irCzMKnRrcENgSK7G185p+9v5eO7DPROw5jjBB+uxXO/B5C1j1D5I1I1AMeccZ8kaBlqJgxhtTha9fJkwiRzYBrgmSS6eTORWMClAY84RlOtB2pL6wkx+/3ffXqbfbSP/mstAF1VkGwfav/XaWp2kxI4prEJi45PR4+wigugLQB/pLvMdItfGxAJLs+npv+w5nM7I2hJVfwvbuPVtAlz9pcn70kHcMvQbXsmdUzV6Se467HuwtruVQEhE6X01AW35VHLQi1GBMG/0xird+6WFi26/zj08nZaetW6BKqodHVYmzrSs5L2OcelJmAOOY2JQwQO/7RJ6zzwWu5hNdAo8STDgyYRhbYFlTRjs=
+matrix:
+  include:
+    -
+      env:
+        JOB: test
+      before_script:
+        - >-
+          npm run format && git diff --exit-code || (echo -e '\n\033[31mERROR:\033[0m
+          Project is not formatted. Please run "npm run format".' && false)
+        - npm run build
+      script:
+        - xvfb-run wct --npm
+        - if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then wct -s 'windows 10/microsoftedge@17' -s 'windows 10/microsoftedge@15' -s 'macos 10.13/safari@11' -s 'macos 10.12/safari@10' -s 'windows 8.1/internet explorer@11' -s 'Linux/chrome@41' --npm; fi
+
+    -
+      env:
+        JOB: benchmark
+      script:
+        - ./travis-bench.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: required
 dist: trusty
 node_js: '10'
 addons:
-  firefox: latest
+  firefox: "66.0"
   chrome: stable
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,12 @@ env:
   - secure: mNT4DpaOzcY+Z8JmXhVdbYBRt1gJG7kVMfe0Kd3HSRwQwAltW1JWhnRWQgW526xi/EFuYkIy1Ec4Hhc0pZ+t+ngXrHgtVPV6te7nQzBhBUNFZv72nDagk8YxQBTcSHMEVRa7c4NXlCW66hM0WWDVy7PACs7NuGj25qegFUulbjNEmYfwF8VMsfyB8/X6NJff8ZQTWEACwODJIBY2l0ogxI2jbUjTnrVNvtjd4IV1gnmi2AvY0RwRs/grigP4oMPcD/5tleUBjlojqq3U/DjMCoaoCge7fPnRZ2O1GHVHPOlAlFWa6DGvsXBiPNqlzchAQtkCKCnNJ1xM8UNlR0EYQCWBSsXO+wmAFoB1UexumHObsaCzLTL2yYXByCzKVNlGkCMppZUp+b+T3Vu039TEF1dCXf4XpQOouNb9pdlR0tkWUOF08hENzeAkHBFO1nw3kt+smm/b/6QXHe0H+X2GN3uKRX/TMYYgR3cckD4cQ9DeaXlJ/6tJtoVkOyNLL1LOHVtS7MTL2oUBJnj29cjOaUoCg/aVEt+g7brysj8Eb7itZctc/GwL/cWqIIKCuUUAuRJYgrBx3AQH9GjMtNAsrMtoVEmcOIK1lBLLmeduZXDogTevTMbGtyToATAQbLX/a2TxUBM5AZLE/dMiUnmZMVEMZ4anp2VhrmzflrbRcBI=
   - secure: UMzIg/aYKoDeMQqDyXcxpX0a1gWwmtCo+tx1zF0xhyoEPz3DNNV7axdqnqhiU9jPf7T5mGK4WWNDYWeFKMooD9J2rCgSxOPZHNDpcwQlC7KNHMKHXlMPLDzh1XborrSABowwj+Osq2Nmy7u1+aRtJDpcZ/PrYpsdHOx1wp+8aeO7ho8IFtgtDbdoQ7NUHXA4JtmORq4DH5MFyetrU70JSjwziL1T7H3kHkstjptMx4b5VszepcwFqsYXX+l0LxD1xYPcSc0QanwThYJLJb1JQSkqaDVphrMo+p7XdDVva9ExXvWfMOwJDRBvYP24sqBcYHei78irCzMKnRrcENgSK7G185p+9v5eO7DPROw5jjBB+uxXO/B5C1j1D5I1I1AMeccZ8kaBlqJgxhtTha9fJkwiRzYBrgmSS6eTORWMClAY84RlOtB2pL6wkx+/3ffXqbfbSP/mstAF1VkGwfav/XaWp2kxI4prEJi45PR4+wigugLQB/pLvMdItfGxAJLs+npv+w5nM7I2hJVfwvbuPVtAlz9pcn70kHcMvQbXsmdUzV6Se467HuwtruVQEhE6X01AW35VHLQi1GBMG/0xird+6WFi26/zj08nZaetW6BKqodHVYmzrSs5L2OcelJmAOOY2JQwQO/7RJ6zzwWu5hNdAo8STDgyYRhbYFlTRjs=
 matrix:
+  fast_finish: true
+  allow_failures:
+    - env: JOB=benchmark
+
   include:
-    -
-      env:
-        JOB: test
+    - env: JOB=test
       before_script:
         - >-
           npm run format && git diff --exit-code || (echo -e '\n\033[31mERROR:\033[0m
@@ -26,8 +28,6 @@ matrix:
         - xvfb-run wct --npm
         - if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then wct -s 'windows 10/microsoftedge@17' -s 'windows 10/microsoftedge@15' -s 'macos 10.13/safari@11' -s 'macos 10.12/safari@10' -s 'windows 8.1/internet explorer@11' -s 'Linux/chrome@41' --npm; fi
 
-    -
-      env:
-        JOB: benchmark
+    - env: JOB=benchmark
       script:
         - ./travis-bench.sh


### PR DESCRIPTION
Fixes https://github.com/Polymer/lit-html/issues/908

The benchmark job is marked under `allow_failures`, and that combined with `fast_finish: true` means that we'll get a green Travis badge as soon as the test job is done, while the benchmark job will continue to run. We can do that since tachometer integrates as a GitHub check directly.

GitHub UI:

![Screen Shot 2019-05-21 at 11 40 50 AM](https://user-images.githubusercontent.com/48894/58121912-5238cb80-7bbd-11e9-9142-325222fbdcca.png)

Travis UI:
![Screen Shot 2019-05-21 at 11 40 02 AM](https://user-images.githubusercontent.com/48894/58121864-359c9380-7bbd-11e9-9ec3-cbdc19e653d2.png)

This PR also pins to Travis Firefox 66 temporarily, because Firefox 67 came out today and is failing to launch with WCT, and will need to be investigated:

```
Test run ended in failure: Error: [get("http://localhost:8081/components/lit-html/generated-index.html?cli_browser_id=1")] Error response status: 13, UnknownError - An unknown server-side error occurred while processing the command. Selenium error: Failed to decode response from marionette
```