### PR TITLE
Fix version number in CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 <!-- ### Removed -->
 <!-- ### Fixed -->
 
-## [1.0.1] - 2019-05-20
+## [1.1.0] - 2019-05-20
 
 ### Changed
 * Many small performance enhancements.


### PR DESCRIPTION
We meant to release 1.0.1, but actually released 1.1.0. Rewriting history to reflect reality.