### PR TITLE
Test that shady-render works without shadow DOM or custom elements.

### DIFF
--- a/src/lib/shady-render.ts
+++ b/src/lib/shady-render.ts
@@ -244,6 +244,9 @@ export const render =
     (result: TemplateResult,
      container: Element|DocumentFragment|ShadowRoot,
      options: ShadyRenderOptions) => {
+      if (!options || !options.scopeName) {
+        throw new Error('The `scopeName` option is required.');
+      }
       const scopeName = options.scopeName;
       const hasRendered = parts.has(container);
       const needsScoping = compatibleShadyCSSVersion &&

--- a/src/lib/shady-render.ts
+++ b/src/lib/shady-render.ts
@@ -244,7 +244,7 @@ export const render =
     (result: TemplateResult,
      container: Element|DocumentFragment|ShadowRoot,
      options: ShadyRenderOptions) => {
-      if (!options || !options.scopeName) {
+      if (!options || typeof options !== 'object' || !options.scopeName) {
         throw new Error('The `scopeName` option is required.');
       }
       const scopeName = options.scopeName;

--- a/src/test/lib/shady-render_no-wc_test.ts
+++ b/src/test/lib/shady-render_no-wc_test.ts
@@ -1,0 +1,32 @@
+/**
+ * @license
+ * Copyright (c) 2019 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+import {render} from '../../lib/shady-render.js';
+import {html} from '../../lit-html.js';
+
+const assert = chai.assert;
+
+suite('shady-render without Shadow DOM or Custom Elements', () => {
+  test('shady-render renders content', () => {
+    const container = document.createElement('scope-1');
+    document.body.appendChild(container);
+    const result = html`
+      <div>Rendered content.</div>
+    `;
+    render(result, container, {scopeName: 'scope-1'});
+    const div = container.querySelector('div');
+    assert.equal(div!.textContent, 'Rendered content.');
+    document.body.removeChild(container);
+  });
+});

--- a/src/test/lib/shady-render_test.ts
+++ b/src/test/lib/shady-render_test.ts
@@ -12,6 +12,7 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
+import {render as shadyRender} from '../../lib/shady-render.js';
 import {html} from '../../lit-html.js';
 import {renderShadowRoot} from '../test-utils/shadow-root.js';
 
@@ -339,4 +340,39 @@ suite('shady-render', () => {
         '1px');
     document.body.removeChild(container);
   });
+
+  test(
+      'throws an error if the options argument is not an object with a `scopeName` property',
+      () => {
+        const container = document.createElement('some-element');
+        document.body.appendChild(container);
+        const shadowRoot = container.attachShadow({mode: 'open'});
+        let error1 = undefined;
+        try {
+          (shadyRender as any)(
+              html`some content`, shadowRoot /*, not provided */);
+        } catch (e) {
+          error1 = e;
+        }
+        assert.notEqual(error1, undefined);
+        assert.equal(error1.message, 'The `scopeName` option is required.');
+        let error2 = undefined;
+        try {
+          (shadyRender as any)(html`some content`, shadowRoot, 'not an object');
+        } catch (e) {
+          error2 = e;
+        }
+        assert.notEqual(error2, undefined);
+        assert.equal(error2.message, 'The `scopeName` option is required.');
+        let error3 = undefined;
+        try {
+          (shadyRender as any)(
+              html`some content`, shadowRoot, {'missing scopeName': true});
+        } catch (e) {
+          error3 = e;
+        }
+        assert.notEqual(error3, undefined);
+        assert.equal(error3.message, 'The `scopeName` option is required.');
+        document.body.removeChild(container);
+      });
 });

--- a/test/index.html
+++ b/test/index.html
@@ -33,6 +33,7 @@
         'shady-apply.html?shadydom=true',
         'shady-apply.html?shadydom=true&shimcssproperties=true',
         'no-template.html',
+        'shady_no-wc.html',
       ]);
     </script>
   </body>

--- a/test/shady_no-wc.html
+++ b/test/shady_no-wc.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html>
+  <head>
+    <script src="../node_modules/mocha/mocha.js"></script>
+    <script src="../node_modules/chai/chai.js"></script>
+    <script src="../node_modules/wct-mocha/wct-mocha.js"></script>
+    <script src="../node_modules/@webcomponents/webcomponentsjs/webcomponents-bundle.js"></script>
+    <script>
+      // Remove Shadow DOM
+      delete window.Element.prototype.assignedSlot;
+      delete window.Element.prototype.attachShadow;
+      delete window.Element.prototype.shadowRoot;
+      delete window.HTMLSlotElement;
+      delete window.ShadowRoot;
+      delete window.Text.prototype.assignedSlot;
+
+      // Remove Custom Elements
+      delete window.CustomElementRegistry;
+      delete window.customElements;
+    </script>
+  </head>
+  <body>
+    <script type="module" src="./lib/shady-render_no-wc_test.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
This PR also adds an explicitly thrown error in shady-render if `options` with a `scopeName` property is not provided. Before, it would throw when reading `options.scopeName` if `options` wasn't provided, which appears broken even though the option is required.

Fixes #742.