### PR TITLE
Check for window existence before accessing it

### DIFF
--- a/src/lib/dom.ts
+++ b/src/lib/dom.ts
@@ -21,11 +21,10 @@ interface MaybePolyfilledCe extends CustomElementRegistry {
 }
 
 /**
- * True if the custom elements polyfill is in use.
+ * True if window exists and the custom elements polyfill is in use.
  */
-export const isCEPolyfill = window.customElements !== undefined &&
-    (window.customElements as MaybePolyfilledCe).polyfillWrapFlushCallback !==
-        undefined;
+export const isCEPolyfill = typeof window !== undefined && window.customElements !== undefined &&
+    (window.customElements as MaybePolyfilledCe).polyfillWrapFlushCallback !== undefined;
 
 /**
  * Reparents nodes, starting from `start` (inclusive) to `end` (exclusive),

--- a/src/lib/dom.ts
+++ b/src/lib/dom.ts
@@ -23,8 +23,10 @@ interface MaybePolyfilledCe extends CustomElementRegistry {
 /**
  * True if window exists and the custom elements polyfill is in use.
  */
-export const isCEPolyfill = typeof window !== undefined && window.customElements !== undefined &&
-    (window.customElements as MaybePolyfilledCe).polyfillWrapFlushCallback !== undefined;
+export const isCEPolyfill = typeof window !== undefined &&
+    window.customElements !== undefined &&
+    (window.customElements as MaybePolyfilledCe).polyfillWrapFlushCallback !==
+        undefined;
 
 /**
  * Reparents nodes, starting from `start` (inclusive) to `end` (exclusive),


### PR DESCRIPTION
Fixes issue I'm experience in a Gatsby build where `window` does not exist.

```
www: a precaution, we're deleting your site's cache to ensure there's not any stale
error Building static HTML failed

www:   15 |  * True if the custom elements polyfill is in use.
www:   16 |  */
www: > 17 | export const isCEPolyfill = window.customElements !== undefined &&
www:      |        ^
www:   18 |     window.customElements.polyfillWrapFlushCallback !==
www:   19 |         undefined;
www:   20 | /**
www: 
www:   WebpackError: ReferenceError: window is not defined
www:   
www:   - dom.js:17 Module.../node_modules/lit-html/lib/dom.js
www:     [lib]/[lit-html]/lib/dom.js:17:8
www:   
www:   - bootstrap:19 __webpack_require__
www:     lib/webpack/bootstrap:19:1
www:   
www:   - parts.js:1 Module.../node_modules/lit-html/lib/parts.js
www:     [lib]/[lit-html]/lib/parts.js:1:1
www:   
www:   - bootstrap:19 __webpack_require__
www:     lib/webpack/bootstrap:19:1
www:   
www:   - default-template-processor.js:1 Module.../node_modules/lit-html/lib/default-  
www: template-processor.js
www:     [lib]/[lit-html]/lib/default-template-processor.js:1:1
www:   
www:   - bootstrap:19 __webpack_require__
www:     lib/webpack/bootstrap:19:1
www:   
www:   - lit-html.js:1 Module.../node_modules/lit-html/lit-html.js
www:     [lib]/[lit-html]/lit-html.js:1:1
www:   
www:   - bootstrap:19 __webpack_require__
www:     lib/webpack/bootstrap:19:1
www:   
www:   - lit-element.js:1 Module.../node_modules/lit-element/lit-element.js
www:     [lib]/[lit-element]/lit-element.js:1:1
www:   
www:   - bootstrap:19 __webpack_require__
www:     lib/webpack/bootstrap:19:1
www:   
www:   
www:   - bootstrap:19 __webpack_require__
www:     lib/webpack/bootstrap:19:1
www:   
www:   - index.ts:1 Module.../components/MyLitComponent/lib/index.js
www:     lib/src/index.ts:1:1
```