### PR TITLE
Distinguish PR from branch builds in Tachometer checks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -662,7 +662,7 @@
     },
     "@polymer/test-fixture": {
       "version": "0.0.3",
-      "resolved": "http://registry.npmjs.org/@polymer/test-fixture/-/test-fixture-0.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/@polymer/test-fixture/-/test-fixture-0.0.3.tgz",
       "integrity": "sha1-REN1JpfU2Sk7vEEuoLXk00HxSdk=",
       "dev": true
     },
@@ -999,18 +999,18 @@
       }
     },
     "@types/koa-bodyparser": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@types/koa-bodyparser/-/koa-bodyparser-4.2.2.tgz",
-      "integrity": "sha512-liOoUnpv7V+NX46kAqYDh503t0PI0NFjALn+L8IAlS/mdwOAg9jJoso88mN22MaWt7hLdQ+Z/MMwb9RglhEAcQ==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@types/koa-bodyparser/-/koa-bodyparser-4.3.0.tgz",
+      "integrity": "sha512-aB/vwwq4G9FAtKzqZ2p8UHTscXxZvICFKVjuckqxCtkX1Ro7F5KHkTCUqTRZFBgDoEkmeca+bFLI1bIsdPPZTA==",
       "dev": true,
       "requires": {
         "@types/koa": "*"
       }
     },
     "@types/koa-compose": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/@types/koa-compose/-/koa-compose-3.2.3.tgz",
-      "integrity": "sha512-kXvR0DPyZ3gaFxZs4WycA8lpzlPGtFmwdbgce+NWd+TG3PycPO3o5FkePH60HoBPd8BBaSiw3vhtgM42O2kQcg==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@types/koa-compose/-/koa-compose-3.2.4.tgz",
+      "integrity": "sha512-ioou0rxkuWL+yBQYsHUQAzRTfVxAg8Y2VfMftU+Y3RA03/MzuFL0x/M2sXXj3PkfnENbHsjeHR1aMdezLYpTeA==",
       "dev": true,
       "requires": {
         "@types/koa": "*"
@@ -1622,7 +1622,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
@@ -2326,7 +2326,7 @@
         },
         "readable-stream": {
           "version": "1.1.14",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "dev": true,
           "requires": {
@@ -3260,7 +3260,7 @@
         },
         "readable-stream": {
           "version": "1.1.14",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "dev": true,
           "requires": {
@@ -3394,7 +3394,7 @@
     },
     "enabled": {
       "version": "1.0.2",
-      "resolved": "http://registry.npmjs.org/enabled/-/enabled-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/enabled/-/enabled-1.0.2.tgz",
       "integrity": "sha1-ll9lE9LC0cX0ZStkouM5ZGf8L5M=",
       "dev": true,
       "requires": {
@@ -3957,7 +3957,7 @@
     },
     "fecha": {
       "version": "2.3.3",
-      "resolved": "http://registry.npmjs.org/fecha/-/fecha-2.3.3.tgz",
+      "resolved": "https://registry.npmjs.org/fecha/-/fecha-2.3.3.tgz",
       "integrity": "sha512-lUGBnIamTAwk4znq5BcqsDaxSmZ9nDVJaij6NvRt/Tg4R69gERA+otPKbS86ROw9nxVMw2/mp1fnaiWqbs6Sdg==",
       "dev": true
     },
@@ -4201,9 +4201,9 @@
       }
     },
     "fs-minipass": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
-      "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.6.tgz",
+      "integrity": "sha512-crhvyXcMejjv3Z5d2Fa9sf5xLYVCF5O1c71QxbVnbLsmYMBEvDAftewesN/HhY03YRoA7zOMxjNGrF5svGaaeQ==",
       "dev": true,
       "requires": {
         "minipass": "^2.2.1"
@@ -4259,7 +4259,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
@@ -5650,9 +5650,9 @@
       },
       "dependencies": {
         "ms": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
         }
       }
@@ -5670,9 +5670,9 @@
       }
     },
     "jstat": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/jstat/-/jstat-1.7.1.tgz",
-      "integrity": "sha512-lcWi9NKovcx8jdCvgsIzua3KB5rs+TK9cyH1NWyctj+e09jKZTk70vv/EdYSG5mp8MiID2TdepavXn4LUr8rZQ==",
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/jstat/-/jstat-1.8.3.tgz",
+      "integrity": "sha512-Jc30D82nwDCNumpnzSz/mJz6G5/heKEChvNjvwSjOmDHFi2REQbVQd1LH8+SMeiUYQ4LBdYT1yIZcHgOQjds9Q==",
       "dev": true
     },
     "jszip": {
@@ -5824,9 +5824,9 @@
           }
         },
         "ms": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
         }
       }
@@ -7686,7 +7686,7 @@
     },
     "readable-stream": {
       "version": "2.3.6",
-      "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "dev": true,
       "requires": {
@@ -8905,7 +8905,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
@@ -9071,15 +9071,15 @@
       }
     },
     "systeminformation": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-4.3.0.tgz",
-      "integrity": "sha512-Qnu5KFsjMMUatUgfLpBreai+Tk+HPCq6uUzHFzUB5TYtonNAGnZjDc/svWNQbB8/rGK9W5iU7/n7RjdRHpvB8w==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-4.9.0.tgz",
+      "integrity": "sha512-u8GLZloVStTvxec6N0M64AJDd6IGGm2h6pZzEHUKBz2WKL2emsoN/6CChPc25LTXXldvVX8U/9lYJrOYGkAiyw==",
       "dev": true
     },
     "table": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/table/-/table-5.3.0.tgz",
-      "integrity": "sha512-6V2qlZHIbbZQGzoP3Ghcj/IQDPhBvQYjZE4W4JEyFMkbzHziIzG6jxmAD87BZ1ZXgwPwgu3MzvCUGMOFRN7wlw==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/table/-/table-5.4.0.tgz",
+      "integrity": "sha512-nHFDrxmbrkU7JAFKqKbDJXfzrX2UBsWmrieXFTGxiI5e4ncg3VqsZeI4EzNmX0ncp4XNGVeoxIWJXfCIXwrsvw==",
       "dev": true,
       "requires": {
         "ajv": "^6.9.1",
@@ -9147,9 +9147,9 @@
       }
     },
     "tachometer": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/tachometer/-/tachometer-0.4.0.tgz",
-      "integrity": "sha512-L9HruOBqAfWXXRpt5jALaJ1zyZP33qBTH6UTVkOw1G1+Gmer6N2B8c1BxO3JicZMdtgF1JyTwtV4blGegMdeCA==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/tachometer/-/tachometer-0.4.1.tgz",
+      "integrity": "sha512-MyVLpBeFhgflidW9jDQyl/MSW3vfcxqn7xRYOX+DDXZu0te3CNonJVA72l6hSBs6UQmQQQPoBNBdw88J6Tonnw==",
       "dev": true,
       "requires": {
         "@types/ansi-escape-sequences": "^4.0.0",
@@ -9293,9 +9293,9 @@
           }
         },
         "ms": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "rollup": "^0.64.1",
     "rollup-plugin-filesize": "^4.0.1",
     "rollup-plugin-terser": "^1.0.1",
-    "tachometer": "^0.4.0",
+    "tachometer": "^0.4.1",
     "tslint": "^5.11.0",
     "typescript": "^3.4.1",
     "uglify-es": "^3.3.5",

--- a/travis-bench.sh
+++ b/travis-bench.sh
@@ -38,7 +38,20 @@ if [[ "${TRAVIS_SECURE_ENV_VARS}" == "true" ]]; then
   # https://github.com/organizations/Polymer/settings/installations
   # by clicking "Configure" and looking at the URL.
   INSTALLATION_ID=851456
-  GITHUB_CHECK="{\"appId\":${APP_ID},\"installationId\":${INSTALLATION_ID},\"repo\":\"${TRAVIS_REPO_SLUG}\",\"commit\":\"${TRAVIS_COMMIT}\"}"
+
+  if [[ "${TRAVIS_PULL_REQUEST}" == "false" ]]; then
+    CHECK_LABEL="Tachometer - Branch"
+    CHECK_COMMIT="${TRAVIS_COMMIT}"
+  else
+    CHECK_LABEL="Tachometer - Pull Request"
+    # Note that for a PR, $TRAVIS_COMMIT will be the SHA of the generated merge
+    # commit, but in order to show up in the GitHub UI we need to instead attach
+    # the check to the feature branch SHA.
+    CHECK_COMMIT="${TRAVIS_PULL_REQUEST_SHA}"
+  fi
+
+  GITHUB_CHECK="{\"label\":\"${CHECK_LABEL}\",\"appId\":${APP_ID},\"installationId\":${INSTALLATION_ID},\"repo\":\"${TRAVIS_REPO_SLUG}\",\"commit\":\"${CHECK_COMMIT}\"}"
+
 else
   # We can't report a GitHub Check unless this is a trusted build with access to
   # our GitHub App's private key. Note that benchmark results can still be seen
@@ -54,4 +67,4 @@ npx tach $BENCHMARK \
   --package-version=this=lit-html@github:${THIS} \
   --package-version=parent=lit-html@github:${PARENT} \
   --package-version=published=lit-html@* \
-  --github-check=$GITHUB_CHECK
+  --github-check="${GITHUB_CHECK}"


### PR DESCRIPTION
Fixes https://github.com/Polymer/lit-html/issues/920

Previously, only the branch build was correctly appearing as a GitHub check, and the PR build was lost. That's because GitHub expects you to attach your checks to the same feature branch commit, not the automatically-generated merge commit, for both the branch and PR builds. We distinguish them by using a different title for the check.

Note in the screenshot below (or in the checks tab on this PR) that there are now two entries under Tachometer, one for the branch, one for the PR.

![screen](https://user-images.githubusercontent.com/48894/59070173-99d27f00-886e-11e9-82e7-29189998c9ef.png)
