### PR TITLE
Revert "Change classMap to set classes correctly for SVGs (#932)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 * Adopt and upgrade template fragments after processing for parts ([#831](https://github.com/Polymer/lit-html/issues/831)).
 * Fixed bindings with attribute-like expressions preceeding them ([#855](https://github.com/Polymer/lit-html/issues/855)).
 * Fixed errors with bindings in HTML comments ([#882](https://github.com/Polymer/lit-html/issues/882)).
-* Change `classMap` directive to set classes correctly on SVGs ([#930](https://github.com/Polymer/lit-html/issues/930)).
 
 ## [1.0.0] - 2019-02-05
 ### Changed

--- a/src/directives/class-map.ts
+++ b/src/directives/class-map.ts
@@ -48,7 +48,7 @@ export const classMap = directive((classInfo: ClassInfo) => (part: Part) => {
 
   // handle static classes
   if (!classMapCache.has(part)) {
-    element.setAttribute('class', committer.strings.join(' '));
+    element.className = committer.strings.join(' ');
   }
 
   const {classList} = element;

--- a/src/test/directives/class-map_test.ts
+++ b/src/test/directives/class-map_test.ts
@@ -17,7 +17,7 @@
 
 import {ClassInfo, classMap} from '../../directives/class-map.js';
 import {render} from '../../lib/render.js';
-import {html, svg} from '../../lit-html.js';
+import {html} from '../../lit-html.js';
 
 const assert = chai.assert;
 
@@ -79,15 +79,6 @@ suite('classMap', () => {
     assert.isTrue(el.classList.contains('aa'));
     assert.isTrue(el.classList.contains('bb'));
     assert.isFalse(el.classList.contains('foo'));
-  });
-
-  test('adds classes on SVG elements', () => {
-    const cssInfo = {foo: 0, bar: true, zonk: true};
-    render(svg`<circle class="${classMap(cssInfo)}"></circle>`, container);
-    const el = container.firstElementChild!;
-    assert.isFalse(el.classList.contains('foo'));
-    assert.isTrue(el.classList.contains('bar'));
-    assert.isTrue(el.classList.contains('zonk'));
   });
 
   test('throws when used on non-class attribute', () => {


### PR DESCRIPTION
This reverts commit dbb33127a1d500686ab8766599606ef27db18ce7.

The test added in #932 fails in IE11.

cc @AdamVig 