### PR TITLE
fix(NodePart): factory method created to help us when creating NodePart introduced due to scope hoisting problem with ParcelJS

### DIFF
--- a/src/lib/parts.ts
+++ b/src/lib/parts.ts
@@ -135,6 +135,15 @@ export class AttributePart implements Part {
 }
 
 /**
+ * Creates a new NodePart instance
+ * Introduced because of scope hoisting problem with parcel js
+ * https://github.com/parcel-bundler/parcel/issues/3172
+ */
+function nodePartFactory(options: RenderOptions) {
+  return new NodePart(options);
+}
+
+/**
  * A Part that controls a location within a Node tree. Like a Range, NodePart
  * has start and end locations and can set and update the Nodes between those
  * locations.
@@ -308,7 +317,7 @@ export class NodePart implements Part {
 
       // If no existing part, create a new one
       if (itemPart === undefined) {
-        itemPart = new NodePart(this.options);
+        itemPart = nodePartFactory(this.options);
         itemParts.push(itemPart);
         if (partIndex === 0) {
           itemPart.appendIntoPart(this);


### PR DESCRIPTION


## [Original Issue ParcelJS](https://github.com/parcel-bundler/parcel/issues/3172)

# Description

The problem here is that when compiled this part of code remains the same without `export` referencing him to the `module` `scope`

Typescript
```typescript
itemPart = new NodePart(this.options);
```

Javascript
```typescript
itemPart = new NodePart(this.options);
```

Instead it should be 

```typescript
itemPart = new exports.NodePart(this.options);
```

The case here is that i am getting the following error

```typescript
Uncaught ReferenceError: NodePart is not defined
```

## Type of change

- [x] Bug fix
- [x] Not introducing any existing change with existing API

# Checklist:

- [x] Implement factory method creating new NodeParts


Example repository of the problem:

https://github.com/Stradivario/parcel-scope-hoisting


Regards! :) 