### PR TITLE
Reparent nodes into detached DocumentFragment when clearing NodePart

### DIFF
--- a/src/lib/parts.ts
+++ b/src/lib/parts.ts
@@ -17,7 +17,7 @@
  */
 
 import {isDirective} from './directive.js';
-import {removeNodes} from './dom.js';
+import {reparentNodes} from './dom.js';
 import {noChange, nothing, Part} from './part.js';
 import {RenderOptions} from './render-options.js';
 import {TemplateInstance} from './template-instance.js';
@@ -329,8 +329,9 @@ export class NodePart implements Part {
   }
 
   clear(startNode: Node = this.startNode) {
-    removeNodes(
-        this.startNode.parentNode!, startNode.nextSibling!, this.endNode);
+    // Ensure that any nested NodeParts are not detached without a parentNode.
+    const frag = document.createDocumentFragment();
+    reparentNodes(frag, startNode.nextSibling!, this.endNode);
   }
 }
 

--- a/src/test/lib/parts_test.ts
+++ b/src/test/lib/parts_test.ts
@@ -12,7 +12,7 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {AttributeCommitter, AttributePart, createMarker, DefaultTemplateProcessor, EventPart, html, NodePart, render, templateFactory, TemplateResult, directive, Part} from '../../lit-html.js';
+import {AttributeCommitter, AttributePart, createMarker, DefaultTemplateProcessor, directive, EventPart, html, NodePart, Part, render, templateFactory, TemplateResult} from '../../lit-html.js';
 import {stripExpressionMarkers} from '../test-utils/strip-markers.js';
 
 const assert = chai.assert;
@@ -533,15 +533,13 @@ suite('Parts', () => {
           part = p;
         });
 
-        const t = (bool: boolean) => html`<div>${
-          bool
-          ? html`${fooDirective()}`
-          : 'detached'
-        }</div>`;
+        const t = (bool: boolean) =>
+            html`<div>${bool ? html`${fooDirective()}` : 'detached'}</div>`;
 
         // First render with unresolved Promise
         render(t(true), container);
-        assert.equal(stripExpressionMarkers(container.innerHTML), '<div></div>');
+        assert.equal(
+            stripExpressionMarkers(container.innerHTML), '<div></div>');
 
         // Simulate an async part settting.
         part!.setValue('foo');
@@ -549,12 +547,14 @@ suite('Parts', () => {
 
         // Now detach the part's wrapping TemplateResult
         render(t(false), container);
-        assert.equal(stripExpressionMarkers(container.innerHTML), '<div>detached</div>');
+        assert.equal(
+            stripExpressionMarkers(container.innerHTML), '<div>detached</div>');
 
         // Simulate an async part settting.
         part!.setValue('bar');
         part!.commit();
-        assert.equal(stripExpressionMarkers(container.innerHTML), '<div>detached</div>');
+        assert.equal(
+            stripExpressionMarkers(container.innerHTML), '<div>detached</div>');
       });
     });
   });


### PR DESCRIPTION
Imagine this template structure:

```js
render(html`${
  // Outer NodePart
  ${
    html`${
      // Nested NodePart here
      directive()
    }`
  }
}`, container)
```

When the `NodePart` renders a `TemplateResult`, we get a structure somewhat like:

```html
<!--NodePart's Start-->
<!--    nested NodePart's Start-->
<!--    nested NodePart's End-->
<!--NodePart's End-->
```

This is because we take the `TemplateResult`'s template fragment (which has the nested `NodePart`'s start/end nodes as direct children), and inject it directly between the outer `NodePart`'s start/end nodes.

When we change the value that's rendered into that part, we would clear out everything between the `NodePart`'s. That leaves the `TemplateResult`'s nested `NodePart`'s start/end nodes completely detached (no `parentNode`). When the nested `NodePart` tries to update (via an async directive), we would try to mutate the nested `nodePart.startNode.parentNode` (which is `null`)!

This fixes it in a hacky way be reparenting those cleared nodes into a `DocumentFragment`. The nested `NodePart` will have now be attached to the `DocumentFragment`, meaning it can update without issue.

Fixes #293