### PR TITLE
Check Node Tree Before Committing

### DIFF
--- a/src/lib/parts.ts
+++ b/src/lib/parts.ts
@@ -319,6 +319,9 @@ export class NodePart implements Part {
   }
 
   commit() {
+    if (this.startNode.parentNode === null) {
+      return;
+    }
     while (isDirective(this.__pendingValue)) {
       const directive = this.__pendingValue;
       this.__pendingValue = noChange;


### PR DESCRIPTION
Imagine this template structure:

```js
render(html`${
  // Outer NodePart
  ${
    html`${
      // Nested NodePart here
      directive()
    }`
  }
}`, container)
```

When the `NodePart` renders a `TemplateResult`, we get a structure somewhat like:

```html
<!--NodePart's Start-->
<!--    nested NodePart's Start-->
<!--    nested NodePart's End-->
<!--NodePart's End-->
```

This is because we take the `TemplateResult`'s template fragment (which has the nested `NodePart`'s start/end nodes as direct children), and inject it directly between the outer `NodePart`'s start/end nodes.

When we change the value that's rendered into that part, we would clear out everything between the `NodePart`'s. That leaves the `TemplateResult`'s nested `NodePart`'s start/end nodes completely detached (no `parentNode`). When the nested `NodePart` tries to update (via an async directive), we would try to mutate the nested `nodePart.startNode.parentNode` (which is `null`)!

This fixes the issue by doing nothing if we do not have a valid node tree (by checking `parentNode`).

Fixes #293