### PR TITLE
Fix repeat object with classmap and stylemap

### DIFF
--- a/src/directives/class-map.ts
+++ b/src/directives/class-map.ts
@@ -71,5 +71,6 @@ export const classMap = directive((classInfo: ClassInfo) => (part: Part) => {
       classList[method](name);
     }
   }
-  classMapCache.set(part, classInfo);
+  // Clone the info before storing so we can see updates to the same object
+  classMapCache.set(part, {...classInfo});
 });

--- a/src/directives/style-map.ts
+++ b/src/directives/style-map.ts
@@ -79,5 +79,6 @@ export const styleMap = directive((styleInfo: StyleInfo) => (part: Part) => {
       style.setProperty(name, styleInfo[name]);
     }
   }
-  styleMapCache.set(part, styleInfo);
+  // Clone the info before storing so we can see updates to the same object
+  styleMapCache.set(part, {...styleInfo});
 });

--- a/src/test/directives/class-map_test.ts
+++ b/src/test/directives/class-map_test.ts
@@ -81,6 +81,20 @@ suite('classMap', () => {
     assert.isFalse(el.classList.contains('foo'));
   });
 
+  test('changes classes when used with the same object', () => {
+    const classInfo = {foo: true};
+    renderClassMapStatic(classInfo);
+    const el = container.firstElementChild!;
+    assert.isTrue(el.classList.contains('aa'));
+    assert.isTrue(el.classList.contains('bb'));
+    assert.isTrue(el.classList.contains('foo'));
+    classInfo.foo = false;
+    renderClassMapStatic(classInfo);
+    assert.isTrue(el.classList.contains('aa'));
+    assert.isTrue(el.classList.contains('bb'));
+    assert.isFalse(el.classList.contains('foo'));
+  });
+
   test('throws when used on non-class attribute', () => {
     assert.throws(() => {
       render(html`<div id="${classMap({})}"></div>`, container);

--- a/src/test/directives/style-map_test.ts
+++ b/src/test/directives/style-map_test.ts
@@ -89,6 +89,19 @@ suite('styleMap', () => {
     assert.equal(el.style.getPropertyValue('--size'), '');
   });
 
+  test('works when used with the same object', () => {
+    const styleInfo = {marginTop: '2px', 'padding-bottom': '4px'};
+    renderStyleMap(styleInfo);
+    const el = container.firstElementChild as HTMLElement;
+    assert.equal(el.style.marginTop, '2px');
+    assert.equal(el.style.paddingBottom, '4px');
+    styleInfo.marginTop = '6px';
+    styleInfo['padding-bottom'] = '8px';
+    renderStyleMap(styleInfo);
+    assert.equal(el.style.marginTop, '6px');
+    assert.equal(el.style.paddingBottom, '8px');
+  });
+
   test('throws when used on non-style attribute', () => {
     assert.throws(() => {
       render(html`<div id="${styleMap({})}"></div>`, container);


### PR DESCRIPTION
Clone the info objects before storing them in the cache, so we can detect changes.

Fixes #972