### PR TITLE
Avoid closures when using directive

### DIFF
--- a/src/directives/async-append.ts
+++ b/src/directives/async-append.ts
@@ -31,71 +31,75 @@ import {createMarker, directive, NodePart, Part} from '../lit-html.js';
  * @param mapper An optional function that maps from (value, index) to another
  *     value. Useful for generating templates for each item in the iterable.
  */
-export const asyncAppend = directive(
+export const asyncAppend =
+    directive(
+        <T>(value: AsyncIterable<T>,
+            mapper?: (v: T, index?: number) => unknown) => ({value, mapper}),
+        async (part: Part, {value, mapper}) => {
+          if (!(part instanceof NodePart)) {
+            throw new Error('asyncAppend can only be used in text bindings');
+          }
+          // If we've already set up this particular iterable, we don't need
+          // to do anything.
+          if (value === part.value) {
+            return;
+          }
+          part.value = value;
+
+          // We keep track of item Parts across iterations, so that we can
+          // share marker nodes between consecutive Parts.
+          let itemPart;
+          let i = 0;
+
+          for await (let v of value) {
+            // Check to make sure that value is the still the current value of
+            // the part, and if not bail because a new value owns this part
+            if (part.value !== value) {
+              break;
+            }
+
+            // When we get the first value, clear the part. This lets the
+            // previous value display until we can replace it.
+            if (i === 0) {
+              part.clear();
+            }
+
+            // As a convenience, because functional-programming-style
+            // transforms of iterables and async iterables requires a library,
+            // we accept a mapper function. This is especially convenient for
+            // rendering a template for each item.
+            if (mapper !== undefined) {
+              // This is safe because T must otherwise be treated as unknown by
+              // the rest of the system.
+              v = mapper(v, i);
+            }
+
+            // Like with sync iterables, each item induces a Part, so we need
+            // to keep track of start and end nodes for the Part.
+            // Note: Because these Parts are not updatable like with a sync
+            // iterable (if we render a new value, we always clear), it may
+            // be possible to optimize away the Parts and just re-use the
+            // Part.setValue() logic.
+
+            let itemStartNode = part.startNode;
+
+            // Check to see if we have a previous item and Part
+            if (itemPart !== undefined) {
+              // Create a new node to separate the previous and next Parts
+              itemStartNode = createMarker();
+              // itemPart is currently the Part for the previous item. Set
+              // it's endNode to the node we'll use for the next Part's
+              // startNode.
+              itemPart.endNode = itemStartNode;
+              part.endNode.parentNode!.insertBefore(
+                  itemStartNode, part.endNode);
+            }
+            itemPart = new NodePart(part.options);
+            itemPart.insertAfterNode(itemStartNode);
+            itemPart.setValue(v);
+            itemPart.commit();
+            i++;
+          }
+        }) as
     <T>(value: AsyncIterable<T>, mapper?: (v: T, index?: number) => unknown) =>
-        ({value, mapper}),
-    async (part: Part, {value, mapper}) => {
-      if (!(part instanceof NodePart)) {
-        throw new Error('asyncAppend can only be used in text bindings');
-      }
-      // If we've already set up this particular iterable, we don't need
-      // to do anything.
-      if (value === part.value) {
-        return;
-      }
-      part.value = value;
-
-      // We keep track of item Parts across iterations, so that we can
-      // share marker nodes between consecutive Parts.
-      let itemPart;
-      let i = 0;
-
-      for await (let v of value) {
-        // Check to make sure that value is the still the current value of
-        // the part, and if not bail because a new value owns this part
-        if (part.value !== value) {
-          break;
-        }
-
-        // When we get the first value, clear the part. This lets the
-        // previous value display until we can replace it.
-        if (i === 0) {
-          part.clear();
-        }
-
-        // As a convenience, because functional-programming-style
-        // transforms of iterables and async iterables requires a library,
-        // we accept a mapper function. This is especially convenient for
-        // rendering a template for each item.
-        if (mapper !== undefined) {
-          // This is safe because T must otherwise be treated as unknown by
-          // the rest of the system.
-          v = mapper(v, i);
-        }
-
-        // Like with sync iterables, each item induces a Part, so we need
-        // to keep track of start and end nodes for the Part.
-        // Note: Because these Parts are not updatable like with a sync
-        // iterable (if we render a new value, we always clear), it may
-        // be possible to optimize away the Parts and just re-use the
-        // Part.setValue() logic.
-
-        let itemStartNode = part.startNode;
-
-        // Check to see if we have a previous item and Part
-        if (itemPart !== undefined) {
-          // Create a new node to separate the previous and next Parts
-          itemStartNode = createMarker();
-          // itemPart is currently the Part for the previous item. Set
-          // it's endNode to the node we'll use for the next Part's
-          // startNode.
-          itemPart.endNode = itemStartNode;
-          part.endNode.parentNode!.insertBefore(itemStartNode, part.endNode);
-        }
-        itemPart = new NodePart(part.options);
-        itemPart.insertAfterNode(itemStartNode);
-        itemPart.setValue(v);
-        itemPart.commit();
-        i++;
-      }
-    });
+        unknown;

--- a/src/directives/async-append.ts
+++ b/src/directives/async-append.ts
@@ -32,8 +32,9 @@ import {createMarker, directive, NodePart, Part} from '../lit-html.js';
  *     value. Useful for generating templates for each item in the iterable.
  */
 export const asyncAppend = directive(
-    <T>(value: AsyncIterable<T>,
-        mapper?: (v: T, index?: number) => unknown) => async (part: Part) => {
+    <T>(value: AsyncIterable<T>, mapper?: (v: T, index?: number) => unknown) =>
+        ({value, mapper}),
+    async (part: Part, {value, mapper}) => {
       if (!(part instanceof NodePart)) {
         throw new Error('asyncAppend can only be used in text bindings');
       }
@@ -69,7 +70,7 @@ export const asyncAppend = directive(
         if (mapper !== undefined) {
           // This is safe because T must otherwise be treated as unknown by
           // the rest of the system.
-          v = mapper(v, i) as T;
+          v = mapper(v, i);
         }
 
         // Like with sync iterables, each item induces a Part, so we need

--- a/src/directives/async-replace.ts
+++ b/src/directives/async-replace.ts
@@ -34,49 +34,50 @@ import {directive, NodePart, Part} from '../lit-html.js';
  */
 export const asyncReplace = directive(
     <T>(value: AsyncIterable<T>, mapper?: (v: T, index?: number) => unknown) =>
-        async (part: Part) => {
-          if (!(part instanceof NodePart)) {
-            throw new Error('asyncReplace can only be used in text bindings');
-          }
-          // If we've already set up this particular iterable, we don't need
-          // to do anything.
-          if (value === part.value) {
-            return;
-          }
+        ({value, mapper}),
+    async (part: Part, {value, mapper}) => {
+      if (!(part instanceof NodePart)) {
+        throw new Error('asyncReplace can only be used in text bindings');
+      }
+      // If we've already set up this particular iterable, we don't need
+      // to do anything.
+      if (value === part.value) {
+        return;
+      }
 
-          // We nest a new part to keep track of previous item values separately
-          // of the iterable as a value itself.
-          const itemPart = new NodePart(part.options);
-          part.value = value;
+      // We nest a new part to keep track of previous item values separately
+      // of the iterable as a value itself.
+      const itemPart = new NodePart(part.options);
+      part.value = value;
 
-          let i = 0;
+      let i = 0;
 
-          for await (let v of value) {
-            // Check to make sure that value is the still the current value of
-            // the part, and if not bail because a new value owns this part
-            if (part.value !== value) {
-              break;
-            }
+      for await (let v of value) {
+        // Check to make sure that value is the still the current value of
+        // the part, and if not bail because a new value owns this part
+        if (part.value !== value) {
+          break;
+        }
 
-            // When we get the first value, clear the part. This let's the
-            // previous value display until we can replace it.
-            if (i === 0) {
-              part.clear();
-              itemPart.appendIntoPart(part);
-            }
+        // When we get the first value, clear the part. This let's the
+        // previous value display until we can replace it.
+        if (i === 0) {
+          part.clear();
+          itemPart.appendIntoPart(part);
+        }
 
-            // As a convenience, because functional-programming-style
-            // transforms of iterables and async iterables requires a library,
-            // we accept a mapper function. This is especially convenient for
-            // rendering a template for each item.
-            if (mapper !== undefined) {
-              // This is safe because T must otherwise be treated as unknown by
-              // the rest of the system.
-              v = mapper(v, i) as T;
-            }
+        // As a convenience, because functional-programming-style
+        // transforms of iterables and async iterables requires a library,
+        // we accept a mapper function. This is especially convenient for
+        // rendering a template for each item.
+        if (mapper !== undefined) {
+          // This is safe because T must otherwise be treated as unknown by
+          // the rest of the system.
+          v = mapper(v, i);
+        }
 
-            itemPart.setValue(v);
-            itemPart.commit();
-            i++;
-          }
-        });
+        itemPart.setValue(v);
+        itemPart.commit();
+        i++;
+      }
+    });

--- a/src/directives/cache.ts
+++ b/src/directives/cache.ts
@@ -37,54 +37,55 @@ const templateCaches =
  * `
  * ```
  */
-export const cache = directive((value: unknown) => (part: Part) => {
-  if (!(part instanceof NodePart)) {
-    throw new Error('cache can only be used in text bindings');
-  }
-
-  let templateCache = templateCaches.get(part);
-
-  if (templateCache === undefined) {
-    templateCache = new WeakMap();
-    templateCaches.set(part, templateCache);
-  }
-
-  const previousValue = part.value;
-
-  // First, can we update the current TemplateInstance, or do we need to move
-  // the current nodes into the cache?
-  if (previousValue instanceof TemplateInstance) {
-    if (value instanceof TemplateResult &&
-        previousValue.template === part.options.templateFactory(value)) {
-      // Same Template, just trigger an update of the TemplateInstance
-      part.setValue(value);
-      return;
-    } else {
-      // Not the same Template, move the nodes from the DOM into the cache.
-      let cachedTemplate = templateCache.get(previousValue.template);
-      if (cachedTemplate === undefined) {
-        cachedTemplate = {
-          instance: previousValue,
-          nodes: document.createDocumentFragment(),
-        };
-        templateCache.set(previousValue.template, cachedTemplate);
+export const cache =
+    directive((value: unknown) => value, (part: Part, value: unknown) => {
+      if (!(part instanceof NodePart)) {
+        throw new Error('cache can only be used in text bindings');
       }
-      reparentNodes(
-          cachedTemplate.nodes, part.startNode.nextSibling, part.endNode);
-    }
-  }
 
-  // Next, can we reuse nodes from the cache?
-  if (value instanceof TemplateResult) {
-    const template = part.options.templateFactory(value);
-    const cachedTemplate = templateCache.get(template);
-    if (cachedTemplate !== undefined) {
-      // Move nodes out of cache
-      part.setValue(cachedTemplate.nodes);
-      part.commit();
-      // Set the Part value to the TemplateInstance so it'll update it.
-      part.value = cachedTemplate.instance;
-    }
-  }
-  part.setValue(value);
-});
+      let templateCache = templateCaches.get(part);
+
+      if (templateCache === undefined) {
+        templateCache = new WeakMap();
+        templateCaches.set(part, templateCache);
+      }
+
+      const previousValue = part.value;
+
+      // First, can we update the current TemplateInstance, or do we need to
+      // move the current nodes into the cache?
+      if (previousValue instanceof TemplateInstance) {
+        if (value instanceof TemplateResult &&
+            previousValue.template === part.options.templateFactory(value)) {
+          // Same Template, just trigger an update of the TemplateInstance
+          part.setValue(value);
+          return;
+        } else {
+          // Not the same Template, move the nodes from the DOM into the cache.
+          let cachedTemplate = templateCache.get(previousValue.template);
+          if (cachedTemplate === undefined) {
+            cachedTemplate = {
+              instance: previousValue,
+              nodes: document.createDocumentFragment(),
+            };
+            templateCache.set(previousValue.template, cachedTemplate);
+          }
+          reparentNodes(
+              cachedTemplate.nodes, part.startNode.nextSibling, part.endNode);
+        }
+      }
+
+      // Next, can we reuse nodes from the cache?
+      if (value instanceof TemplateResult) {
+        const template = part.options.templateFactory(value);
+        const cachedTemplate = templateCache.get(template);
+        if (cachedTemplate !== undefined) {
+          // Move nodes out of cache
+          part.setValue(cachedTemplate.nodes);
+          part.commit();
+          // Set the Part value to the TemplateInstance so it'll update it.
+          part.value = cachedTemplate.instance;
+        }
+      }
+      part.setValue(value);
+    });

--- a/src/directives/class-map.ts
+++ b/src/directives/class-map.ts
@@ -35,50 +35,51 @@ const previousClassesCache = new WeakMap<Part, Set<string>>();
  * `{foo: bar}` applies the class `foo` if the value of `bar` is truthy.
  * @param classInfo {ClassInfo}
  */
-export const classMap = directive((classInfo: ClassInfo) => (part: Part) => {
-  if (!(part instanceof AttributePart) || (part instanceof PropertyPart) ||
-      part.committer.name !== 'class' || part.committer.parts.length > 1) {
-    throw new Error(
-        'The `classMap` directive must be used in the `class` attribute ' +
-        'and must be the only part in the attribute.');
-  }
-
-  const {committer} = part;
-  const {element} = committer;
-
-  let previousClasses = previousClassesCache.get(part);
-  if (previousClasses === undefined) {
-    // Write static classes once
-    element.className = committer.strings.join(' ');
-    previousClassesCache.set(part, previousClasses = new Set());
-  }
-
-  const {classList} = element;
-
-  // Remove old classes that no longer apply
-  // We use forEach() instead of for-of so that re don't require down-level
-  // iteration.
-  previousClasses.forEach((name) => {
-    if (!(name in classInfo)) {
-      classList.remove(name);
-      previousClasses!.delete(name);
-    }
-  });
-
-  // Add or remove classes based on their classMap value
-  for (const name in classInfo) {
-    const value = classInfo[name];
-    // We explicitly want a loose truthy check of `value` because it seems more
-    // convenient that '' and 0 are skipped.
-    // tslint:disable-next-line: triple-equals
-    if (value != previousClasses.has(name)) {
-      if (value) {
-        classList.add(name);
-        previousClasses.add(name);
-      } else {
-        classList.remove(name);
-        previousClasses.delete(name);
+export const classMap = directive(
+    (classInfo: ClassInfo) => classInfo, (part: Part, classInfo: ClassInfo) => {
+      if (!(part instanceof AttributePart) || (part instanceof PropertyPart) ||
+          part.committer.name !== 'class' || part.committer.parts.length > 1) {
+        throw new Error(
+            'The `classMap` directive must be used in the `class` attribute ' +
+            'and must be the only part in the attribute.');
       }
-    }
-  }
-});
+
+      const {committer} = part;
+      const {element} = committer;
+
+      let previousClasses = previousClassesCache.get(part);
+      if (previousClasses === undefined) {
+        // Write static classes once
+        element.className = committer.strings.join(' ');
+        previousClassesCache.set(part, previousClasses = new Set());
+      }
+
+      const {classList} = element;
+
+      // Remove old classes that no longer apply
+      // We use forEach() instead of for-of so that re don't require down-level
+      // iteration.
+      previousClasses.forEach((name) => {
+        if (!(name in classInfo)) {
+          classList.remove(name);
+          previousClasses!.delete(name);
+        }
+      });
+
+      // Add or remove classes based on their classMap value
+      for (const name in classInfo) {
+        const value = classInfo[name];
+        // We explicitly want a loose truthy check of `value` because it seems
+        // more convenient that '' and 0 are skipped. tslint:disable-next-line:
+        // triple-equals
+        if (value != previousClasses.has(name)) {
+          if (value) {
+            classList.add(name);
+            previousClasses.add(name);
+          } else {
+            classList.remove(name);
+            previousClasses.delete(name);
+          }
+        }
+      }
+    });

--- a/src/directives/guard.ts
+++ b/src/directives/guard.ts
@@ -49,8 +49,9 @@ const previousValues = new WeakMap<Part, unknown>();
  * @param value the value to check before re-rendering
  * @param f the template function
  */
-export const guard =
-    directive((value: unknown, f: () => unknown) => (part: Part): void => {
+export const guard = directive(
+    (value: unknown, f: () => unknown) => ({value, f}),
+    (part: Part, {value, f}: {value: unknown, f: () => unknown}) => {
       const previousValue = previousValues.get(part);
       if (Array.isArray(value)) {
         // Dirty-check arrays by item

--- a/src/directives/if-defined.ts
+++ b/src/directives/if-defined.ts
@@ -20,13 +20,14 @@ import {AttributePart, directive, Part} from '../lit-html.js';
  *
  * For other part types, this directive is a no-op.
  */
-export const ifDefined = directive((value: unknown) => (part: Part) => {
-  if (value === undefined && part instanceof AttributePart) {
-    if (value !== part.value) {
-      const name = part.committer.name;
-      part.committer.element.removeAttribute(name);
-    }
-  } else {
-    part.setValue(value);
-  }
-});
+export const ifDefined =
+    directive((value: unknown) => value, (part: Part, value: unknown) => {
+      if (value === undefined && part instanceof AttributePart) {
+        if (value !== part.value) {
+          const name = part.committer.name;
+          part.committer.element.removeAttribute(name);
+        }
+      } else {
+        part.setValue(value);
+      }
+    });

--- a/src/directives/repeat.ts
+++ b/src/directives/repeat.ts
@@ -106,334 +106,341 @@ function normalizer<T, R>(
  * items to values, and DOM will be reused against potentially different items.
  */
 export const repeat =
-    directive(normalizer, (containerPart: Part, {items, keyFn, templateFn}) => {
-      if (!(containerPart instanceof NodePart)) {
-        throw new Error('repeat can only be used in text bindings');
-      }
-      // Old part & key lists are retrieved from the last update
-      // (associated with the part for this instance of the directive)
-      const oldParts = partListCache.get(containerPart) || [];
-      const oldKeys = keyListCache.get(containerPart) || [];
-
-      // New part list will be built up as we go (either reused from
-      // old parts or created for new keys in this update). This is
-      // saved in the above cache at the end of the update.
-      const newParts: NodePart[] = [];
-
-      // New value list is eagerly generated from items along with a
-      // parallel array indicating its key.
-      const newValues: unknown[] = [];
-      const newKeys: unknown[] = [];
-      let index = 0;
-      for (const item of items) {
-        newKeys[index] = keyFn ? keyFn(item, index) : index;
-        newValues[index] = templateFn(item, index);
-        index++;
-      }
-
-      // Maps from key to index for current and previous update; these
-      // are generated lazily only when needed as a performance
-      // optimization, since they are only required for multiple
-      // non-contiguous changes in the list, which are less common.
-      let newKeyToIndexMap!: Map<unknown, number>;
-      let oldKeyToIndexMap!: Map<unknown, number>;
-
-      // Head and tail pointers to old parts and new values
-      let oldHead = 0;
-      let oldTail = oldParts.length - 1;
-      let newHead = 0;
-      let newTail = newValues.length - 1;
-
-      // Overview of O(n) reconciliation algorithm (general approach
-      // based on ideas found in ivi, vue, snabbdom, etc.):
-      //
-      // * We start with the list of old parts and new values (and
-      //   arrays of their respective keys), head/tail pointers into
-      //   each, and we build up the new list of parts by updating
-      //   (and when needed, moving) old parts or creating new ones.
-      //   The initial scenario might look like this (for brevity of
-      //   the diagrams, the numbers in the array reflect keys
-      //   associated with the old parts or new values, although keys
-      //   and parts/values are actually stored in parallel arrays
-      //   indexed using the same head/tail pointers):
-      //
-      //      oldHead v                 v oldTail
-      //   oldKeys:  [0, 1, 2, 3, 4, 5, 6]
-      //   newParts: [ ,  ,  ,  ,  ,  ,  ]
-      //   newKeys:  [0, 2, 1, 4, 3, 7, 6] <- reflects the user's new
-      //                                      item order
-      //      newHead ^                 ^ newTail
-      //
-      // * Iterate old & new lists from both sides, updating,
-      //   swapping, or removing parts at the head/tail locations
-      //   until neither head nor tail can move.
-      //
-      // * Example below: keys at head pointers match, so update old
-      //   part 0 in-place (no need to move it) and record part 0 in
-      //   the `newParts` list. The last thing we do is advance the
-      //   `oldHead` and `newHead` pointers (will be reflected in the
-      //   next diagram).
-      //
-      //      oldHead v                 v oldTail
-      //   oldKeys:  [0, 1, 2, 3, 4, 5, 6]
-      //   newParts: [0,  ,  ,  ,  ,  ,  ] <- heads matched: update 0
-      //   newKeys:  [0, 2, 1, 4, 3, 7, 6]    and advance both oldHead
-      //                                      & newHead
-      //      newHead ^                 ^ newTail
-      //
-      // * Example below: head pointers don't match, but tail
-      //   pointers do, so update part 6 in place (no need to move
-      //   it), and record part 6 in the `newParts` list. Last,
-      //   advance the `oldTail` and `oldHead` pointers.
-      //
-      //         oldHead v              v oldTail
-      //   oldKeys:  [0, 1, 2, 3, 4, 5, 6]
-      //   newParts: [0,  ,  ,  ,  ,  , 6] <- tails matched: update 6
-      //   newKeys:  [0, 2, 1, 4, 3, 7, 6]    and advance both oldTail
-      //                                      & newTail
-      //         newHead ^              ^ newTail
-      //
-      // * If neither head nor tail match; next check if one of the
-      //   old head/tail items was removed. We first need to generate
-      //   the reverse map of new keys to index (`newKeyToIndexMap`),
-      //   which is done once lazily as a performance optimization,
-      //   since we only hit this case if multiple non-contiguous
-      //   changes were made. Note that for contiguous removal
-      //   anywhere in the list, the head and tails would advance
-      //   from either end and pass each other before we get to this
-      //   case and removals would be handled in the final while loop
-      //   without needing to generate the map.
-      //
-      // * Example below: The key at `oldTail` was removed (no longer
-      //   in the `newKeyToIndexMap`), so remove that part from the
-      //   DOM and advance just the `oldTail` pointer.
-      //
-      //         oldHead v           v oldTail
-      //   oldKeys:  [0, 1, 2, 3, 4, 5, 6]
-      //   newParts: [0,  ,  ,  ,  ,  , 6] <- 5 not in new map: remove
-      //   newKeys:  [0, 2, 1, 4, 3, 7, 6]    5 and advance oldTail
-      //         newHead ^           ^ newTail
-      //
-      // * Once head and tail cannot move, any mismatches are due to
-      //   either new or moved items; if a new key is in the previous
-      //   "old key to old index" map, move the old part to the new
-      //   location, otherwise create and insert a new part. Note
-      //   that when moving an old part we null its position in the
-      //   oldParts array if it lies between the head and tail so we
-      //   know to skip it when the pointers get there.
-      //
-      // * Example below: neither head nor tail match, and neither
-      //   were removed; so find the `newHead` key in the
-      //   `oldKeyToIndexMap`, and move that old part's DOM into the
-      //   next head position (before `oldParts[oldHead]`). Last,
-      //   null the part in the `oldPart` array since it was
-      //   somewhere in the remaining oldParts still to be scanned
-      //   (between the head and tail pointers) so that we know to
-      //   skip that old part on future iterations.
-      //
-      //         oldHead v        v oldTail
-      //   oldKeys:  [0, 1, -, 3, 4, 5, 6]
-      //   newParts: [0, 2,  ,  ,  ,  , 6] <- stuck: update & move 2
-      //   newKeys:  [0, 2, 1, 4, 3, 7, 6]    into place and advance
-      //                                      newHead
-      //         newHead ^           ^ newTail
-      //
-      // * Note that for moves/insertions like the one above, a part
-      //   inserted at the head pointer is inserted before the
-      //   current `oldParts[oldHead]`, and a part inserted at the
-      //   tail pointer is inserted before `newParts[newTail+1]`. The
-      //   seeming asymmetry lies in the fact that new parts are
-      //   moved into place outside in, so to the right of the head
-      //   pointer are old parts, and to the right of the tail
-      //   pointer are new parts.
-      //
-      // * We always restart back from the top of the algorithm,
-      //   allowing matching and simple updates in place to
-      //   continue...
-      //
-      // * Example below: the head pointers once again match, so
-      //   simply update part 1 and record it in the `newParts`
-      //   array.  Last, advance both head pointers.
-      //
-      //         oldHead v        v oldTail
-      //   oldKeys:  [0, 1, -, 3, 4, 5, 6]
-      //   newParts: [0, 2, 1,  ,  ,  , 6] <- heads matched: update 1
-      //   newKeys:  [0, 2, 1, 4, 3, 7, 6]    and advance both oldHead
-      //                                      & newHead
-      //            newHead ^        ^ newTail
-      //
-      // * As mentioned above, items that were moved as a result of
-      //   being stuck (the final else clause in the code below) are
-      //   marked with null, so we always advance old pointers over
-      //   these so we're comparing the next actual old value on
-      //   either end.
-      //
-      // * Example below: `oldHead` is null (already placed in
-      //   newParts), so advance `oldHead`.
-      //
-      //            oldHead v     v oldTail
-      //   oldKeys:  [0, 1, -, 3, 4, 5, 6] <- old head already used:
-      //   newParts: [0, 2, 1,  ,  ,  , 6]    advance oldHead
-      //   newKeys:  [0, 2, 1, 4, 3, 7, 6]
-      //               newHead ^     ^ newTail
-      //
-      // * Note it's not critical to mark old parts as null when they
-      //   are moved from head to tail or tail to head, since they
-      //   will be outside the pointer range and never visited again.
-      //
-      // * Example below: Here the old tail key matches the new head
-      //   key, so the part at the `oldTail` position and move its
-      //   DOM to the new head position (before `oldParts[oldHead]`).
-      //   Last, advance `oldTail` and `newHead` pointers.
-      //
-      //               oldHead v  v oldTail
-      //   oldKeys:  [0, 1, -, 3, 4, 5, 6]
-      //   newParts: [0, 2, 1, 4,  ,  , 6] <- old tail matches new
-      //   newKeys:  [0, 2, 1, 4, 3, 7, 6]   head: update & move 4,
-      //                                     advance oldTail & newHead
-      //               newHead ^     ^ newTail
-      //
-      // * Example below: Old and new head keys match, so update the
-      //   old head part in place, and advance the `oldHead` and
-      //   `newHead` pointers.
-      //
-      //               oldHead v oldTail
-      //   oldKeys:  [0, 1, -, 3, 4, 5, 6]
-      //   newParts: [0, 2, 1, 4, 3,   ,6] <- heads match: update 3
-      //   newKeys:  [0, 2, 1, 4, 3, 7, 6]    and advance oldHead &
-      //                                      newHead
-      //                  newHead ^  ^ newTail
-      //
-      // * Once the new or old pointers move past each other then all
-      //   we have left is additions (if old list exhausted) or
-      //   removals (if new list exhausted). Those are handled in the
-      //   final while loops at the end.
-      //
-      // * Example below: `oldHead` exceeded `oldTail`, so we're done
-      //   with the main loop.  Create the remaining part and insert
-      //   it at the new head position, and the update is complete.
-      //
-      //                   (oldHead > oldTail)
-      //   oldKeys:  [0, 1, -, 3, 4, 5, 6]
-      //   newParts: [0, 2, 1, 4, 3, 7 ,6] <- create and insert 7
-      //   newKeys:  [0, 2, 1, 4, 3, 7, 6]
-      //                     newHead ^ newTail
-      //
-      // * Note that the order of the if/else clauses is not
-      //   important to the algorithm, as long as the null checks
-      //   come first (to ensure we're always working on valid old
-      //   parts) and that the final else clause comes last (since
-      //   that's where the expensive moves occur). The order of
-      //   remaining clauses is is just a simple guess at which cases
-      //   will be most common.
-      //
-      // * TODO(kschaaf) Note, we could calculate the longest
-      //   increasing subsequence (LIS) of old items in new position,
-      //   and only move those not in the LIS set. However that costs
-      //   O(nlogn) time and adds a bit more code, and only helps
-      //   make rare types of mutations require fewer moves. The
-      //   above handles removes, adds, reversal, swaps, and single
-      //   moves of contiguous items in linear time, in the minimum
-      //   number of moves. As the number of multiple moves where LIS
-      //   might help approaches a random shuffle, the LIS
-      //   optimization becomes less helpful, so it seems not worth
-      //   the code at this point. Could reconsider if a compelling
-      //   case arises.
-
-      while (oldHead <= oldTail && newHead <= newTail) {
-        if (oldParts[oldHead] === null) {
-          // `null` means old part at head has already been used
-          // below; skip
-          oldHead++;
-        } else if (oldParts[oldTail] === null) {
-          // `null` means old part at tail has already been used
-          // below; skip
-          oldTail--;
-        } else if (oldKeys[oldHead] === newKeys[newHead]) {
-          // Old head matches new head; update in place
-          newParts[newHead] =
-              updatePart(oldParts[oldHead]!, newValues[newHead]);
-          oldHead++;
-          newHead++;
-        } else if (oldKeys[oldTail] === newKeys[newTail]) {
-          // Old tail matches new tail; update in place
-          newParts[newTail] =
-              updatePart(oldParts[oldTail]!, newValues[newTail]);
-          oldTail--;
-          newTail--;
-        } else if (oldKeys[oldHead] === newKeys[newTail]) {
-          // Old head matches new tail; update and move to new tail
-          newParts[newTail] =
-              updatePart(oldParts[oldHead]!, newValues[newTail]);
-          insertPartBefore(
-              containerPart, oldParts[oldHead]!, newParts[newTail + 1]);
-          oldHead++;
-          newTail--;
-        } else if (oldKeys[oldTail] === newKeys[newHead]) {
-          // Old tail matches new head; update and move to new head
-          newParts[newHead] =
-              updatePart(oldParts[oldTail]!, newValues[newHead]);
-          insertPartBefore(
-              containerPart, oldParts[oldTail]!, oldParts[oldHead]!);
-          oldTail--;
-          newHead++;
-        } else {
-          if (newKeyToIndexMap === undefined) {
-            // Lazily generate key-to-index maps, used for removals &
-            // moves below
-            newKeyToIndexMap = generateMap(newKeys, newHead, newTail);
-            oldKeyToIndexMap = generateMap(oldKeys, oldHead, oldTail);
+    directive(
+        normalizer,
+        (containerPart: Part, {items, keyFn, templateFn}) => {
+          if (!(containerPart instanceof NodePart)) {
+            throw new Error('repeat can only be used in text bindings');
           }
-          if (!newKeyToIndexMap.has(oldKeys[oldHead])) {
-            // Old head is no longer in new list; remove
-            removePart(oldParts[oldHead]!);
-            oldHead++;
-          } else if (!newKeyToIndexMap.has(oldKeys[oldTail])) {
-            // Old tail is no longer in new list; remove
-            removePart(oldParts[oldTail]!);
-            oldTail--;
-          } else {
-            // Any mismatches at this point are due to additions or
-            // moves; see if we have an old part we can reuse and move
-            // into place
-            const oldIndex = oldKeyToIndexMap.get(newKeys[newHead]);
-            const oldPart = oldIndex !== undefined ? oldParts[oldIndex] : null;
-            if (oldPart === null) {
-              // No old part for this value; create a new one and
-              // insert it
-              const newPart =
-                  createAndInsertPart(containerPart, oldParts[oldHead]!);
-              updatePart(newPart, newValues[newHead]);
-              newParts[newHead] = newPart;
+          // Old part & key lists are retrieved from the last update
+          // (associated with the part for this instance of the directive)
+          const oldParts = partListCache.get(containerPart) || [];
+          const oldKeys = keyListCache.get(containerPart) || [];
+
+          // New part list will be built up as we go (either reused from
+          // old parts or created for new keys in this update). This is
+          // saved in the above cache at the end of the update.
+          const newParts: NodePart[] = [];
+
+          // New value list is eagerly generated from items along with a
+          // parallel array indicating its key.
+          const newValues: unknown[] = [];
+          const newKeys: unknown[] = [];
+          let index = 0;
+          for (const item of items) {
+            newKeys[index] = keyFn ? keyFn(item, index) : index;
+            newValues[index] = templateFn(item, index);
+            index++;
+          }
+
+          // Maps from key to index for current and previous update; these
+          // are generated lazily only when needed as a performance
+          // optimization, since they are only required for multiple
+          // non-contiguous changes in the list, which are less common.
+          let newKeyToIndexMap!: Map<unknown, number>;
+          let oldKeyToIndexMap!: Map<unknown, number>;
+
+          // Head and tail pointers to old parts and new values
+          let oldHead = 0;
+          let oldTail = oldParts.length - 1;
+          let newHead = 0;
+          let newTail = newValues.length - 1;
+
+          // Overview of O(n) reconciliation algorithm (general approach
+          // based on ideas found in ivi, vue, snabbdom, etc.):
+          //
+          // * We start with the list of old parts and new values (and
+          //   arrays of their respective keys), head/tail pointers into
+          //   each, and we build up the new list of parts by updating
+          //   (and when needed, moving) old parts or creating new ones.
+          //   The initial scenario might look like this (for brevity of
+          //   the diagrams, the numbers in the array reflect keys
+          //   associated with the old parts or new values, although keys
+          //   and parts/values are actually stored in parallel arrays
+          //   indexed using the same head/tail pointers):
+          //
+          //      oldHead v                 v oldTail
+          //   oldKeys:  [0, 1, 2, 3, 4, 5, 6]
+          //   newParts: [ ,  ,  ,  ,  ,  ,  ]
+          //   newKeys:  [0, 2, 1, 4, 3, 7, 6] <- reflects the user's new
+          //                                      item order
+          //      newHead ^                 ^ newTail
+          //
+          // * Iterate old & new lists from both sides, updating,
+          //   swapping, or removing parts at the head/tail locations
+          //   until neither head nor tail can move.
+          //
+          // * Example below: keys at head pointers match, so update old
+          //   part 0 in-place (no need to move it) and record part 0 in
+          //   the `newParts` list. The last thing we do is advance the
+          //   `oldHead` and `newHead` pointers (will be reflected in the
+          //   next diagram).
+          //
+          //      oldHead v                 v oldTail
+          //   oldKeys:  [0, 1, 2, 3, 4, 5, 6]
+          //   newParts: [0,  ,  ,  ,  ,  ,  ] <- heads matched: update 0
+          //   newKeys:  [0, 2, 1, 4, 3, 7, 6]    and advance both oldHead
+          //                                      & newHead
+          //      newHead ^                 ^ newTail
+          //
+          // * Example below: head pointers don't match, but tail
+          //   pointers do, so update part 6 in place (no need to move
+          //   it), and record part 6 in the `newParts` list. Last,
+          //   advance the `oldTail` and `oldHead` pointers.
+          //
+          //         oldHead v              v oldTail
+          //   oldKeys:  [0, 1, 2, 3, 4, 5, 6]
+          //   newParts: [0,  ,  ,  ,  ,  , 6] <- tails matched: update 6
+          //   newKeys:  [0, 2, 1, 4, 3, 7, 6]    and advance both oldTail
+          //                                      & newTail
+          //         newHead ^              ^ newTail
+          //
+          // * If neither head nor tail match; next check if one of the
+          //   old head/tail items was removed. We first need to generate
+          //   the reverse map of new keys to index (`newKeyToIndexMap`),
+          //   which is done once lazily as a performance optimization,
+          //   since we only hit this case if multiple non-contiguous
+          //   changes were made. Note that for contiguous removal
+          //   anywhere in the list, the head and tails would advance
+          //   from either end and pass each other before we get to this
+          //   case and removals would be handled in the final while loop
+          //   without needing to generate the map.
+          //
+          // * Example below: The key at `oldTail` was removed (no longer
+          //   in the `newKeyToIndexMap`), so remove that part from the
+          //   DOM and advance just the `oldTail` pointer.
+          //
+          //         oldHead v           v oldTail
+          //   oldKeys:  [0, 1, 2, 3, 4, 5, 6]
+          //   newParts: [0,  ,  ,  ,  ,  , 6] <- 5 not in new map: remove
+          //   newKeys:  [0, 2, 1, 4, 3, 7, 6]    5 and advance oldTail
+          //         newHead ^           ^ newTail
+          //
+          // * Once head and tail cannot move, any mismatches are due to
+          //   either new or moved items; if a new key is in the previous
+          //   "old key to old index" map, move the old part to the new
+          //   location, otherwise create and insert a new part. Note
+          //   that when moving an old part we null its position in the
+          //   oldParts array if it lies between the head and tail so we
+          //   know to skip it when the pointers get there.
+          //
+          // * Example below: neither head nor tail match, and neither
+          //   were removed; so find the `newHead` key in the
+          //   `oldKeyToIndexMap`, and move that old part's DOM into the
+          //   next head position (before `oldParts[oldHead]`). Last,
+          //   null the part in the `oldPart` array since it was
+          //   somewhere in the remaining oldParts still to be scanned
+          //   (between the head and tail pointers) so that we know to
+          //   skip that old part on future iterations.
+          //
+          //         oldHead v        v oldTail
+          //   oldKeys:  [0, 1, -, 3, 4, 5, 6]
+          //   newParts: [0, 2,  ,  ,  ,  , 6] <- stuck: update & move 2
+          //   newKeys:  [0, 2, 1, 4, 3, 7, 6]    into place and advance
+          //                                      newHead
+          //         newHead ^           ^ newTail
+          //
+          // * Note that for moves/insertions like the one above, a part
+          //   inserted at the head pointer is inserted before the
+          //   current `oldParts[oldHead]`, and a part inserted at the
+          //   tail pointer is inserted before `newParts[newTail+1]`. The
+          //   seeming asymmetry lies in the fact that new parts are
+          //   moved into place outside in, so to the right of the head
+          //   pointer are old parts, and to the right of the tail
+          //   pointer are new parts.
+          //
+          // * We always restart back from the top of the algorithm,
+          //   allowing matching and simple updates in place to
+          //   continue...
+          //
+          // * Example below: the head pointers once again match, so
+          //   simply update part 1 and record it in the `newParts`
+          //   array.  Last, advance both head pointers.
+          //
+          //         oldHead v        v oldTail
+          //   oldKeys:  [0, 1, -, 3, 4, 5, 6]
+          //   newParts: [0, 2, 1,  ,  ,  , 6] <- heads matched: update 1
+          //   newKeys:  [0, 2, 1, 4, 3, 7, 6]    and advance both oldHead
+          //                                      & newHead
+          //            newHead ^        ^ newTail
+          //
+          // * As mentioned above, items that were moved as a result of
+          //   being stuck (the final else clause in the code below) are
+          //   marked with null, so we always advance old pointers over
+          //   these so we're comparing the next actual old value on
+          //   either end.
+          //
+          // * Example below: `oldHead` is null (already placed in
+          //   newParts), so advance `oldHead`.
+          //
+          //            oldHead v     v oldTail
+          //   oldKeys:  [0, 1, -, 3, 4, 5, 6] <- old head already used:
+          //   newParts: [0, 2, 1,  ,  ,  , 6]    advance oldHead
+          //   newKeys:  [0, 2, 1, 4, 3, 7, 6]
+          //               newHead ^     ^ newTail
+          //
+          // * Note it's not critical to mark old parts as null when they
+          //   are moved from head to tail or tail to head, since they
+          //   will be outside the pointer range and never visited again.
+          //
+          // * Example below: Here the old tail key matches the new head
+          //   key, so the part at the `oldTail` position and move its
+          //   DOM to the new head position (before `oldParts[oldHead]`).
+          //   Last, advance `oldTail` and `newHead` pointers.
+          //
+          //               oldHead v  v oldTail
+          //   oldKeys:  [0, 1, -, 3, 4, 5, 6]
+          //   newParts: [0, 2, 1, 4,  ,  , 6] <- old tail matches new
+          //   newKeys:  [0, 2, 1, 4, 3, 7, 6]   head: update & move 4,
+          //                                     advance oldTail & newHead
+          //               newHead ^     ^ newTail
+          //
+          // * Example below: Old and new head keys match, so update the
+          //   old head part in place, and advance the `oldHead` and
+          //   `newHead` pointers.
+          //
+          //               oldHead v oldTail
+          //   oldKeys:  [0, 1, -, 3, 4, 5, 6]
+          //   newParts: [0, 2, 1, 4, 3,   ,6] <- heads match: update 3
+          //   newKeys:  [0, 2, 1, 4, 3, 7, 6]    and advance oldHead &
+          //                                      newHead
+          //                  newHead ^  ^ newTail
+          //
+          // * Once the new or old pointers move past each other then all
+          //   we have left is additions (if old list exhausted) or
+          //   removals (if new list exhausted). Those are handled in the
+          //   final while loops at the end.
+          //
+          // * Example below: `oldHead` exceeded `oldTail`, so we're done
+          //   with the main loop.  Create the remaining part and insert
+          //   it at the new head position, and the update is complete.
+          //
+          //                   (oldHead > oldTail)
+          //   oldKeys:  [0, 1, -, 3, 4, 5, 6]
+          //   newParts: [0, 2, 1, 4, 3, 7 ,6] <- create and insert 7
+          //   newKeys:  [0, 2, 1, 4, 3, 7, 6]
+          //                     newHead ^ newTail
+          //
+          // * Note that the order of the if/else clauses is not
+          //   important to the algorithm, as long as the null checks
+          //   come first (to ensure we're always working on valid old
+          //   parts) and that the final else clause comes last (since
+          //   that's where the expensive moves occur). The order of
+          //   remaining clauses is is just a simple guess at which cases
+          //   will be most common.
+          //
+          // * TODO(kschaaf) Note, we could calculate the longest
+          //   increasing subsequence (LIS) of old items in new position,
+          //   and only move those not in the LIS set. However that costs
+          //   O(nlogn) time and adds a bit more code, and only helps
+          //   make rare types of mutations require fewer moves. The
+          //   above handles removes, adds, reversal, swaps, and single
+          //   moves of contiguous items in linear time, in the minimum
+          //   number of moves. As the number of multiple moves where LIS
+          //   might help approaches a random shuffle, the LIS
+          //   optimization becomes less helpful, so it seems not worth
+          //   the code at this point. Could reconsider if a compelling
+          //   case arises.
+
+          while (oldHead <= oldTail && newHead <= newTail) {
+            if (oldParts[oldHead] === null) {
+              // `null` means old part at head has already been used
+              // below; skip
+              oldHead++;
+            } else if (oldParts[oldTail] === null) {
+              // `null` means old part at tail has already been used
+              // below; skip
+              oldTail--;
+            } else if (oldKeys[oldHead] === newKeys[newHead]) {
+              // Old head matches new head; update in place
+              newParts[newHead] =
+                  updatePart(oldParts[oldHead]!, newValues[newHead]);
+              oldHead++;
+              newHead++;
+            } else if (oldKeys[oldTail] === newKeys[newTail]) {
+              // Old tail matches new tail; update in place
+              newParts[newTail] =
+                  updatePart(oldParts[oldTail]!, newValues[newTail]);
+              oldTail--;
+              newTail--;
+            } else if (oldKeys[oldHead] === newKeys[newTail]) {
+              // Old head matches new tail; update and move to new tail
+              newParts[newTail] =
+                  updatePart(oldParts[oldHead]!, newValues[newTail]);
+              insertPartBefore(
+                  containerPart, oldParts[oldHead]!, newParts[newTail + 1]);
+              oldHead++;
+              newTail--;
+            } else if (oldKeys[oldTail] === newKeys[newHead]) {
+              // Old tail matches new head; update and move to new head
+              newParts[newHead] =
+                  updatePart(oldParts[oldTail]!, newValues[newHead]);
+              insertPartBefore(
+                  containerPart, oldParts[oldTail]!, oldParts[oldHead]!);
+              oldTail--;
+              newHead++;
             } else {
-              // Reuse old part
-              newParts[newHead] = updatePart(oldPart, newValues[newHead]);
-              insertPartBefore(containerPart, oldPart, oldParts[oldHead]!);
-              // This marks the old part as having been used, so that
-              // it will be skipped in the first two checks above
-              oldParts[oldIndex as number] = null;
+              if (newKeyToIndexMap === undefined) {
+                // Lazily generate key-to-index maps, used for removals &
+                // moves below
+                newKeyToIndexMap = generateMap(newKeys, newHead, newTail);
+                oldKeyToIndexMap = generateMap(oldKeys, oldHead, oldTail);
+              }
+              if (!newKeyToIndexMap.has(oldKeys[oldHead])) {
+                // Old head is no longer in new list; remove
+                removePart(oldParts[oldHead]!);
+                oldHead++;
+              } else if (!newKeyToIndexMap.has(oldKeys[oldTail])) {
+                // Old tail is no longer in new list; remove
+                removePart(oldParts[oldTail]!);
+                oldTail--;
+              } else {
+                // Any mismatches at this point are due to additions or
+                // moves; see if we have an old part we can reuse and move
+                // into place
+                const oldIndex = oldKeyToIndexMap.get(newKeys[newHead]);
+                const oldPart =
+                    oldIndex !== undefined ? oldParts[oldIndex] : null;
+                if (oldPart === null) {
+                  // No old part for this value; create a new one and
+                  // insert it
+                  const newPart =
+                      createAndInsertPart(containerPart, oldParts[oldHead]!);
+                  updatePart(newPart, newValues[newHead]);
+                  newParts[newHead] = newPart;
+                } else {
+                  // Reuse old part
+                  newParts[newHead] = updatePart(oldPart, newValues[newHead]);
+                  insertPartBefore(containerPart, oldPart, oldParts[oldHead]!);
+                  // This marks the old part as having been used, so that
+                  // it will be skipped in the first two checks above
+                  oldParts[oldIndex as number] = null;
+                }
+                newHead++;
+              }
             }
-            newHead++;
           }
-        }
-      }
-      // Add parts for any remaining new values
-      while (newHead <= newTail) {
-        // For all remaining additions, we insert before last new
-        // tail, since old pointers are no longer valid
-        const newPart =
-            createAndInsertPart(containerPart, newParts[newTail + 1]);
-        updatePart(newPart, newValues[newHead]);
-        newParts[newHead++] = newPart;
-      }
-      // Remove any remaining unused old parts
-      while (oldHead <= oldTail) {
-        const oldPart = oldParts[oldHead++];
-        if (oldPart !== null) {
-          removePart(oldPart);
-        }
-      }
-      // Save order of new parts for next round
-      partListCache.set(containerPart, newParts);
-      keyListCache.set(containerPart, newKeys);
-    });
+          // Add parts for any remaining new values
+          while (newHead <= newTail) {
+            // For all remaining additions, we insert before last new
+            // tail, since old pointers are no longer valid
+            const newPart =
+                createAndInsertPart(containerPart, newParts[newTail + 1]);
+            updatePart(newPart, newValues[newHead]);
+            newParts[newHead++] = newPart;
+          }
+          // Remove any remaining unused old parts
+          while (oldHead <= oldTail) {
+            const oldPart = oldParts[oldHead++];
+            if (oldPart !== null) {
+              removePart(oldPart);
+            }
+          }
+          // Save order of new parts for next round
+          partListCache.set(containerPart, newParts);
+          keyListCache.set(containerPart, newKeys);
+        }) as
+    <T, R>(
+        items: Iterable<T>,
+        keyFnOrTemplate: KeyFn<T, R>|ItemTemplate<T>,
+        template?: ItemTemplate<R>) => unknown;

--- a/src/directives/repeat.ts
+++ b/src/directives/repeat.ts
@@ -12,10 +12,9 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {DirectiveFn} from '../lib/directive.js';
 import {createMarker, directive, NodePart, Part, removeNodes, reparentNodes} from '../lit-html.js';
 
-export type KeyFn<T> = (item: T, index: number) => unknown;
+export type KeyFn<T, R> = (item: T, index: number) => R;
 export type ItemTemplate<T> = (item: T, index: number) => unknown;
 
 // Helper functions for manipulating parts
@@ -68,6 +67,25 @@ const generateMap = (list: unknown[], start: number, end: number) => {
 const partListCache = new WeakMap<NodePart, (NodePart | null)[]>();
 const keyListCache = new WeakMap<NodePart, unknown[]>();
 
+function normalizer<T, R>(
+    items: Iterable<T>,
+    keyFnOrTemplate: KeyFn<T, R>|ItemTemplate<T>,
+    template?: ItemTemplate<R>): {
+  items: Iterable<T>,
+  keyFn: KeyFn<T, R>|undefined,
+  templateFn: ItemTemplate<T>|ItemTemplate<R>
+} {
+  let keyFn: KeyFn<T, R>|undefined;
+  let templateFn;
+  if (template === undefined) {
+    templateFn = keyFnOrTemplate as ItemTemplate<T>;
+  } else {
+    templateFn = template as ItemTemplate<R>;
+    keyFn = keyFnOrTemplate as KeyFn<T, R>;
+  }
+  return {items, keyFn, templateFn};
+}
+
 /**
  * A directive that repeats a series of values (usually `TemplateResults`)
  * generated from an iterable, and updates those items efficiently when the
@@ -88,355 +106,334 @@ const keyListCache = new WeakMap<NodePart, unknown[]>();
  * items to values, and DOM will be reused against potentially different items.
  */
 export const repeat =
-    directive(
-        <T>(items: Iterable<T>,
-            keyFnOrTemplate: KeyFn<T>|ItemTemplate<T>,
-            template?: ItemTemplate<T>):
-            DirectiveFn => {
-              let keyFn: KeyFn<T>;
-              if (template === undefined) {
-                template = keyFnOrTemplate;
-              } else if (keyFnOrTemplate !== undefined) {
-                keyFn = keyFnOrTemplate as KeyFn<T>;
-              }
+    directive(normalizer, (containerPart: Part, {items, keyFn, templateFn}) => {
+      if (!(containerPart instanceof NodePart)) {
+        throw new Error('repeat can only be used in text bindings');
+      }
+      // Old part & key lists are retrieved from the last update
+      // (associated with the part for this instance of the directive)
+      const oldParts = partListCache.get(containerPart) || [];
+      const oldKeys = keyListCache.get(containerPart) || [];
 
-              return (containerPart: Part): void => {
-                if (!(containerPart instanceof NodePart)) {
-                  throw new Error('repeat can only be used in text bindings');
-                }
-                // Old part & key lists are retrieved from the last update
-                // (associated with the part for this instance of the directive)
-                const oldParts = partListCache.get(containerPart) || [];
-                const oldKeys = keyListCache.get(containerPart) || [];
+      // New part list will be built up as we go (either reused from
+      // old parts or created for new keys in this update). This is
+      // saved in the above cache at the end of the update.
+      const newParts: NodePart[] = [];
 
-                // New part list will be built up as we go (either reused from
-                // old parts or created for new keys in this update). This is
-                // saved in the above cache at the end of the update.
-                const newParts: NodePart[] = [];
+      // New value list is eagerly generated from items along with a
+      // parallel array indicating its key.
+      const newValues: unknown[] = [];
+      const newKeys: unknown[] = [];
+      let index = 0;
+      for (const item of items) {
+        newKeys[index] = keyFn ? keyFn(item, index) : index;
+        newValues[index] = templateFn(item, index);
+        index++;
+      }
 
-                // New value list is eagerly generated from items along with a
-                // parallel array indicating its key.
-                const newValues: unknown[] = [];
-                const newKeys: unknown[] = [];
-                let index = 0;
-                for (const item of items) {
-                  newKeys[index] = keyFn ? keyFn(item, index) : index;
-                  newValues[index] = template !(item, index);
-                  index++;
-                }
+      // Maps from key to index for current and previous update; these
+      // are generated lazily only when needed as a performance
+      // optimization, since they are only required for multiple
+      // non-contiguous changes in the list, which are less common.
+      let newKeyToIndexMap!: Map<unknown, number>;
+      let oldKeyToIndexMap!: Map<unknown, number>;
 
-                // Maps from key to index for current and previous update; these
-                // are generated lazily only when needed as a performance
-                // optimization, since they are only required for multiple
-                // non-contiguous changes in the list, which are less common.
-                let newKeyToIndexMap!: Map<unknown, number>;
-                let oldKeyToIndexMap!: Map<unknown, number>;
+      // Head and tail pointers to old parts and new values
+      let oldHead = 0;
+      let oldTail = oldParts.length - 1;
+      let newHead = 0;
+      let newTail = newValues.length - 1;
 
-                // Head and tail pointers to old parts and new values
-                let oldHead = 0;
-                let oldTail = oldParts.length - 1;
-                let newHead = 0;
-                let newTail = newValues.length - 1;
+      // Overview of O(n) reconciliation algorithm (general approach
+      // based on ideas found in ivi, vue, snabbdom, etc.):
+      //
+      // * We start with the list of old parts and new values (and
+      //   arrays of their respective keys), head/tail pointers into
+      //   each, and we build up the new list of parts by updating
+      //   (and when needed, moving) old parts or creating new ones.
+      //   The initial scenario might look like this (for brevity of
+      //   the diagrams, the numbers in the array reflect keys
+      //   associated with the old parts or new values, although keys
+      //   and parts/values are actually stored in parallel arrays
+      //   indexed using the same head/tail pointers):
+      //
+      //      oldHead v                 v oldTail
+      //   oldKeys:  [0, 1, 2, 3, 4, 5, 6]
+      //   newParts: [ ,  ,  ,  ,  ,  ,  ]
+      //   newKeys:  [0, 2, 1, 4, 3, 7, 6] <- reflects the user's new
+      //                                      item order
+      //      newHead ^                 ^ newTail
+      //
+      // * Iterate old & new lists from both sides, updating,
+      //   swapping, or removing parts at the head/tail locations
+      //   until neither head nor tail can move.
+      //
+      // * Example below: keys at head pointers match, so update old
+      //   part 0 in-place (no need to move it) and record part 0 in
+      //   the `newParts` list. The last thing we do is advance the
+      //   `oldHead` and `newHead` pointers (will be reflected in the
+      //   next diagram).
+      //
+      //      oldHead v                 v oldTail
+      //   oldKeys:  [0, 1, 2, 3, 4, 5, 6]
+      //   newParts: [0,  ,  ,  ,  ,  ,  ] <- heads matched: update 0
+      //   newKeys:  [0, 2, 1, 4, 3, 7, 6]    and advance both oldHead
+      //                                      & newHead
+      //      newHead ^                 ^ newTail
+      //
+      // * Example below: head pointers don't match, but tail
+      //   pointers do, so update part 6 in place (no need to move
+      //   it), and record part 6 in the `newParts` list. Last,
+      //   advance the `oldTail` and `oldHead` pointers.
+      //
+      //         oldHead v              v oldTail
+      //   oldKeys:  [0, 1, 2, 3, 4, 5, 6]
+      //   newParts: [0,  ,  ,  ,  ,  , 6] <- tails matched: update 6
+      //   newKeys:  [0, 2, 1, 4, 3, 7, 6]    and advance both oldTail
+      //                                      & newTail
+      //         newHead ^              ^ newTail
+      //
+      // * If neither head nor tail match; next check if one of the
+      //   old head/tail items was removed. We first need to generate
+      //   the reverse map of new keys to index (`newKeyToIndexMap`),
+      //   which is done once lazily as a performance optimization,
+      //   since we only hit this case if multiple non-contiguous
+      //   changes were made. Note that for contiguous removal
+      //   anywhere in the list, the head and tails would advance
+      //   from either end and pass each other before we get to this
+      //   case and removals would be handled in the final while loop
+      //   without needing to generate the map.
+      //
+      // * Example below: The key at `oldTail` was removed (no longer
+      //   in the `newKeyToIndexMap`), so remove that part from the
+      //   DOM and advance just the `oldTail` pointer.
+      //
+      //         oldHead v           v oldTail
+      //   oldKeys:  [0, 1, 2, 3, 4, 5, 6]
+      //   newParts: [0,  ,  ,  ,  ,  , 6] <- 5 not in new map: remove
+      //   newKeys:  [0, 2, 1, 4, 3, 7, 6]    5 and advance oldTail
+      //         newHead ^           ^ newTail
+      //
+      // * Once head and tail cannot move, any mismatches are due to
+      //   either new or moved items; if a new key is in the previous
+      //   "old key to old index" map, move the old part to the new
+      //   location, otherwise create and insert a new part. Note
+      //   that when moving an old part we null its position in the
+      //   oldParts array if it lies between the head and tail so we
+      //   know to skip it when the pointers get there.
+      //
+      // * Example below: neither head nor tail match, and neither
+      //   were removed; so find the `newHead` key in the
+      //   `oldKeyToIndexMap`, and move that old part's DOM into the
+      //   next head position (before `oldParts[oldHead]`). Last,
+      //   null the part in the `oldPart` array since it was
+      //   somewhere in the remaining oldParts still to be scanned
+      //   (between the head and tail pointers) so that we know to
+      //   skip that old part on future iterations.
+      //
+      //         oldHead v        v oldTail
+      //   oldKeys:  [0, 1, -, 3, 4, 5, 6]
+      //   newParts: [0, 2,  ,  ,  ,  , 6] <- stuck: update & move 2
+      //   newKeys:  [0, 2, 1, 4, 3, 7, 6]    into place and advance
+      //                                      newHead
+      //         newHead ^           ^ newTail
+      //
+      // * Note that for moves/insertions like the one above, a part
+      //   inserted at the head pointer is inserted before the
+      //   current `oldParts[oldHead]`, and a part inserted at the
+      //   tail pointer is inserted before `newParts[newTail+1]`. The
+      //   seeming asymmetry lies in the fact that new parts are
+      //   moved into place outside in, so to the right of the head
+      //   pointer are old parts, and to the right of the tail
+      //   pointer are new parts.
+      //
+      // * We always restart back from the top of the algorithm,
+      //   allowing matching and simple updates in place to
+      //   continue...
+      //
+      // * Example below: the head pointers once again match, so
+      //   simply update part 1 and record it in the `newParts`
+      //   array.  Last, advance both head pointers.
+      //
+      //         oldHead v        v oldTail
+      //   oldKeys:  [0, 1, -, 3, 4, 5, 6]
+      //   newParts: [0, 2, 1,  ,  ,  , 6] <- heads matched: update 1
+      //   newKeys:  [0, 2, 1, 4, 3, 7, 6]    and advance both oldHead
+      //                                      & newHead
+      //            newHead ^        ^ newTail
+      //
+      // * As mentioned above, items that were moved as a result of
+      //   being stuck (the final else clause in the code below) are
+      //   marked with null, so we always advance old pointers over
+      //   these so we're comparing the next actual old value on
+      //   either end.
+      //
+      // * Example below: `oldHead` is null (already placed in
+      //   newParts), so advance `oldHead`.
+      //
+      //            oldHead v     v oldTail
+      //   oldKeys:  [0, 1, -, 3, 4, 5, 6] <- old head already used:
+      //   newParts: [0, 2, 1,  ,  ,  , 6]    advance oldHead
+      //   newKeys:  [0, 2, 1, 4, 3, 7, 6]
+      //               newHead ^     ^ newTail
+      //
+      // * Note it's not critical to mark old parts as null when they
+      //   are moved from head to tail or tail to head, since they
+      //   will be outside the pointer range and never visited again.
+      //
+      // * Example below: Here the old tail key matches the new head
+      //   key, so the part at the `oldTail` position and move its
+      //   DOM to the new head position (before `oldParts[oldHead]`).
+      //   Last, advance `oldTail` and `newHead` pointers.
+      //
+      //               oldHead v  v oldTail
+      //   oldKeys:  [0, 1, -, 3, 4, 5, 6]
+      //   newParts: [0, 2, 1, 4,  ,  , 6] <- old tail matches new
+      //   newKeys:  [0, 2, 1, 4, 3, 7, 6]   head: update & move 4,
+      //                                     advance oldTail & newHead
+      //               newHead ^     ^ newTail
+      //
+      // * Example below: Old and new head keys match, so update the
+      //   old head part in place, and advance the `oldHead` and
+      //   `newHead` pointers.
+      //
+      //               oldHead v oldTail
+      //   oldKeys:  [0, 1, -, 3, 4, 5, 6]
+      //   newParts: [0, 2, 1, 4, 3,   ,6] <- heads match: update 3
+      //   newKeys:  [0, 2, 1, 4, 3, 7, 6]    and advance oldHead &
+      //                                      newHead
+      //                  newHead ^  ^ newTail
+      //
+      // * Once the new or old pointers move past each other then all
+      //   we have left is additions (if old list exhausted) or
+      //   removals (if new list exhausted). Those are handled in the
+      //   final while loops at the end.
+      //
+      // * Example below: `oldHead` exceeded `oldTail`, so we're done
+      //   with the main loop.  Create the remaining part and insert
+      //   it at the new head position, and the update is complete.
+      //
+      //                   (oldHead > oldTail)
+      //   oldKeys:  [0, 1, -, 3, 4, 5, 6]
+      //   newParts: [0, 2, 1, 4, 3, 7 ,6] <- create and insert 7
+      //   newKeys:  [0, 2, 1, 4, 3, 7, 6]
+      //                     newHead ^ newTail
+      //
+      // * Note that the order of the if/else clauses is not
+      //   important to the algorithm, as long as the null checks
+      //   come first (to ensure we're always working on valid old
+      //   parts) and that the final else clause comes last (since
+      //   that's where the expensive moves occur). The order of
+      //   remaining clauses is is just a simple guess at which cases
+      //   will be most common.
+      //
+      // * TODO(kschaaf) Note, we could calculate the longest
+      //   increasing subsequence (LIS) of old items in new position,
+      //   and only move those not in the LIS set. However that costs
+      //   O(nlogn) time and adds a bit more code, and only helps
+      //   make rare types of mutations require fewer moves. The
+      //   above handles removes, adds, reversal, swaps, and single
+      //   moves of contiguous items in linear time, in the minimum
+      //   number of moves. As the number of multiple moves where LIS
+      //   might help approaches a random shuffle, the LIS
+      //   optimization becomes less helpful, so it seems not worth
+      //   the code at this point. Could reconsider if a compelling
+      //   case arises.
 
-                // Overview of O(n) reconciliation algorithm (general approach
-                // based on ideas found in ivi, vue, snabbdom, etc.):
-                //
-                // * We start with the list of old parts and new values (and
-                //   arrays of their respective keys), head/tail pointers into
-                //   each, and we build up the new list of parts by updating
-                //   (and when needed, moving) old parts or creating new ones.
-                //   The initial scenario might look like this (for brevity of
-                //   the diagrams, the numbers in the array reflect keys
-                //   associated with the old parts or new values, although keys
-                //   and parts/values are actually stored in parallel arrays
-                //   indexed using the same head/tail pointers):
-                //
-                //      oldHead v                 v oldTail
-                //   oldKeys:  [0, 1, 2, 3, 4, 5, 6]
-                //   newParts: [ ,  ,  ,  ,  ,  ,  ]
-                //   newKeys:  [0, 2, 1, 4, 3, 7, 6] <- reflects the user's new
-                //                                      item order
-                //      newHead ^                 ^ newTail
-                //
-                // * Iterate old & new lists from both sides, updating,
-                //   swapping, or removing parts at the head/tail locations
-                //   until neither head nor tail can move.
-                //
-                // * Example below: keys at head pointers match, so update old
-                //   part 0 in-place (no need to move it) and record part 0 in
-                //   the `newParts` list. The last thing we do is advance the
-                //   `oldHead` and `newHead` pointers (will be reflected in the
-                //   next diagram).
-                //
-                //      oldHead v                 v oldTail
-                //   oldKeys:  [0, 1, 2, 3, 4, 5, 6]
-                //   newParts: [0,  ,  ,  ,  ,  ,  ] <- heads matched: update 0
-                //   newKeys:  [0, 2, 1, 4, 3, 7, 6]    and advance both oldHead
-                //                                      & newHead
-                //      newHead ^                 ^ newTail
-                //
-                // * Example below: head pointers don't match, but tail
-                //   pointers do, so update part 6 in place (no need to move
-                //   it), and record part 6 in the `newParts` list. Last,
-                //   advance the `oldTail` and `oldHead` pointers.
-                //
-                //         oldHead v              v oldTail
-                //   oldKeys:  [0, 1, 2, 3, 4, 5, 6]
-                //   newParts: [0,  ,  ,  ,  ,  , 6] <- tails matched: update 6
-                //   newKeys:  [0, 2, 1, 4, 3, 7, 6]    and advance both oldTail
-                //                                      & newTail
-                //         newHead ^              ^ newTail
-                //
-                // * If neither head nor tail match; next check if one of the
-                //   old head/tail items was removed. We first need to generate
-                //   the reverse map of new keys to index (`newKeyToIndexMap`),
-                //   which is done once lazily as a performance optimization,
-                //   since we only hit this case if multiple non-contiguous
-                //   changes were made. Note that for contiguous removal
-                //   anywhere in the list, the head and tails would advance
-                //   from either end and pass each other before we get to this
-                //   case and removals would be handled in the final while loop
-                //   without needing to generate the map.
-                //
-                // * Example below: The key at `oldTail` was removed (no longer
-                //   in the `newKeyToIndexMap`), so remove that part from the
-                //   DOM and advance just the `oldTail` pointer.
-                //
-                //         oldHead v           v oldTail
-                //   oldKeys:  [0, 1, 2, 3, 4, 5, 6]
-                //   newParts: [0,  ,  ,  ,  ,  , 6] <- 5 not in new map: remove
-                //   newKeys:  [0, 2, 1, 4, 3, 7, 6]    5 and advance oldTail
-                //         newHead ^           ^ newTail
-                //
-                // * Once head and tail cannot move, any mismatches are due to
-                //   either new or moved items; if a new key is in the previous
-                //   "old key to old index" map, move the old part to the new
-                //   location, otherwise create and insert a new part. Note
-                //   that when moving an old part we null its position in the
-                //   oldParts array if it lies between the head and tail so we
-                //   know to skip it when the pointers get there.
-                //
-                // * Example below: neither head nor tail match, and neither
-                //   were removed; so find the `newHead` key in the
-                //   `oldKeyToIndexMap`, and move that old part's DOM into the
-                //   next head position (before `oldParts[oldHead]`). Last,
-                //   null the part in the `oldPart` array since it was
-                //   somewhere in the remaining oldParts still to be scanned
-                //   (between the head and tail pointers) so that we know to
-                //   skip that old part on future iterations.
-                //
-                //         oldHead v        v oldTail
-                //   oldKeys:  [0, 1, -, 3, 4, 5, 6]
-                //   newParts: [0, 2,  ,  ,  ,  , 6] <- stuck: update & move 2
-                //   newKeys:  [0, 2, 1, 4, 3, 7, 6]    into place and advance
-                //                                      newHead
-                //         newHead ^           ^ newTail
-                //
-                // * Note that for moves/insertions like the one above, a part
-                //   inserted at the head pointer is inserted before the
-                //   current `oldParts[oldHead]`, and a part inserted at the
-                //   tail pointer is inserted before `newParts[newTail+1]`. The
-                //   seeming asymmetry lies in the fact that new parts are
-                //   moved into place outside in, so to the right of the head
-                //   pointer are old parts, and to the right of the tail
-                //   pointer are new parts.
-                //
-                // * We always restart back from the top of the algorithm,
-                //   allowing matching and simple updates in place to
-                //   continue...
-                //
-                // * Example below: the head pointers once again match, so
-                //   simply update part 1 and record it in the `newParts`
-                //   array.  Last, advance both head pointers.
-                //
-                //         oldHead v        v oldTail
-                //   oldKeys:  [0, 1, -, 3, 4, 5, 6]
-                //   newParts: [0, 2, 1,  ,  ,  , 6] <- heads matched: update 1
-                //   newKeys:  [0, 2, 1, 4, 3, 7, 6]    and advance both oldHead
-                //                                      & newHead
-                //            newHead ^        ^ newTail
-                //
-                // * As mentioned above, items that were moved as a result of
-                //   being stuck (the final else clause in the code below) are
-                //   marked with null, so we always advance old pointers over
-                //   these so we're comparing the next actual old value on
-                //   either end.
-                //
-                // * Example below: `oldHead` is null (already placed in
-                //   newParts), so advance `oldHead`.
-                //
-                //            oldHead v     v oldTail
-                //   oldKeys:  [0, 1, -, 3, 4, 5, 6] <- old head already used:
-                //   newParts: [0, 2, 1,  ,  ,  , 6]    advance oldHead
-                //   newKeys:  [0, 2, 1, 4, 3, 7, 6]
-                //               newHead ^     ^ newTail
-                //
-                // * Note it's not critical to mark old parts as null when they
-                //   are moved from head to tail or tail to head, since they
-                //   will be outside the pointer range and never visited again.
-                //
-                // * Example below: Here the old tail key matches the new head
-                //   key, so the part at the `oldTail` position and move its
-                //   DOM to the new head position (before `oldParts[oldHead]`).
-                //   Last, advance `oldTail` and `newHead` pointers.
-                //
-                //               oldHead v  v oldTail
-                //   oldKeys:  [0, 1, -, 3, 4, 5, 6]
-                //   newParts: [0, 2, 1, 4,  ,  , 6] <- old tail matches new
-                //   newKeys:  [0, 2, 1, 4, 3, 7, 6]   head: update & move 4,
-                //                                     advance oldTail & newHead
-                //               newHead ^     ^ newTail
-                //
-                // * Example below: Old and new head keys match, so update the
-                //   old head part in place, and advance the `oldHead` and
-                //   `newHead` pointers.
-                //
-                //               oldHead v oldTail
-                //   oldKeys:  [0, 1, -, 3, 4, 5, 6]
-                //   newParts: [0, 2, 1, 4, 3,   ,6] <- heads match: update 3
-                //   newKeys:  [0, 2, 1, 4, 3, 7, 6]    and advance oldHead &
-                //                                      newHead
-                //                  newHead ^  ^ newTail
-                //
-                // * Once the new or old pointers move past each other then all
-                //   we have left is additions (if old list exhausted) or
-                //   removals (if new list exhausted). Those are handled in the
-                //   final while loops at the end.
-                //
-                // * Example below: `oldHead` exceeded `oldTail`, so we're done
-                //   with the main loop.  Create the remaining part and insert
-                //   it at the new head position, and the update is complete.
-                //
-                //                   (oldHead > oldTail)
-                //   oldKeys:  [0, 1, -, 3, 4, 5, 6]
-                //   newParts: [0, 2, 1, 4, 3, 7 ,6] <- create and insert 7
-                //   newKeys:  [0, 2, 1, 4, 3, 7, 6]
-                //                     newHead ^ newTail
-                //
-                // * Note that the order of the if/else clauses is not
-                //   important to the algorithm, as long as the null checks
-                //   come first (to ensure we're always working on valid old
-                //   parts) and that the final else clause comes last (since
-                //   that's where the expensive moves occur). The order of
-                //   remaining clauses is is just a simple guess at which cases
-                //   will be most common.
-                //
-                // * TODO(kschaaf) Note, we could calculate the longest
-                //   increasing subsequence (LIS) of old items in new position,
-                //   and only move those not in the LIS set. However that costs
-                //   O(nlogn) time and adds a bit more code, and only helps
-                //   make rare types of mutations require fewer moves. The
-                //   above handles removes, adds, reversal, swaps, and single
-                //   moves of contiguous items in linear time, in the minimum
-                //   number of moves. As the number of multiple moves where LIS
-                //   might help approaches a random shuffle, the LIS
-                //   optimization becomes less helpful, so it seems not worth
-                //   the code at this point. Could reconsider if a compelling
-                //   case arises.
-
-                while (oldHead <= oldTail && newHead <= newTail) {
-                  if (oldParts[oldHead] === null) {
-                    // `null` means old part at head has already been used
-                    // below; skip
-                    oldHead++;
-                  } else if (oldParts[oldTail] === null) {
-                    // `null` means old part at tail has already been used
-                    // below; skip
-                    oldTail--;
-                  } else if (oldKeys[oldHead] === newKeys[newHead]) {
-                    // Old head matches new head; update in place
-                    newParts[newHead] =
-                        updatePart(oldParts[oldHead]!, newValues[newHead]);
-                    oldHead++;
-                    newHead++;
-                  } else if (oldKeys[oldTail] === newKeys[newTail]) {
-                    // Old tail matches new tail; update in place
-                    newParts[newTail] =
-                        updatePart(oldParts[oldTail]!, newValues[newTail]);
-                    oldTail--;
-                    newTail--;
-                  } else if (oldKeys[oldHead] === newKeys[newTail]) {
-                    // Old head matches new tail; update and move to new tail
-                    newParts[newTail] =
-                        updatePart(oldParts[oldHead]!, newValues[newTail]);
-                    insertPartBefore(
-                        containerPart,
-                        oldParts[oldHead]!,
-                        newParts[newTail + 1]);
-                    oldHead++;
-                    newTail--;
-                  } else if (oldKeys[oldTail] === newKeys[newHead]) {
-                    // Old tail matches new head; update and move to new head
-                    newParts[newHead] =
-                        updatePart(oldParts[oldTail]!, newValues[newHead]);
-                    insertPartBefore(
-                        containerPart, oldParts[oldTail]!, oldParts[oldHead]!);
-                    oldTail--;
-                    newHead++;
-                  } else {
-                    if (newKeyToIndexMap === undefined) {
-                      // Lazily generate key-to-index maps, used for removals &
-                      // moves below
-                      newKeyToIndexMap = generateMap(newKeys, newHead, newTail);
-                      oldKeyToIndexMap = generateMap(oldKeys, oldHead, oldTail);
-                    }
-                    if (!newKeyToIndexMap.has(oldKeys[oldHead])) {
-                      // Old head is no longer in new list; remove
-                      removePart(oldParts[oldHead]!);
-                      oldHead++;
-                    } else if (!newKeyToIndexMap.has(oldKeys[oldTail])) {
-                      // Old tail is no longer in new list; remove
-                      removePart(oldParts[oldTail]!);
-                      oldTail--;
-                    } else {
-                      // Any mismatches at this point are due to additions or
-                      // moves; see if we have an old part we can reuse and move
-                      // into place
-                      const oldIndex = oldKeyToIndexMap.get(newKeys[newHead]);
-                      const oldPart =
-                          oldIndex !== undefined ? oldParts[oldIndex] : null;
-                      if (oldPart === null) {
-                        // No old part for this value; create a new one and
-                        // insert it
-                        const newPart = createAndInsertPart(
-                            containerPart, oldParts[oldHead]!);
-                        updatePart(newPart, newValues[newHead]);
-                        newParts[newHead] = newPart;
-                      } else {
-                        // Reuse old part
-                        newParts[newHead] =
-                            updatePart(oldPart, newValues[newHead]);
-                        insertPartBefore(
-                            containerPart, oldPart, oldParts[oldHead]!);
-                        // This marks the old part as having been used, so that
-                        // it will be skipped in the first two checks above
-                        oldParts[oldIndex as number] = null;
-                      }
-                      newHead++;
-                    }
-                  }
-                }
-                // Add parts for any remaining new values
-                while (newHead <= newTail) {
-                  // For all remaining additions, we insert before last new
-                  // tail, since old pointers are no longer valid
-                  const newPart =
-                      createAndInsertPart(containerPart, newParts[newTail + 1]);
-                  updatePart(newPart, newValues[newHead]);
-                  newParts[newHead++] = newPart;
-                }
-                // Remove any remaining unused old parts
-                while (oldHead <= oldTail) {
-                  const oldPart = oldParts[oldHead++];
-                  if (oldPart !== null) {
-                    removePart(oldPart);
-                  }
-                }
-                // Save order of new parts for next round
-                partListCache.set(containerPart, newParts);
-                keyListCache.set(containerPart, newKeys);
-              };
-            }) as
-    <T>(items: Iterable<T>,
-        keyFnOrTemplate: KeyFn<T>|ItemTemplate<T>,
-        template?: ItemTemplate<T>) => DirectiveFn;
+      while (oldHead <= oldTail && newHead <= newTail) {
+        if (oldParts[oldHead] === null) {
+          // `null` means old part at head has already been used
+          // below; skip
+          oldHead++;
+        } else if (oldParts[oldTail] === null) {
+          // `null` means old part at tail has already been used
+          // below; skip
+          oldTail--;
+        } else if (oldKeys[oldHead] === newKeys[newHead]) {
+          // Old head matches new head; update in place
+          newParts[newHead] =
+              updatePart(oldParts[oldHead]!, newValues[newHead]);
+          oldHead++;
+          newHead++;
+        } else if (oldKeys[oldTail] === newKeys[newTail]) {
+          // Old tail matches new tail; update in place
+          newParts[newTail] =
+              updatePart(oldParts[oldTail]!, newValues[newTail]);
+          oldTail--;
+          newTail--;
+        } else if (oldKeys[oldHead] === newKeys[newTail]) {
+          // Old head matches new tail; update and move to new tail
+          newParts[newTail] =
+              updatePart(oldParts[oldHead]!, newValues[newTail]);
+          insertPartBefore(
+              containerPart, oldParts[oldHead]!, newParts[newTail + 1]);
+          oldHead++;
+          newTail--;
+        } else if (oldKeys[oldTail] === newKeys[newHead]) {
+          // Old tail matches new head; update and move to new head
+          newParts[newHead] =
+              updatePart(oldParts[oldTail]!, newValues[newHead]);
+          insertPartBefore(
+              containerPart, oldParts[oldTail]!, oldParts[oldHead]!);
+          oldTail--;
+          newHead++;
+        } else {
+          if (newKeyToIndexMap === undefined) {
+            // Lazily generate key-to-index maps, used for removals &
+            // moves below
+            newKeyToIndexMap = generateMap(newKeys, newHead, newTail);
+            oldKeyToIndexMap = generateMap(oldKeys, oldHead, oldTail);
+          }
+          if (!newKeyToIndexMap.has(oldKeys[oldHead])) {
+            // Old head is no longer in new list; remove
+            removePart(oldParts[oldHead]!);
+            oldHead++;
+          } else if (!newKeyToIndexMap.has(oldKeys[oldTail])) {
+            // Old tail is no longer in new list; remove
+            removePart(oldParts[oldTail]!);
+            oldTail--;
+          } else {
+            // Any mismatches at this point are due to additions or
+            // moves; see if we have an old part we can reuse and move
+            // into place
+            const oldIndex = oldKeyToIndexMap.get(newKeys[newHead]);
+            const oldPart = oldIndex !== undefined ? oldParts[oldIndex] : null;
+            if (oldPart === null) {
+              // No old part for this value; create a new one and
+              // insert it
+              const newPart =
+                  createAndInsertPart(containerPart, oldParts[oldHead]!);
+              updatePart(newPart, newValues[newHead]);
+              newParts[newHead] = newPart;
+            } else {
+              // Reuse old part
+              newParts[newHead] = updatePart(oldPart, newValues[newHead]);
+              insertPartBefore(containerPart, oldPart, oldParts[oldHead]!);
+              // This marks the old part as having been used, so that
+              // it will be skipped in the first two checks above
+              oldParts[oldIndex as number] = null;
+            }
+            newHead++;
+          }
+        }
+      }
+      // Add parts for any remaining new values
+      while (newHead <= newTail) {
+        // For all remaining additions, we insert before last new
+        // tail, since old pointers are no longer valid
+        const newPart =
+            createAndInsertPart(containerPart, newParts[newTail + 1]);
+        updatePart(newPart, newValues[newHead]);
+        newParts[newHead++] = newPart;
+      }
+      // Remove any remaining unused old parts
+      while (oldHead <= oldTail) {
+        const oldPart = oldParts[oldHead++];
+        if (oldPart !== null) {
+          removePart(oldPart);
+        }
+      }
+      // Save order of new parts for next round
+      partListCache.set(containerPart, newParts);
+      keyListCache.set(containerPart, newKeys);
+    });

--- a/src/directives/unsafe-html.ts
+++ b/src/directives/unsafe-html.ts
@@ -34,21 +34,24 @@ const previousValues = new WeakMap<NodePart, PreviousValue>();
  * sanitized or escaped, as it may lead to cross-site-scripting
  * vulnerabilities.
  */
-export const unsafeHTML = directive((value: unknown) => (part: Part): void => {
-  if (!(part instanceof NodePart)) {
-    throw new Error('unsafeHTML can only be used in text bindings');
-  }
+export const unsafeHTML =
+    directive((value: unknown) => value, (part: Part, value: unknown) => {
+      if (!(part instanceof NodePart)) {
+        throw new Error('unsafeHTML can only be used in text bindings');
+      }
 
-  const previousValue = previousValues.get(part);
+      const previousValue = previousValues.get(part);
 
-  if (previousValue !== undefined && isPrimitive(value) &&
-      value === previousValue.value && part.value === previousValue.fragment) {
-    return;
-  }
+      if (previousValue !== undefined && isPrimitive(value) &&
+          value === previousValue.value &&
+          part.value === previousValue.fragment) {
+        return;
+      }
 
-  const template = document.createElement('template');
-  template.innerHTML = value as string;  // innerHTML casts to string internally
-  const fragment = document.importNode(template.content, true);
-  part.setValue(fragment);
-  previousValues.set(part, {value, fragment});
-});
+      const template = document.createElement('template');
+      template.innerHTML =
+          value as string;  // innerHTML casts to string internally
+      const fragment = document.importNode(template.content, true);
+      part.setValue(fragment);
+      previousValues.set(part, {value, fragment});
+    });

--- a/src/directives/until.ts
+++ b/src/directives/until.ts
@@ -48,57 +48,58 @@ const _infinity = 0x7fffffff;
  *     const content = fetch('./content.txt').then(r => r.text());
  *     html`${until(content, html`<span>Loading...</span>`)}`
  */
-export const until = directive((...args: unknown[]) => (part: Part) => {
-  let state = _state.get(part)!;
-  if (state === undefined) {
-    state = {
-      lastRenderedIndex: _infinity,
-      values: [],
-    };
-    _state.set(part, state);
-  }
-  const previousValues = state.values;
-  let previousLength = previousValues.length;
-  state.values = args;
+export const until =
+    directive((...args: unknown[]) => args, (part: Part, args: unknown[]) => {
+      let state = _state.get(part)!;
+      if (state === undefined) {
+        state = {
+          lastRenderedIndex: _infinity,
+          values: [],
+        };
+        _state.set(part, state);
+      }
+      const previousValues = state.values;
+      let previousLength = previousValues.length;
+      state.values = args;
 
-  for (let i = 0; i < args.length; i++) {
-    // If we've rendered a higher-priority value already, stop.
-    if (i > state.lastRenderedIndex) {
-      break;
-    }
+      for (let i = 0; i < args.length; i++) {
+        // If we've rendered a higher-priority value already, stop.
+        if (i > state.lastRenderedIndex) {
+          break;
+        }
 
-    const value = args[i];
+        const value = args[i];
 
-    // Render non-Promise values immediately
-    if (isPrimitive(value) ||
-        typeof (value as {then?: unknown}).then !== 'function') {
-      part.setValue(value);
-      state.lastRenderedIndex = i;
-      // Since a lower-priority value will never overwrite a higher-priority
-      // synchronous value, we can stop processing now.
-      break;
-    }
+        // Render non-Promise values immediately
+        if (isPrimitive(value) ||
+            typeof (value as {then?: unknown}).then !== 'function') {
+          part.setValue(value);
+          state.lastRenderedIndex = i;
+          // Since a lower-priority value will never overwrite a higher-priority
+          // synchronous value, we can stop processing now.
+          break;
+        }
 
-    // If this is a Promise we've already handled, skip it.
-    if (i < previousLength && value === previousValues[i]) {
-      continue;
-    }
+        // If this is a Promise we've already handled, skip it.
+        if (i < previousLength && value === previousValues[i]) {
+          continue;
+        }
 
-    // We have a Promise that we haven't seen before, so priorities may have
-    // changed. Forget what we rendered before.
-    state.lastRenderedIndex = _infinity;
-    previousLength = 0;
+        // We have a Promise that we haven't seen before, so priorities may have
+        // changed. Forget what we rendered before.
+        state.lastRenderedIndex = _infinity;
+        previousLength = 0;
 
-    Promise.resolve(value).then((resolvedValue: unknown) => {
-      const index = state.values.indexOf(value);
-      // If state.values doesn't contain the value, we've re-rendered without
-      // the value, so don't render it. Then, only render if the value is
-      // higher-priority than what's already been rendered.
-      if (index > -1 && index < state.lastRenderedIndex) {
-        state.lastRenderedIndex = index;
-        part.setValue(resolvedValue);
-        part.commit();
+        Promise.resolve(value).then((resolvedValue: unknown) => {
+          const index = state.values.indexOf(value);
+          // If state.values doesn't contain the value, we've re-rendered
+          // without the value, so don't render it. Then, only render if the
+          // value is higher-priority than what's already been rendered.
+          if (index > -1 && index < state.lastRenderedIndex) {
+            state.lastRenderedIndex = index;
+            part.setValue(resolvedValue);
+            part.commit();
+          }
+        });
       }
     });
-  }
-});

--- a/src/lib/directive.ts
+++ b/src/lib/directive.ts
@@ -79,5 +79,5 @@ export const directive =
 
 export const isDirective =
     <P extends Part, T>(o: unknown): o is PartialDirective<P, T> => {
-      return typeof o === 'object' && directives.has(o as object);
+      return typeof o === 'object' && o !== null && directives.has(o);
     };

--- a/src/lib/parts.ts
+++ b/src/lib/parts.ts
@@ -211,9 +211,10 @@ export class AttributePart implements Part {
 
   commit() {
     while (isDirective(this.value)) {
-      const directive = this.value;
+      const partial = this.value;
+      const directive = partial[0];
       this.value = noChange;
-      directive(this);
+      directive(this, partial[1]);
     }
     if (this.value === noChange) {
       return;
@@ -290,9 +291,10 @@ export class NodePart implements Part {
 
   commit() {
     while (isDirective(this.__pendingValue)) {
-      const directive = this.__pendingValue;
+      const partial = this.__pendingValue;
+      const directive = partial[0];
       this.__pendingValue = noChange;
-      directive(this);
+      directive(this, partial[1]);
     }
     const value = this.__pendingValue;
     if (value === noChange) {
@@ -476,9 +478,10 @@ export class BooleanAttributePart implements Part {
 
   commit() {
     while (isDirective(this.__pendingValue)) {
-      const directive = this.__pendingValue;
+      const partial = this.__pendingValue;
+      const directive = partial[0];
       this.__pendingValue = noChange;
-      directive(this);
+      directive(this, partial[1]);
     }
     if (this.__pendingValue === noChange) {
       return;
@@ -583,9 +586,10 @@ export class EventPart implements Part {
 
   commit() {
     while (isDirective(this.__pendingValue)) {
-      const directive = this.__pendingValue;
+      const partial = this.__pendingValue;
+      const directive = partial[0];
       this.__pendingValue = noChange as EventHandlerWithOptions;
-      directive(this);
+      directive(this, partial[1]);
     }
     if (this.__pendingValue === noChange) {
       return;

--- a/src/lit-html.ts
+++ b/src/lit-html.ts
@@ -34,7 +34,7 @@ import {defaultTemplateProcessor} from './lib/default-template-processor.js';
 import {SVGTemplateResult, TemplateResult} from './lib/template-result.js';
 
 export {DefaultTemplateProcessor, defaultTemplateProcessor} from './lib/default-template-processor.js';
-export {directive, DirectiveFn, isDirective} from './lib/directive.js';
+export {directive, isDirective} from './lib/directive.js';
 // TODO(justinfagnani): remove line when we get NodePart moving methods
 export {removeNodes, reparentNodes} from './lib/dom.js';
 export {noChange, nothing, Part} from './lib/part.js';

--- a/src/test/lib/render_test.ts
+++ b/src/test/lib/render_test.ts
@@ -777,7 +777,7 @@ suite('render()', () => {
 
   suite('directives', () => {
     test('renders directives on NodeParts', () => {
-      const fooDirective = directive(() => (part: Part) => {
+      const fooDirective = directive(() => undefined, (part: Part) => {
         part.setValue('foo');
       });
 
@@ -787,7 +787,7 @@ suite('render()', () => {
     });
 
     test('renders directives on AttributeParts', () => {
-      const fooDirective = directive(() => (part: AttributePart) => {
+      const fooDirective = directive(() => undefined, (part: AttributePart) => {
         part.setValue('foo');
       });
 
@@ -797,7 +797,7 @@ suite('render()', () => {
     });
 
     test('renders directives on PropertyParts', () => {
-      const fooDirective = directive(() => (part: AttributePart) => {
+      const fooDirective = directive(() => undefined, (part: AttributePart) => {
         part.setValue(1234);
       });
 
@@ -817,13 +817,17 @@ suite('render()', () => {
         <div @test-event=${(e: Event) => {
                 event = e;
               }}>
-          ${directive(() => (part: NodePart) => {
-                // This emulates a custom element that fires an event in its
-                // connectedCallback
-                part.startNode.dispatchEvent(new CustomEvent('test-event', {
-                  bubbles: true,
-                }));
-              })()}
+          ${
+                  directive(
+                      () => undefined,
+                      (part: NodePart) => {
+                        // This emulates a custom element that fires an event in
+                        // its connectedCallback
+                        part.startNode.dispatchEvent(
+                            new CustomEvent('test-event', {
+                              bubbles: true,
+                            }));
+                      })()}
         </div>`,
               container);
           document.body.removeChild(container);
@@ -836,7 +840,7 @@ suite('render()', () => {
           // This tests that attribute directives are called in the commit
           // phase, not the setValue phase
           let event = undefined;
-          const fire = directive(() => (part: AttributePart) => {
+          const fire = directive(() => undefined, (part: AttributePart) => {
             part.committer.element.dispatchEvent(new CustomEvent('test-event', {
               bubbles: true,
             }));


### PR DESCRIPTION
This avoids the closure produced when using a directive. In a basic example, directives were:

```typescript
(value: unknown) => ((part: Part) => void)
```

That inner closure to wrap over the value by the caller is **expensive**. Now, we generate a simple tuple to store the value and directive's inner function (🚲🏡 the naming here), which is much easier to generate and GC.

**But the [perf improvements](https://jsbench.github.io/#759b99dbded0441f69b3cd7722e34f3b)!** All those closures are killing us with GC time. Allocating a short tuple is a lot less expensive. If we realllly wanted, we could even do away with the `WeakMap` here and [really reap some benefits](https://jsbench.github.io/#4f3d62eb97bd1c992a5257d34fcebea0).