### PR TITLE
Use TemplateStringsArray.raw strings to render

### DIFF
--- a/src/lib/shady-render.ts
+++ b/src/lib/shady-render.ts
@@ -61,7 +61,7 @@ const shadyTemplateFactory = (scopeName: string) =>
       let templateCache = templateCaches.get(cacheKey);
       if (templateCache === undefined) {
         templateCache = {
-          stringsArray: new WeakMap<TemplateStringsArray, Template>(),
+          stringsArray: new WeakMap<readonly string[], Template>(),
           keyString: new Map<string, Template>()
         };
         templateCaches.set(cacheKey, templateCache);

--- a/src/lib/template-factory.ts
+++ b/src/lib/template-factory.ts
@@ -49,7 +49,7 @@ export function templateFactory(result: TemplateResult) {
   let templateCache = templateCaches.get(result.type);
   if (templateCache === undefined) {
     templateCache = {
-      stringsArray: new WeakMap<TemplateStringsArray, Template>(),
+      stringsArray: new WeakMap<readonly string[], Template>(),
       keyString: new Map<string, Template>()
     };
     templateCaches.set(result.type, templateCache);
@@ -89,7 +89,7 @@ export function templateFactory(result: TemplateResult) {
  * joining the strings array.
  */
 export type templateCache = {
-  readonly stringsArray: WeakMap<TemplateStringsArray, Template>; //
+  readonly stringsArray: WeakMap<readonly string[], Template>; //
   readonly keyString: Map<string, Template>;
 };
 

--- a/src/lib/template-result.ts
+++ b/src/lib/template-result.ts
@@ -27,7 +27,7 @@ const commentMarker = ` ${marker} `;
  * interpolated expressions.
  */
 export class TemplateResult {
-  readonly strings: TemplateStringsArray;
+  readonly strings: readonly string[];
   readonly values: ReadonlyArray<unknown>;
   readonly type: string;
   readonly processor: TemplateProcessor;
@@ -35,7 +35,7 @@ export class TemplateResult {
   constructor(
       strings: TemplateStringsArray, values: ReadonlyArray<unknown>,
       type: string, processor: TemplateProcessor) {
-    this.strings = strings;
+    this.strings = strings.raw;
     this.values = values;
     this.type = type;
     this.processor = processor;

--- a/src/test/lib/render_test.ts
+++ b/src/test/lib/render_test.ts
@@ -54,6 +54,11 @@ suite('render()', () => {
       assert.equal(stripExpressionMarkers(container.innerHTML), 'test');
     });
 
+    test('renders js escapes as text', () => {
+      render(html`te\nst`, container);
+      assert.equal(stripExpressionMarkers(container.innerHTML), 'te\\nst');
+    });
+
     test('renders a string', () => {
       render(html`<div>${'foo'}</div>`, container);
       assert.equal(
@@ -903,6 +908,14 @@ suite('render()', () => {
     test('renders no comments inside textContent', () => {
       render(html`<style>${''}</style>`, container);
       assert.equal(container.firstElementChild!.textContent, '');
+    });
+
+    test('renders escaped unicode characters', () => {
+      render(
+          html`<style>li:before { content: "\0025a0  " }</style>`, container);
+      assert.equal(
+          container.firstElementChild!.textContent,
+          'li:before { content: "\\0025a0  " }');
     });
 
     test('renders style tags with expressions correctly', () => {


### PR DESCRIPTION
This is a breaking change.

Now, any JS escape chars will be printed as if they were literal text characters. Eg, `\n` won't print a newline, it'll print "\\" and "n". If you want to print escape chars, use HTML's percent escapes or pass a string inside a dynamic Part.

Fixes https://github.com/Polymer/lit-html/issues/348.