### PR TITLE
Fix typo in trusted types

### DIFF
--- a/src/lib/template-result.ts
+++ b/src/lib/template-result.ts
@@ -35,7 +35,7 @@ function convertConstantTemplateStringToTrustedHTML(value: string): string|
   // TrustedTypes have been renamed to trustedTypes
   // (https://github.com/WICG/trusted-types/issues/177)
   const trustedTypes =
-      (w.trustedTypes || w.trustedTypes) as TrustedTypePolicyFactory;
+      (w.trustedTypes || w.TrustedTypes) as TrustedTypePolicyFactory;
   if (trustedTypes && !policy) {
     policy = trustedTypes.createPolicy('lit-html', {createHTML: (s) => s});
   }


### PR DESCRIPTION
We want to check for either trustedTypes or TrustedTypes here, until the capitalized TrustedTypes implementation is gone