### PR TITLE
Draft: Add animation directives

### DIFF
--- a/demo/animate/index.html
+++ b/demo/animate/index.html
@@ -118,10 +118,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
           <button @click=${() => renderDemo(!showFab, currentPage)}>Toggle fab</button>
 
-          ${animate(showFab ? html`<div class="fab"></div>` : nothing, { prefix: 'fab' })}
+          ${animate(showFab ? html`<div class="fab"></div>` : nothing, { entry: 'fab-entry', exit: 'fab-exit' })}
         </div>
 
-        ${animate(currentPage, { prefix: 'page' })}
+        ${animate(currentPage, { entry: 'page-entry', exit: 'page-exit' })}
 
       `, document.getElementById('demo'));
     }

--- a/demo/animate/index.html
+++ b/demo/animate/index.html
@@ -1,0 +1,133 @@
+<!--
+@license
+Copyright (c) 2019 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<!doctype html>
+<html>
+
+<head>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+
+  <style>
+    body {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      margin: 0;
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    #demo {
+      width: 100%;
+      max-width: 800px;
+    }
+
+    .buttons {
+      padding: 36px 0;
+    }
+
+    .page {
+      padding: 16px;
+      background-color: white;
+      box-shadow: 0 3px 6px rgba(0, 0, 0, 0.16), 0 3px 6px rgba(0, 0, 0, 0.23);
+      border-radius: 4px;
+      max-width: 800px;
+    }
+
+    h2 {
+      margin-top: 0;
+    }
+
+    @keyframes page-entry {
+      from {
+        transform: translateX(100vw)
+      }
+    }
+
+    @keyframes page-exit {
+      to {
+        transform: translateX(-100vw)
+      }
+    }
+
+    .page-entry {
+      animation: page-entry 600ms;
+      position: absolute;
+    }
+
+    .page-exit {
+      animation: page-exit 600ms;
+      position: absolute;
+    }
+
+    .fab {
+      position: fixed;
+      bottom: 48px;
+      right: 48px;
+      width: 48px;
+      height: 48px;
+      border-radius: 50%;
+      box-shadow: 0 3px 6px rgba(0, 0, 0, 0.16), 0 3px 6px rgba(0, 0, 0, 0.23);
+      background-color: blue;
+      transform-origin: center;
+    }
+
+    @keyframes fab-entry {
+      from { transform: scale(0) }
+    }
+
+    @keyframes fab-exit {
+      to { transform: scale(0) }
+    }
+
+    .fab.fab-entry {
+      animation: fab-entry 300ms;
+    }
+
+    .fab.fab-exit {
+      animation: fab-exit 300ms;
+    }
+  </style>
+</head>
+
+<body>
+  <div id="demo">
+
+  </div>
+
+  <script type="module">
+    import { html, render, nothing } from '../../lit-html.js';
+    import { animate } from '../../directives/animate.js';
+    import pages from './pages.js';
+
+    function renderDemo(showFab, currentPage) {
+      render(html`
+        <div class="buttons">
+          <button @click=${() => {
+            const i = pages.indexOf(currentPage);
+            renderDemo(showFab, pages[i + 1 < pages.length ? i + 1 : 0]);
+          }}>Next page</button>
+
+          <button @click=${() => renderDemo(!showFab, currentPage)}>Toggle fab</button>
+
+          ${animate(showFab ? html`<div class="fab"></div>` : nothing, { prefix: 'fab' })}
+        </div>
+
+        ${animate(currentPage, { prefix: 'page' })}
+
+      `, document.getElementById('demo'));
+    }
+
+    renderDemo(false, pages[0]);
+  </script>
+</body>
+
+</html>

--- a/demo/animate/pages.js
+++ b/demo/animate/pages.js
@@ -1,0 +1,24 @@
+import { html } from '../../lit-html.js';
+
+const pageA = html`
+  <div class="page">
+    <h2>Page 1</h1>
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla faucibus mauris sit amet justo finibus, ac scelerisque dolor dapibus. Donec leo tortor, accumsan sit amet blandit sed, lobortis non magna. Aenean volutpat ornare magna ut ornare. Nam sed iaculis felis. Donec vel nunc a risus cursus accumsan. Duis at eros et est finibus porta. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Maecenas vehicula posuere lectus. Donec feugiat, tellus et rutrum semper, turpis mi consectetur odio, in condimentum arcu nisl placerat tellus. Nunc pretium ut ante eu malesuada. Aliquam eget dolor eu massa viverra ultrices. Proin sit amet orci vel nulla feugiat suscipit quis nec turpis. Mauris in tincidunt risus, vel mattis elit. Nam vel risus ut enim blandit ullamcorper. Quisque ullamcorper leo ac nisi imperdiet, venenatis posuere eros scelerisque. Mauris vitae malesuada lacus.
+  </div>
+`;
+
+const pageB = html`
+  <div class="page">
+    <h2>Page 2</h1>
+    Praesent pharetra, est ut bibendum ullamcorper, leo magna aliquam erat, ut commodo ligula quam nec neque. Nunc rutrum mattis risus non dignissim. Sed pretium facilisis odio lobortis condimentum. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Phasellus finibus eros sed elementum scelerisque. Duis vitae suscipit tellus. Sed tellus risus, imperdiet quis sapien id, tristique molestie orci. Proin a nisl eu neque rutrum rhoncus sed sed lectus. Maecenas ornare, ex nec feugiat consectetur, eros nibh malesuada nisl, sit amet finibus dui massa ut ex. Etiam ac purus sit amet nulla semper imperdiet sit amet eget ex. Suspendisse sit amet dui in magna dapibus lobortis. Donec ac tristique augue, id hendrerit justo. Quisque nec nisi eu nulla lacinia aliquet. Maecenas sodales vulputate quam ut ullamcorper. Ut risus urna, ornare vel consequat vel, consectetur in quam. Nullam id placerat nunc.
+  </div>
+`;
+
+const pageC = html`
+  <div class="page">
+    <h2>Page 3</h1>
+    Aenean aliquam consequat tortor, vitae faucibus magna ultricies nec. In rhoncus placerat tortor sed fermentum. Sed viverra mi et auctor hendrerit. Nulla dignissim, eros non porta condimentum, dolor mauris tincidunt ex, et mollis turpis lorem in dolor. Fusce et risus in quam efficitur blandit. Interdum et malesuada fames ac ante ipsum primis in faucibus. Cras hendrerit elementum lacus ac vehicula.
+  </div>
+`;
+
+export default [pageA, pageB, pageC];

--- a/demo/track-animation/index.html
+++ b/demo/track-animation/index.html
@@ -1,0 +1,69 @@
+<!--
+@license
+Copyright (c) 2019 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<!doctype html>
+<html>
+
+<head>
+  <style>
+    body {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      margin: 0;
+    }
+
+    .search-bar {
+      width: 100px;
+      transition: width 600ms ease-in-out;
+    }
+
+    .search-bar[expanded] {
+      width: 600px;
+    }
+
+    .search-bar[expanded][animating] {
+      border: 1px solid blue;
+    }
+
+    .search-bar:not([expanded])[animating] {
+      border: 1px solid red;
+    }
+  </style>
+</head>
+
+<body>
+  <div id="demo"></div>
+
+  <script type="module">
+    import { html, render } from '../../lit-html.js';
+    import { trackTransition } from '../../directives/track-transition.js';
+
+    function renderDemo(searchExpanded) {
+      render(html`
+        <div>
+          <input
+            class="search-bar"
+            placeholder="Search"
+            ?expanded=${searchExpanded}
+            ?animating=${trackTransition('width')}
+          >
+
+          <button @click=${() => renderDemo(!searchExpanded)}>
+            Toggle search
+          </button>
+        </div>
+      `, document.getElementById('demo'));
+    }
+
+    renderDemo(false);
+  </script>
+</body>
+
+</html>

--- a/src/directives/animate.ts
+++ b/src/directives/animate.ts
@@ -18,19 +18,20 @@ import { NodePart } from "../lib/parts.js";
 import { TemplateResult } from "../lib/template-result.js";
 
 export interface AnimateData {
-  element?: Element;
   value?: unknown;
+  element?: HTMLElement;
   activePart: NodePart;
   inactivePart: NodePart;
 }
 
 export interface AnimateOptions {
-  prefix: string;
+  entry?: string;
+  exit?: string;
 }
 
 const previousData = new WeakMap<NodePart, AnimateData>();
 
-function shouldAnimate(a: any, b: any) {
+function renderValueChanged(a: any, b: any) {
   if (a instanceof TemplateResult && b instanceof TemplateResult) {
     return a.strings !== b.strings;
   } else {
@@ -39,12 +40,57 @@ function shouldAnimate(a: any, b: any) {
 }
 
 /** Finds element in-between the two given nodes. */
-function findRenderedElement(start: Node, end: Node): Element | undefined {
+function findRenderedElement(start: Node, end: Node): HTMLElement | undefined {
   let current: Node | null = start;
   while (current && current.nodeType !== 1 /* Node.ELEMENT_NODE */ && current !== end) {
     current = current.nextSibling;
   }
-  return current && current.nodeType === 1 /* Node.ELEMENT_NODE */ ? current as Element : undefined;
+  return current && current.nodeType === 1 /* Node.ELEMENT_NODE */ ? current as HTMLElement : undefined;
+}
+
+/**
+ * Resolves when all animations on the element have finished, or when another animation was triggered.
+ * @param element the element to animate on
+ * @param animation the class which triggers the animation
+ */
+function runAnimation(el: HTMLElement, animation: string) {
+  return new Promise<void>((resolve) => {
+    const animations = new Set<string>();
+
+    const done = () => {
+      el.classList.remove(animation);
+      el.removeEventListener('animationstart', onStart);
+      el.removeEventListener('animationcancel', onEndOrCancel);
+      el.removeEventListener('animationend', onEndOrCancel);
+      resolve();
+    };
+
+    const onStart = (e: AnimationEvent) => {
+      if (e.target === el) {
+        animations.add(e.animationName)
+      }
+    };
+
+    const onEndOrCancel = (e: AnimationEvent) => {
+      if (!el.classList.contains(animation)) {
+        // class is gone, which means this animation was raced by another
+        done();
+        return;
+      }
+
+      if (e.target === el) {
+        animations.delete(e.animationName);
+        if (animations.size === 0) {
+          done();
+        }
+      }
+    };
+
+    el.addEventListener('animationstart', onStart);
+    el.addEventListener('animationcancel', onEndOrCancel);
+    el.addEventListener('animationend', onEndOrCancel);
+    el.classList.add(animation);
+  });
 }
 
 /**
@@ -52,11 +98,11 @@ function findRenderedElement(start: Node, end: Node): Element | undefined {
  *
  * When the template rendered by this directive changes, a class is added to the first rendered
  * element of the previous template and to the first rendered element of the new template. After
- * an animation of the same name is finished, the class is removed and the previous template is
+ * the animations on those elements are finished, the class is removed and the previous template is
  * removed from the DOM.
  *
- * In the second parameter, a prefix must be given which is used to create the class and animation
- * name listened for.
+ * In the options parameter you specify which class should be set to play the entry or exit animation.
+ * If a value is left empty, an animation is not played for that event.
  *
  * @param value the value to render, must be a TemplateResult if it should be animated
  * @param options animation options
@@ -84,26 +130,21 @@ function findRenderedElement(start: Node, end: Node): Element | undefined {
  *  import { html, nothing } from 'lit-html';
  *  import { animate } from 'lit-html/directives/animate.js';
  *
- *  ${animate(showFoo ? html`<div>Foo</div>` : nothing, { prefix: 'foo' })}
+ *  ${animate(showFoo ? html`<div>Foo</div>` : nothing, { entry: 'foo-entry', exit: 'foo-exit' })}
  * `
  * ```
  */
-export const animate = directive((value: unknown, options: AnimateOptions) => (parentPart: Part) => {
+export const animate = directive((value: unknown, options: AnimateOptions = {}) => (parentPart: Part) => {
   if (!(parentPart instanceof NodePart)) {
     throw new Error('animate can only be used in a NodePart');
   }
-
-  if (!options) {
-    throw new Error('Missing animate options');
-  }
-
-  const entryName = `${options.prefix}-entry`;
-  const exitName = `${options.prefix}-exit`;
+  const { entry, exit } = options;
 
   let data = previousData.get(parentPart);
   const initialRender = !data;
 
   if (!data) {
+    // first render, create child parts
     data = {
       activePart: new NodePart(parentPart.options),
       inactivePart: new NodePart(parentPart.options),
@@ -113,53 +154,56 @@ export const animate = directive((value: unknown, options: AnimateOptions) => (p
     data.activePart.appendIntoPart(parentPart);
     data.inactivePart.appendIntoPart(parentPart);
   } else {
-    // if we should not animate, only update the rendered value
-    if (!shouldAnimate(data.value, value)) {
+    if (!renderValueChanged(data.value, value)) {
+      // value or template did not change, no need to run any animations
       data.activePart.setValue(value);
       data.activePart.commit();
       return;
     }
 
-    // animate the current element out
+    // animate or remove previously rendered value
     const { element, activePart } = data;
     if (element) {
-      const handleEvent = (e: Event) => {
-        if ((e as AnimationEvent).animationName === exitName) {
+      if (exit) {
+        // cancel any existing animation
+        if (entry) {
+          element.classList.remove(entry);
+        }
+
+        // animate the current element out, then remove it
+        runAnimation(element, exit).then(() => {
           activePart.setValue(nothing);
           activePart.commit();
-          element.removeEventListener('animationend', handleEvent);
-        }
-      };
-      element.addEventListener('animationend', handleEvent);
-
-      element.classList.remove(entryName);
-      element.classList.add(exitName);
+        });
+      } else {
+        // no need to animate, just remove it
+        activePart.setValue(nothing);
+        activePart.commit();
+      }
     }
   }
 
-  // render into the inactive part, so that the previous element can animate out
+  // swap the active/inactive parts
   const previousPart = data.activePart;
   data.activePart = data.inactivePart;
   data.inactivePart = previousPart;
 
+  // render the new template
   data.activePart.setValue(value);
   data.activePart.commit();
 
+  // look for the rendered element
   const element = findRenderedElement(data.activePart.startNode, data.activePart.endNode);
   data.element = element;
   data.value = value;
 
-  // animate rendered element if this isn't the initial render
-  if (!initialRender && element) {
-    const handleEvent = (e: Event) => {
-      if ((e as AnimationEvent).animationName === entryName) {
-        element.classList.remove(entryName);
-        element.removeEventListener('animationend', handleEvent);
-      }
-    };
-    element.addEventListener('animationend', handleEvent);
+  // cancel an existing exit animation, this can occur when quickly toggling templates
+  if (exit && element) {
+    element.classList.remove(exit);
+  }
 
-    element.classList.remove(exitName);
-    element.classList.add(entryName);
+  // animate rendered element if this isn't the initial render
+  if (!initialRender && element && entry) {
+    runAnimation(element, entry);
   }
 });

--- a/src/directives/animate.ts
+++ b/src/directives/animate.ts
@@ -1,0 +1,165 @@
+/**
+ * @license
+ * Copyright (c) 2019 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+import { directive } from "../lib/directive.js";
+import { Part, nothing } from "../lib/part.js";
+import { NodePart } from "../lib/parts.js";
+import { TemplateResult } from "../lib/template-result.js";
+
+export interface AnimateData {
+  element?: Element;
+  value?: unknown;
+  activePart: NodePart;
+  inactivePart: NodePart;
+}
+
+export interface AnimateOptions {
+  prefix: string;
+}
+
+const previousData = new WeakMap<NodePart, AnimateData>();
+
+function shouldAnimate(a: any, b: any) {
+  if (a instanceof TemplateResult && b instanceof TemplateResult) {
+    return a.strings !== b.strings;
+  } else {
+    return a !== b;
+  }
+}
+
+/** Finds element in-between the two given nodes. */
+function findRenderedElement(start: Node, end: Node): Element | undefined {
+  let current: Node | null = start;
+  while (current && current.nodeType !== 1 /* Node.ELEMENT_NODE */ && current !== end) {
+    current = current.nextSibling;
+  }
+  return current && current.nodeType === 1 /* Node.ELEMENT_NODE */ ? current as Element : undefined;
+}
+
+/**
+ * Enables animating DOM nodes when they are added/removed from the DOM.
+ *
+ * When the template rendered by this directive changes, a class is added to the first rendered
+ * element of the previous template and to the first rendered element of the new template. After
+ * an animation of the same name is finished, the class is removed and the previous template is
+ * removed from the DOM.
+ *
+ * In the second parameter, a prefix must be given which is used to create the class and animation
+ * name listened for.
+ *
+ * @param value the value to render, must be a TemplateResult if it should be animated
+ * @param options animation options
+ * @example:
+ * ```css
+ * @keyframes foo-entry {
+ *   from { opacity: 0 }
+ * }
+ *
+ * @keyframes foo-exit {
+ *   to { opacity: 0 }
+ * }
+ *
+ * .foo-entry {
+ *   animation: foo-entry 300ms;
+ * }
+ *
+ * .foo-exit {
+ *   animation: foo-exit 300ms;
+ * }
+ * ```
+ *
+ * ```js
+ * html`
+ *  import { html, nothing } from 'lit-html';
+ *  import { animate } from 'lit-html/directives/animate.js';
+ *
+ *  ${animate(showFoo ? html`<div>Foo</div>` : nothing, { prefix: 'foo' })}
+ * `
+ * ```
+ */
+export const animate = directive((value: unknown, options: AnimateOptions) => (parentPart: Part) => {
+  if (!(parentPart instanceof NodePart)) {
+    throw new Error('animate can only be used in a NodePart');
+  }
+
+  if (!options) {
+    throw new Error('Missing animate options');
+  }
+
+  const entryName = `${options.prefix}-entry`;
+  const exitName = `${options.prefix}-exit`;
+
+  let data = previousData.get(parentPart);
+  const initialRender = !data;
+
+  if (!data) {
+    data = {
+      activePart: new NodePart(parentPart.options),
+      inactivePart: new NodePart(parentPart.options),
+    };
+    previousData.set(parentPart, data);
+
+    data.activePart.appendIntoPart(parentPart);
+    data.inactivePart.appendIntoPart(parentPart);
+  } else {
+    // if we should not animate, only update the rendered value
+    if (!shouldAnimate(data.value, value)) {
+      data.activePart.setValue(value);
+      data.activePart.commit();
+      return;
+    }
+
+    // animate the current element out
+    const { element, activePart } = data;
+    if (element) {
+      const handleEvent = (e: Event) => {
+        if ((e as AnimationEvent).animationName === exitName) {
+          activePart.setValue(nothing);
+          activePart.commit();
+          element.removeEventListener('animationend', handleEvent);
+        }
+      };
+      element.addEventListener('animationend', handleEvent);
+
+      element.classList.remove(entryName);
+      element.classList.add(exitName);
+    }
+  }
+
+  // render into the inactive part, so that the previous element can animate out
+  const previousPart = data.activePart;
+  data.activePart = data.inactivePart;
+  data.inactivePart = previousPart;
+
+  data.activePart.setValue(value);
+  data.activePart.commit();
+
+  const element = findRenderedElement(data.activePart.startNode, data.activePart.endNode);
+  data.element = element;
+  data.value = value;
+
+  // animate rendered element if this isn't the initial render
+  if (!initialRender && element) {
+    const handleEvent = (e: Event) => {
+      if ((e as AnimationEvent).animationName === entryName) {
+        element.classList.remove(entryName);
+        element.removeEventListener('animationend', handleEvent);
+      }
+    };
+    element.addEventListener('animationend', handleEvent);
+
+    element.classList.remove(exitName);
+    element.classList.add(entryName);
+  }
+});

--- a/src/directives/track-animation.ts
+++ b/src/directives/track-animation.ts
@@ -1,0 +1,65 @@
+import { directive } from '../lib/directive.js';
+import { BooleanAttributePart } from '../lib/parts.js';
+
+interface TrackAnimationData {
+  trackedAnimations: string[];
+  activeAnimations: Set<string>;
+}
+
+const dataForPart = new WeakMap<BooleanAttributePart, TrackAnimationData>();
+
+/**
+ * Tracks animations on an element, reflecting the state to a boolean attribute.
+ *
+ * @param trackedAnimations the animation name(s) to track
+ * @example
+ * ```js
+ * html`<div ?animating=${trackAnimation('my-animation', 'my-other-animation')}></div>`
+ * ```
+ */
+export const trackAnimation = directive((...trackedAnimations: string[]) => (part: BooleanAttributePart) => {
+  if (!(part instanceof BooleanAttributePart)) {
+    throw new Error('trackAnimation can only be used in a boolean attribute');
+  }
+
+  const cachedData = dataForPart.get(part);
+  if (cachedData) {
+    // re-render, only (potentially) update tracked animations
+    cachedData.trackedAnimations = trackedAnimations;
+    return;
+  }
+
+  // first render, set up listeners
+  const data = { trackedAnimations, activeAnimations: new Set<string>() };
+  dataForPart.set(part, data);
+
+  const { element } = part;
+
+  const onStart = (e: Event) => {
+    const { animationName } = (e as AnimationEvent);
+
+    if (e.target === element && data.trackedAnimations.includes(animationName)) {
+      data.activeAnimations.add(animationName)
+      part.setValue(true);
+      part.commit();
+    }
+  };
+
+  const onEndOrCancel = (e: Event) => {
+    const { animationName } = (e as AnimationEvent);
+    if (e.target === element && data.activeAnimations.has(animationName)) {
+      data.activeAnimations.delete(animationName);
+
+      if (data.activeAnimations.size === 0) {
+        part.setValue(false);
+        part.commit();
+      }
+    }
+  };
+
+  element.addEventListener('animationstart', onStart);
+  // animationcancel is not implemented on all browsers
+  // (https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/animationcancel_event)
+  element.addEventListener('animationcancel', onEndOrCancel);
+  element.addEventListener('animationend', onEndOrCancel);
+});

--- a/src/directives/track-transition.ts
+++ b/src/directives/track-transition.ts
@@ -1,0 +1,63 @@
+import { directive } from '../lib/directive.js';
+import { BooleanAttributePart } from '../lib/parts.js';
+
+interface TrackTransitionData {
+  trackedProperties: string[];
+  activeTransitions: Set<string>;
+}
+
+const dataForPart = new WeakMap<BooleanAttributePart, TrackTransitionData>();
+
+/**
+ * Tracks transitions on an element, reflecting the state to a boolean attribute.
+ *
+ * @param trackTransition the css property name(s) to track
+ * @example
+ * ```js
+ * html`<div ?animating=${trackTransition('width', 'height')}></div>`
+ * ```
+ */
+export const trackTransition = directive((...trackedProperties: string[]) => (part: BooleanAttributePart) => {
+  if (!(part instanceof BooleanAttributePart)) {
+    throw new Error('trackTransition can only be used in a boolean attribute');
+  }
+
+  const cachedData = dataForPart.get(part);
+  if (cachedData) {
+    // re-render, only (potentially) update tracked properties
+    cachedData.trackedProperties = trackedProperties;
+    return;
+  }
+
+  // first render, set up listeners
+  const data = { trackedProperties, activeTransitions: new Set<string>() };
+  dataForPart.set(part, data);
+
+  const { element } = part;
+
+  const onStart = (e: Event) => {
+    const { propertyName } = (e as TransitionEvent);
+
+    if (e.target === element && data.trackedProperties.includes(propertyName)) {
+      data.activeTransitions.add(propertyName)
+      part.setValue(true);
+      part.commit();
+    }
+  };
+
+  const onEndOrCancel = (e: Event) => {
+    const { propertyName } = (e as TransitionEvent);
+    if (data.activeTransitions.has(propertyName)) {
+      data.activeTransitions.delete(propertyName);
+
+      if (e.target === element && data.activeTransitions.size === 0) {
+        part.setValue(false);
+        part.commit();
+      }
+    }
+  };
+
+  element.addEventListener('transitionstart', onStart);
+  element.addEventListener('transitioncancel', onEndOrCancel);
+  element.addEventListener('transitionend', onEndOrCancel);
+});


### PR DESCRIPTION
As discussed in https://github.com/Polymer/lit-html/issues/1017, these are three directives I've been working on.

I've focused on doing the animations in CSS, with the directives just there to manage/communicate the state. This can be expanded on further using web animations from javascript. I'm not sure how well supported web animations are, I don't hear much about it.

**trackAnimation / trackTransition**
The `trackAnimation` and `trackTransition` directives are pretty straightforward. You apply them on a boolean attribute and provide a list of animations/transitions to track. The attribute it set/removed based on whether there is an active animation or transition:

```js
html`
  <div ?animating=${trackAnimation('show-foo', 'hide-foo')}></div>
`;
```

This state can then be used in CSS/JS.

**animate**
Animating to/from display: none, or elements that are added/removed to/from the DOM is quite complex and impossible to do from CSS alone. The `animate` directive is intended to make this easier.

The `animate` directive should be used in a NodePart and renders whatever value is passed to it. When the value is a `TemplateResult`, it will apply a class to the first rendered child element and waits for an animation on that element to be finished.

It maintains two child parts, alternating between them as values passed to the part changes. This way it can animate the content of the previous part out while the content of the new part is being animated in.

For example to animate a float actioning button as it enters/exits:
```css
@keyframes fab-entry {
  from { transform: scale(0) }
}

@keyframes fab-exit {
  to { transform: scale(0) }
}

.fab.fab-entry {
  animation: fab-entry 300ms;
}

.fab.fab-exit {
  animation: fab-exit 300ms;
}
```

```js
html`${animate(showFab ? html`<div class="fab"></div>` : nothing, { entry: 'fab-entry', exit: 'fab-exit' })}`
```

When the element is added, it adds a `fab-entry` class until all animations on the element finish. When the element needs to be removed, it adds a `fab-exit` class and removes the element after the animation finishes.

The directive can work with any amount of templates, for example you can use it in an application router to animate page transitions:

```js
html`${animate(this._renderPage(), { entry: 'page-entry', exit: 'page-exit' })}`
```

I didn't write any tests yet, as I'd like to iron out the API first. I did add a demo to demonstrate how it works.