### PR TITLE
implements !bind attribute

### DIFF
--- a/src/lib/default-template-processor.ts
+++ b/src/lib/default-template-processor.ts
@@ -17,7 +17,7 @@
  */
 
 import {Part} from './part.js';
-import {AttributeCommitter, BooleanAttributePart, EventPart, NodePart, PropertyCommitter} from './parts.js';
+import {AttributeCommitter, BooleanAttributePart, EventPart, NodePart, PropertyCommitter, BindingPart} from './parts.js';
 import {RenderOptions} from './render-options.js';
 import {TemplateProcessor} from './template-processor.js';
 
@@ -41,6 +41,9 @@ export class DefaultTemplateProcessor implements TemplateProcessor {
     if (prefix === '.') {
       const committer = new PropertyCommitter(element, name.slice(1), strings);
       return committer.parts;
+    }
+    if (name === '!bind') {
+      return [new BindingPart(element)];
     }
     if (prefix === '@') {
       return [new EventPart(element, name.slice(1), options.eventContext)];

--- a/src/lit-html.ts
+++ b/src/lit-html.ts
@@ -38,7 +38,7 @@ export {directive, DirectiveFn, isDirective} from './lib/directive.js';
 // TODO(justinfagnani): remove line when we get NodePart moving methods
 export {removeNodes, reparentNodes} from './lib/dom.js';
 export {noChange, nothing, Part} from './lib/part.js';
-export {AttributeCommitter, AttributePart, BooleanAttributePart, EventPart, isIterable, isPrimitive, NodePart, PropertyCommitter, PropertyPart} from './lib/parts.js';
+export {AttributeCommitter, AttributePart, BooleanAttributePart, EventPart, isIterable, isPrimitive, NodePart, PropertyCommitter, PropertyPart, BindingPart} from './lib/parts.js';
 export {RenderOptions} from './lib/render-options.js';
 export {parts, render} from './lib/render.js';
 export {templateCaches, templateFactory} from './lib/template-factory.js';

--- a/src/test/lib/parts_test.ts
+++ b/src/test/lib/parts_test.ts
@@ -12,7 +12,7 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {__testOnlySetSanitizeDOMValueExperimentalMayChangeWithoutWarning} from '../../lib/parts';
+import {__testOnlySetSanitizeDOMValueExperimentalMayChangeWithoutWarning, BindingPart} from '../../lib/parts';
 import {__testOnlyClearSanitizerDoNotCallOrElse} from '../../lib/parts.js';
 import {AttributeCommitter, AttributePart, createMarker, DefaultTemplateProcessor, EventPart, html, NodePart, render, templateFactory, TemplateResult} from '../../lit-html.js';
 import {stripExpressionMarkers} from '../test-utils/strip-markers.js';
@@ -522,6 +522,32 @@ suite('Parts', () => {
     });
   });
 
+  suite('BindingPart', () => {
+    let part: BindingPart;
+    let element: HTMLElement;
+
+    setup(() => {
+      element = document.createElement('div');
+      document.body.appendChild(element);
+    });
+    test('supports passing element parameter to listener', () => {
+      part = new BindingPart(element);
+      let listenerCalled = false;
+      let rightElementPassed = false;
+
+      const listener = (_el: Element) => {
+        listenerCalled = true;
+        if (_el === element) {
+          rightElementPassed = true;
+        }
+      };
+      part.setValue(listener);
+      part.commit();
+      assert.isTrue(listenerCalled, 'listenerCalled');
+      assert.isTrue(rightElementPassed, 'rightElementPassed');
+    });
+  });
+                                                                          
   suite('EventPart', () => {
     let part: EventPart;
     let element: HTMLElement;

--- a/src/test/lib/render_test.ts
+++ b/src/test/lib/render_test.ts
@@ -14,6 +14,7 @@
 
 import {AttributePart, directive, html, noChange, NodePart, nothing, Part, render, svg, templateFactory} from '../../lit-html.js';
 import {stripExpressionMarkers} from '../test-utils/strip-markers.js';
+import {ifDefined} from '../../directives/if-defined.js';
 
 const assert = chai.assert;
 
@@ -772,6 +773,49 @@ suite('render()', () => {
       inner.dispatchEvent(new Event('test'));
       assert.isOk(event);
       assert.equal(eventPhase, Event.CAPTURING_PHASE);
+    });
+  });
+
+  suite('binding', () => {
+    setup(() => {
+      document.body.appendChild(container);
+    });
+
+    teardown(() => {
+      document.body.removeChild(container);
+    });
+
+    test('resolves directives for binding event listener', () => {
+      let target;
+      const t = (listener : any) => html`<div !bind=${listener}></div>`;
+      let listener: any = (element: Element) => target = element;
+      render(t(ifDefined(listener)), container);
+      const div = container.querySelector('div')!;
+      assert.equal(target, div);
+    });
+
+    test('allows updating binding listener', () => {
+      let listener1Called, listener2Called;
+      const t = (listener : (element : Element) => void) => html`<div !bind=${listener}></div>`;
+      let listener1: any = () => listener1Called = true;
+      render(t(listener1), container);
+      assert.equal(listener1Called, true);
+      let listener2 = () => listener2Called = true;
+      render(t(listener2), container);
+      assert.equal(listener2Called, true);
+    });
+
+    test('removes binding listeners', () => {
+      let target;
+      let listener: any = (element: Element) => target = element;
+      const t = () => html`<div !bind=${listener}></div>`;
+      render(t(), container);
+      const div = container.querySelector('div')!;
+      assert.equal(target, div);
+      listener = null;
+      target = undefined;
+      render(t(), container);
+      assert.equal(target, undefined);
     });
   });
 


### PR DESCRIPTION
Implements a default attribute !bind, which receives a listener that is called on the first commit. 
That way developers can manually add event listeners or access element methods on load.

It was designed to allow for a more modular design, when implementing more complex behaviors like event listeners for drag and drop. 