### PR TITLE
Load in nodejs for packaging treeshake able

### DIFF
--- a/src/lib/dom.ts
+++ b/src/lib/dom.ts
@@ -23,7 +23,8 @@ interface MaybePolyfilledCe extends CustomElementRegistry {
 /**
  * True if the custom elements polyfill is in use.
  */
-export const isCEPolyfill = typeof window !== 'undefined' && window.customElements != null &&
+export const isCEPolyfill = typeof window !== 'undefined' &&
+    window.customElements != null &&
     (window.customElements as MaybePolyfilledCe).polyfillWrapFlushCallback !==
         undefined;
 

--- a/src/lib/dom.ts
+++ b/src/lib/dom.ts
@@ -23,7 +23,7 @@ interface MaybePolyfilledCe extends CustomElementRegistry {
 /**
  * True if the custom elements polyfill is in use.
  */
-export const isCEPolyfill = window.customElements != null &&
+export const isCEPolyfill = typeof window !== 'undefined' && window.customElements != null &&
     (window.customElements as MaybePolyfilledCe).polyfillWrapFlushCallback !==
         undefined;
 

--- a/src/lit-html.ts
+++ b/src/lit-html.ts
@@ -56,7 +56,7 @@ declare global {
 // IMPORTANT: do not change the property name or the assignment expression.
 // This line will be used in regexes to search for lit-html usage.
 // TODO(justinfagnani): inject version number at build time
-(window['litHtmlVersions'] || (window['litHtmlVersions'] = [])).push('1.1.2');
+if (typeof window !== 'undefined') { (window['litHtmlVersions'] || (window['litHtmlVersions'] = [])).push('1.1.2'); }
 
 /**
  * Interprets a template literal as an HTML template that can efficiently

--- a/src/lit-html.ts
+++ b/src/lit-html.ts
@@ -56,7 +56,9 @@ declare global {
 // IMPORTANT: do not change the property name or the assignment expression.
 // This line will be used in regexes to search for lit-html usage.
 // TODO(justinfagnani): inject version number at build time
-if (typeof window !== 'undefined') { (window['litHtmlVersions'] || (window['litHtmlVersions'] = [])).push('1.1.2'); }
+if (typeof window !== 'undefined') {
+  (window['litHtmlVersions'] || (window['litHtmlVersions'] = [])).push('1.1.2');
+}
 
 /**
  * Interprets a template literal as an HTML template that can efficiently


### PR DESCRIPTION
I made some adjustments to make the lib loadable via import inside nodejs current as a module so we can use it and inhire from it.

- refactored checks to be conditional so the module is still loadable in nodejs for processing in advanced packaging scenarios 

## Example
This example can be build via rollup and you will get the right html version 

```
//lit-html-loader.mjs
import { html as litHtml } from 'lit-html'
import { html as strHtml } from 'str-html'
import { isNode, isBrowser, isJsdom } from './check-env-helper.mjs'
export const html = isNode ? strHtml : litHtml;

// index.mjs
import { html } from './lit-html-loader.mjs'
```

this closes: #1051 