### PR TITLE
Add live() directive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 * Added interop with the proposed Trusted Types spec: https://github.com/WICG/trusted-types ([#970](https://github.com/Polymer/lit-html/pull/970))
 * Added a sanitization system, for integrating with DOM value sanitizers to prevent XSS attacks. See the docs on the SanitizerFactory type and the setSanitizerFactory function for details.
+* Added the `live()` directive. Fixes #877
 
 
 ### Fixed

--- a/src/directives/live.ts
+++ b/src/directives/live.ts
@@ -1,0 +1,73 @@
+/**
+ * @license
+ * Copyright (c) 2019 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+import {AttributePart, BooleanAttributePart, directive, EventPart, NodePart, PropertyPart} from '../lit-html.js';
+
+/**
+ * Checks binding values against live DOM values, instead of previously bound
+ * values, when determining whether to update the value.
+ *
+ * This is useful for cases where the DOM value may change from outside of
+ * lit-html, such as with a binding to an `<input>` element's `value` property,
+ * a content editable elements text, or to a custom element that changes it's
+ * own properties or attributes.
+ *
+ * In these cases if the DOM value changes, but the value set through lit-html
+ * bindings hasn't, lit-html won't know to update the DOM value and will leave
+ * it alone. If this is not what you want - if you want to overwrite the DOM
+ * value with the bound value no matter what, then use the `live()` directive:
+ *
+ *     html`<input .value=${live(x)}>`
+ *
+ * `live()` performs a strict equality check agains the live DOM value, and if
+ * the new value is equal to the live value, does nothing. This means that
+ * `live()` should not be used when the binding will cause a type conversion. If
+ * you use `live()` with an attribute binding, make sure that only strings are
+ * passed in, or the binding will update every render.
+ */
+export const live = directive(
+    (value: unknown) => (part: NodePart|AttributePart|PropertyPart|
+                         BooleanAttributePart) => {
+      let previousValue: unknown;
+      if (part instanceof EventPart || part instanceof NodePart) {
+        throw new Error(
+            'The `live` directive is not allowed on text or event bindings');
+      }
+      if (part instanceof BooleanAttributePart) {
+        checkStrings(part.strings);
+        previousValue = part.element.hasAttribute(part.name);
+        // This is a hack needed because BooleanAttributePart doesn't have a
+        // committer and does its own dirty checking after directives
+        part.value = previousValue;
+      } else {
+        const {element, name, strings} = part.committer;
+        checkStrings(strings);
+        if (part instanceof PropertyPart) {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          previousValue = (element as any)[name];
+        } else if (part instanceof AttributePart) {
+          previousValue = element.getAttribute(name);
+        }
+        if (previousValue === value) {
+          return;
+        }
+      }
+      part.setValue(value);
+    });
+
+const checkStrings = (strings: readonly string[]) => {
+  if (strings.length !== 2 || strings[0] !== '' || strings[1] !== '') {
+    throw new Error('`live` bindings can only contain a single expression');
+  }
+};

--- a/src/directives/live.ts
+++ b/src/directives/live.ts
@@ -37,7 +37,7 @@ import {AttributePart, BooleanAttributePart, directive, EventPart, NodePart, Pro
  * passed in, or the binding will update every render.
  */
 export const live = directive(
-    (value: unknown) => (part: NodePart|AttributePart|PropertyPart|
+    (value: unknown) => (part: AttributePart|PropertyPart|
                          BooleanAttributePart) => {
       let previousValue: unknown;
       if (part instanceof EventPart || part instanceof NodePart) {

--- a/src/directives/live.ts
+++ b/src/directives/live.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright (c) 2019 The Polymer Project Authors. All rights reserved.
+ * Copyright (c) 2020 The Polymer Project Authors. All rights reserved.
  * This code may only be used under the BSD style license found at
  * http://polymer.github.io/LICENSE.txt
  * The complete set of authors may be found at
@@ -56,10 +56,13 @@ export const live = directive(
         if (part instanceof PropertyPart) {
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           previousValue = (element as any)[name];
+          if (previousValue === value) {
+            return;
+          }
         } else if (part instanceof AttributePart) {
           previousValue = element.getAttribute(name);
         }
-        if (previousValue === value) {
+        if (previousValue === String(value)) {
           return;
         }
       }

--- a/src/test/directives/live_test.ts
+++ b/src/test/directives/live_test.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright (c) 2019 The Polymer Project Authors. All rights reserved.
+ * Copyright (c) 2020 The Polymer Project Authors. All rights reserved.
  * This code may only be used under the BSD style license found at
  * http://polymer.github.io/LICENSE.txt
  * The complete set of authors may be found at
@@ -46,6 +46,15 @@ suite('live', () => {
   });
 
   suite('properties', () => {
+    test('live() is useful', () => {
+      const go = (x: string) => render(html`<input .value="${x}">}`, container);
+      go('a');
+      const el = container.firstElementChild as HTMLInputElement;
+      el.value = 'b';
+      go('a');
+      assert.equal(el.value, 'b');
+    });
+
     test('updates an externally set property', () => {
       const go = (x: string) =>
           render(html`<input .value="${live(x)}">}`, container);
@@ -104,6 +113,32 @@ suite('live', () => {
       assert.equal(mutationCount, 1);
     });
   });
+
+  test(
+      'does not set a non-changed attribute with a non-string value',
+      async () => {
+        let mutationCount = 0;
+        const observer = new MutationObserver((records) => {
+          mutationCount += records.length;
+        });
+        const go = (x: number) =>
+            render(html`<div x="${live(x)}"></div>}`, container);
+        go(1);
+        const el = container.firstElementChild as LiveTester;
+        assert.equal(el.getAttribute('x'), '1');
+
+        observer.observe(el, {attributes: true});
+
+        go(2);
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        assert.equal(el.getAttribute('x'), '2');
+        assert.equal(mutationCount, 1);
+
+        go(2);
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        assert.equal(el.getAttribute('x'), '2');
+        assert.equal(mutationCount, 1);
+      });
 
   suite('boolean attributes', () => {
     test('updates an externally set boolean attribute', () => {

--- a/src/test/directives/live_test.ts
+++ b/src/test/directives/live_test.ts
@@ -94,12 +94,12 @@ suite('live', () => {
       observer.observe(el, {attributes: true});
 
       go('b');
-      await Promise.resolve();
+      await new Promise((resolve) => setTimeout(resolve, 0));
       assert.equal(el.getAttribute('x'), 'b');
       assert.equal(mutationCount, 1);
 
       go('b');
-      await Promise.resolve();
+      await new Promise((resolve) => setTimeout(resolve, 0));
       assert.equal(el.getAttribute('x'), 'b');
       assert.equal(mutationCount, 1);
     });
@@ -139,12 +139,12 @@ suite('live', () => {
       observer.observe(el, {attributes: true});
 
       go(false);
-      await Promise.resolve();
+      await new Promise((resolve) => setTimeout(resolve, 0));
       assert.equal(el.getAttribute('hidden'), null);
       assert.equal(mutationCount, 1);
 
       go(false);
-      await Promise.resolve();
+      await new Promise((resolve) => setTimeout(resolve, 0));
       assert.equal(el.getAttribute('hidden'), null);
       assert.equal(mutationCount, 1);
     });

--- a/src/test/directives/live_test.ts
+++ b/src/test/directives/live_test.ts
@@ -1,0 +1,152 @@
+/**
+ * @license
+ * Copyright (c) 2019 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+/// <reference path="../../../node_modules/@types/mocha/index.d.ts" />
+/// <reference path="../../../node_modules/@types/chai/index.d.ts" />
+
+import {live} from '../../directives/live.js';
+import {render} from '../../lib/render.js';
+import {html} from '../../lit-html.js';
+
+const assert = chai.assert;
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+class LiveTester extends HTMLElement {
+  _x?: string;
+  _setCount = 0;
+
+  get x(): string|undefined {
+    return this._x;
+  }
+
+  set x(v: string|undefined) {
+    this._x = v;
+    this._setCount++;
+  }
+}
+customElements.define('live-tester', LiveTester);
+
+suite('live', () => {
+  let container: HTMLDivElement;
+
+  setup(() => {
+    container = document.createElement('div');
+  });
+
+  suite('properties', () => {
+    test('updates an externally set property', () => {
+      const go = (x: string) =>
+          render(html`<input .value="${live(x)}">}`, container);
+      go('a');
+      const el = container.firstElementChild as HTMLInputElement;
+      el.value = 'b';
+      go('a');
+      assert.equal(el.value, 'a');
+    });
+
+    test('does not set a non-changed property', () => {
+      const go = (x: string) =>
+          render(html`<live-tester .x="${live(x)}"></live-tester>}`, container);
+      go('a');
+      const el = container.firstElementChild as LiveTester;
+      assert.equal(el.x, 'a');
+      assert.equal(el._setCount, 1);
+      go('a');
+      assert.equal(el.x, 'a');
+      assert.equal(el._setCount, 1);
+    });
+  });
+
+  suite('attributes', () => {
+    test('updates an externally set attribute', () => {
+      const go = (x: string) =>
+          render(html`<div class="${live(x)}">}`, container);
+      go('a');
+      const el = container.firstElementChild as HTMLDivElement;
+      el.className = 'b'
+      go('a');
+      assert.equal(el.getAttribute('class'), 'a');
+    });
+
+    test('does not set a non-changed attribute', async () => {
+      let mutationCount = 0;
+      const observer = new MutationObserver((records) => {
+        mutationCount += records.length;
+      });
+      const go = (x: string) =>
+          render(html`<div x="${live(x)}"></div>}`, container);
+      go('a');
+      const el = container.firstElementChild as LiveTester;
+      assert.equal(el.getAttribute('x'), 'a');
+
+      observer.observe(el, {attributes: true});
+
+      go('b');
+      await Promise.resolve();
+      assert.equal(el.getAttribute('x'), 'b');
+      assert.equal(mutationCount, 1);
+
+      go('b');
+      await Promise.resolve();
+      assert.equal(el.getAttribute('x'), 'b');
+      assert.equal(mutationCount, 1);
+    });
+  });
+
+  suite('boolean attributes', () => {
+    test('updates an externally set boolean attribute', () => {
+      const go = (x: boolean) =>
+          render(html`<div ?hidden="${live(x)}"></div>}`, container);
+
+      go(true);
+      const el = container.firstElementChild as HTMLDivElement;
+      assert.equal(el.getAttribute('hidden'), '');
+
+      go(true);
+      assert.equal(el.getAttribute('hidden'), '');
+
+      el.removeAttribute('hidden');
+      assert.equal(el.getAttribute('hidden'), null);
+
+      go(true);
+      assert.equal(el.getAttribute('hidden'), '');
+    });
+
+    test('does not set a non-changed boolean attribute', async () => {
+      let mutationCount = 0;
+      const observer = new MutationObserver((records) => {
+        mutationCount += records.length;
+      });
+      const go = (x: boolean) =>
+          render(html`<div ?hidden="${live(x)}"></div>}`, container);
+
+      go(true);
+      const el = container.firstElementChild as LiveTester;
+      assert.equal(el.getAttribute('hidden'), '');
+
+      observer.observe(el, {attributes: true});
+
+      go(false);
+      await Promise.resolve();
+      assert.equal(el.getAttribute('hidden'), null);
+      assert.equal(mutationCount, 1);
+
+      go(false);
+      await Promise.resolve();
+      assert.equal(el.getAttribute('hidden'), null);
+      assert.equal(mutationCount, 1);
+    });
+  });
+});

--- a/test/index.html
+++ b/test/index.html
@@ -19,6 +19,7 @@
     <script type="module" src="./directives/cache_test.js"></script>
     <script type="module" src="./directives/guard_test.js"></script>
     <script type="module" src="./directives/if-defined_test.js"></script>
+    <script type="module" src="./directives/live_test.js"></script>
     <script type="module" src="./directives/repeat_test.js"></script>
     <script type="module" src="./directives/until_test.js"></script>
     <script type="module" src="./directives/unsafe-html_test.js"></script>


### PR DESCRIPTION
Fixes #877

This directive dirty-checks new values against the live DOM value rather than the previously rendered value stored by the lit-html Part. `live()` only works with attribute, property, and boolean attribute bindings.

Event bindings use addEventListener and don't have a single "live" value, so the directive doesn't make sense there. It's possible that a lit-html bound event listener is removed externally, but that seems like a very, very corner case.

I tried to make this work with NodeParts in case the text value is changed externally, like with content editable, but in those cases the part markers would likely be disturbed, making that case difficult to support. That might work with a binding to `.textContent`.

cc @LarsDenBakker who wrote a `live()` directive for open-wc.