### PR TITLE
Change classMap to set classes correctly for SVGs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 * Fixed a bug where `classMap` and `styleMap` directives wouldn't render mutated objects. ([#972](https://github.com/Polymer/lit-html/issues/972))
 * Fixed a bug where ifDefined() would set an attribute even when the value didn't change. ([#890](https://github.com/Polymer/lit-html/issues/890))
+* Change `classMap` directive to set classes correctly on SVGs ([1070#](https://github.com/Polymer/lit-html/issues/1070)).
 
 
 ## [1.1.2] - 2019-08-12

--- a/src/directives/class-map.ts
+++ b/src/directives/class-map.ts
@@ -91,17 +91,21 @@ export const classMap = directive((classInfo: ClassInfo) => (part: Part) => {
   // Add or remove classes based on their ClassInfo value
   for (const name in classInfo) {
     const value = classInfo[name];
+    const cached = previousClasses.get(name);
     // We explicitly want a loose truthy check of `value` because it seems more
     // convenient that '' and 0 are skipped.
-    if (value != previousClasses.has(name)) {
-      changed = true;
-      if (value) {
-        // Dynamic classes are set to false, so we know to remove them when
-        // omitted from the ClassInfo.
+    if (value) {
+      // Dynamic classes are set to false, so we know to remove them when
+      // omitted from the ClassInfo.
+      if (cached !== false) {
         previousClasses.set(name, false);
-      } else {
-        previousClasses.delete(name);
       }
+      if (cached === undefined) {
+        changed = true;
+      }
+    } else if (cached !== undefined) {
+      changed = true;
+      previousClasses.delete(name);
     }
   }
 

--- a/src/directives/class-map.ts
+++ b/src/directives/class-map.ts
@@ -79,10 +79,10 @@ export const classMap = directive((classInfo: ClassInfo) => (part: Part) => {
   // Remove old classes that no longer apply
   // We use forEach() instead of for-of so that re don't require down-level
   // iteration.
-  previousClasses.forEach((value: unknown, key: string) => {
+  previousClasses.forEach((value: unknown, name: string) => {
     // If the value is true, then it was a static class, which we do not remove
     // unless the ClassInfo specifically overrides it.
-    if (value !== true && !(key in classInfo)) {
+    if (value !== true && !(name in classInfo)) {
       changed = true;
       previousClasses!.delete(name);
     }

--- a/src/directives/class-map.ts
+++ b/src/directives/class-map.ts
@@ -34,14 +34,14 @@ const previousClassesCache = new WeakMap<Part, Map<string, boolean>>();
 
 /**
  * Classes are parsed as a series of tokens separated by ASCII whitespace. This
- * token splitter allows us to extract the tokens from the static classes given
- * in th template literal.
+ * token parser allows us to extract the tokens from the static classes given
+ * in the template literal.
  *
  * https://html.spec.whatwg.org/multipage/dom.html#classes
  * https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#set-of-space-separated-tokens
  * https://infra.spec.whatwg.org/#ascii-whitespace
  */
-const tokenSplitter = /[\t\n\f\r ]+/;
+const tokens = /[^\t\n\f\r ]+/g;
 
 /**
  * A directive that applies CSS classes. This must be used in the `class`
@@ -70,9 +70,12 @@ export const classMap = directive((classInfo: ClassInfo) => (part: Part) => {
     previousClassesCache.set(part, previousClasses);
     // Normalize all static classes into individual tokens. This is necessary
     // since each individual string could contain multiple tokens.
-    const strings = committer.strings.join(' ').split(tokenSplitter);
-    // Ensure static classes are never removed, by setting them to true
-    strings.forEach(s => previousClasses!.set(s, true));
+    const strings = committer.strings.join(' ');
+    let match;
+    while ((match = tokens.exec(strings))) {
+      // Ensure static classes are never removed, by setting them to true
+      previousClasses!.set(match[0], true);
+    }
     changed = true;
   }
 

--- a/src/directives/class-map.ts
+++ b/src/directives/class-map.ts
@@ -49,7 +49,7 @@ export const classMap = directive((classInfo: ClassInfo) => (part: Part) => {
   let previousClasses = previousClassesCache.get(part);
   if (previousClasses === undefined) {
     // Write static classes once
-    element.className = committer.strings.join(' ');
+    element.setAttribute('class', committer.strings.join(' '));
     previousClassesCache.set(part, previousClasses = new Set());
   }
 

--- a/src/test/directives/class-map_test.ts
+++ b/src/test/directives/class-map_test.ts
@@ -111,7 +111,7 @@ suite('classMap', () => {
     const el = container.firstElementChild!;
     const classes = el.getAttribute('class')!.split(' ');
     // Sigh, IE.
-    assert.isFalse(classes.indexOf('foo') === -1);
+    assert.isTrue(classes.indexOf('foo') === -1);
     assert.isTrue(classes.indexOf('bar') > -1);
     assert.isTrue(classes.indexOf('zonk') > -1);
   });

--- a/src/test/directives/class-map_test.ts
+++ b/src/test/directives/class-map_test.ts
@@ -17,7 +17,7 @@
 
 import {ClassInfo, classMap} from '../../directives/class-map.js';
 import {render} from '../../lib/render.js';
-import {html} from '../../lit-html.js';
+import {html, svg} from '../../lit-html.js';
 
 const assert = chai.assert;
 
@@ -93,6 +93,15 @@ suite('classMap', () => {
     assert.isTrue(el.classList.contains('aa'));
     assert.isTrue(el.classList.contains('bb'));
     assert.isFalse(el.classList.contains('foo'));
+  });
+
+  test('adds classes on SVG elements', () => {
+    const cssInfo = {foo: 0, bar: true, zonk: true};
+    render(svg`<circle class="${classMap(cssInfo)}"></circle>`, container);
+    const el = container.firstElementChild!;
+    assert.isFalse(el.classList.contains('foo'));
+    assert.isTrue(el.classList.contains('bar'));
+    assert.isTrue(el.classList.contains('zonk'));
   });
 
   test('throws when used on non-class attribute', () => {

--- a/src/test/directives/class-map_test.ts
+++ b/src/test/directives/class-map_test.ts
@@ -109,9 +109,11 @@ suite('classMap', () => {
     const cssInfo = {foo: 0, bar: true, zonk: true};
     render(svg`<circle class="${classMap(cssInfo)}"></circle>`, container);
     const el = container.firstElementChild!;
-    assert.isFalse(el.classList.contains('foo'));
-    assert.isTrue(el.classList.contains('bar'));
-    assert.isTrue(el.classList.contains('zonk'));
+    const classes = el.getAttribute('class')!.split(' ');
+    // Sigh, IE.
+    assert.isFalse(classes.indexOf('foo') === -1);
+    assert.isTrue(classes.indexOf('bar') > -1);
+    assert.isTrue(classes.indexOf('zonk') > -1);
   });
 
   test('throws when used on non-class attribute', () => {

--- a/src/test/directives/class-map_test.ts
+++ b/src/test/directives/class-map_test.ts
@@ -81,6 +81,16 @@ suite('classMap', () => {
     assert.isFalse(el.classList.contains('foo'));
   });
 
+  test('can override static classes', () => {
+    renderClassMapStatic({aa: false, bb: true});
+    const el = container.firstElementChild!;
+    assert.isFalse(el.classList.contains('aa'));
+    assert.isTrue(el.classList.contains('bb'));
+    renderClassMapStatic({});
+    assert.isFalse(el.classList.contains('aa'));
+    assert.isFalse(el.classList.contains('bb'));
+  });
+
   test('changes classes when used with the same object', () => {
     const classInfo = {foo: true};
     renderClassMapStatic(classInfo);


### PR DESCRIPTION
This fixes the `classMap` directive inside SVGs by avoiding `className`, and avoiding `classList` which isn't supported in IE11 SVGs.

This is another attempt at https://github.com/Polymer/lit-html/pull/932. I've reused @AdamVig's commit to give him the commit stats.
Fixes https://github.com/Polymer/lit-html/issues/930.