### PR TITLE
Rework TemplateInstance cloning

### DIFF
--- a/src/directives/async-append.ts
+++ b/src/directives/async-append.ts
@@ -84,7 +84,7 @@ export const asyncAppend = directive(
         // Check to see if we have a previous item and Part
         if (itemPart !== undefined) {
           // Create a new node to separate the previous and next Parts
-          itemStartNode = createMarker();
+          itemStartNode = createMarker('');
           // itemPart is currently the Part for the previous item. Set
           // it's endNode to the node we'll use for the next Part's
           // startNode.

--- a/src/directives/repeat.ts
+++ b/src/directives/repeat.ts
@@ -25,8 +25,8 @@ const createAndInsertPart =
       const container = containerPart.startNode.parentNode as Node;
       const beforeNode =
           beforePart == null ? containerPart.endNode : beforePart.startNode;
-      const startNode = container.insertBefore(createMarker(), beforeNode);
-      container.insertBefore(createMarker(), beforeNode);
+      const startNode = container.insertBefore(createMarker(''), beforeNode);
+      container.insertBefore(createMarker(''), beforeNode);
       const newPart = new NodePart(containerPart.options, undefined);
       newPart.insertAfterNode(startNode);
       return newPart;

--- a/src/lib/parts.ts
+++ b/src/lib/parts.ts
@@ -277,8 +277,8 @@ export class NodePart implements Part {
    * This part must be empty, as its contents are not automatically moved.
    */
   appendInto(container: Node) {
-    this.startNode = container.appendChild(createMarker());
-    this.endNode = container.appendChild(createMarker());
+    this.startNode = container.appendChild(createMarker(''));
+    this.endNode = container.appendChild(createMarker(''));
   }
 
   /**
@@ -299,8 +299,8 @@ export class NodePart implements Part {
    * This part must be empty, as its contents are not automatically moved.
    */
   appendIntoPart(part: NodePart) {
-    part.__insert(this.startNode = createMarker());
-    part.__insert(this.endNode = createMarker());
+    part.__insert(this.startNode = createMarker(''));
+    part.__insert(this.endNode = createMarker(''));
   }
 
   /**
@@ -309,7 +309,7 @@ export class NodePart implements Part {
    * This part must be empty, as its contents are not automatically moved.
    */
   insertAfterPart(ref: NodePart) {
-    ref.__insert(this.startNode = createMarker());
+    ref.__insert(this.startNode = createMarker(''));
     this.endNode = ref.endNode;
     ref.endNode = this.startNode;
   }

--- a/src/lib/template.ts
+++ b/src/lib/template.ts
@@ -33,6 +33,16 @@ export const nodeMarker = `<!--${marker}-->`;
 export const markerRegex = new RegExp(`${marker}|${nodeMarker}`);
 
 /**
+ * A marker used to say the next sibling holds a part.
+ */
+export const partMarker = `${marker}-part:`;
+
+/**
+ * A marker that says the previous sibling is a template element.
+ */
+export const templateMarker = `${marker}-template`;
+
+/**
  * Suffix appended to all bound attribute names.
  */
 export const boundAttributeSuffix = '$lit$';
@@ -41,38 +51,38 @@ export const boundAttributeSuffix = '$lit$';
  * An updatable Template that tracks the location of dynamic parts.
  */
 export class Template {
-  readonly parts: TemplatePart[] = [];
+  readonly parts: Array<TemplatePart|undefined> = [];
   readonly element: HTMLTemplateElement;
 
   constructor(result: TemplateResult, element: HTMLTemplateElement) {
     this.element = element;
 
-    const nodesToRemove: Node[] = [];
-    const stack: Node[] = [];
     // Edge needs all 4 parameters present; IE11 needs 3rd parameter to be null
     const walker = document.createTreeWalker(
         element.content,
         133 /* NodeFilter.SHOW_{ELEMENT|COMMENT|TEXT} */,
         null,
         false);
-    // Keeps track of the last index associated with a part. We try to delete
-    // unnecessary nodes, but we never want to associate two different parts
-    // to the same index. They must have a constant node between.
-    let lastPartIndex = 0;
-    let index = -1;
+    const nodesToRemove: Node[] = [];
+    const stack: Node[] = [];
+
+    // Keeps track of the last part's staring node. We try to delete
+    // unnecessary nodes, but we never want to associate two different parts to
+    // the same starting node. They must have a constant node between.
+    let lastPartStart = null;
     let partIndex = 0;
+
     const {strings, values: {length}} = result;
     while (partIndex < length) {
       const node = walker.nextNode() as Element | Comment | Text | null;
       if (node === null) {
         // We've exhausted the content inside a nested template element.
         // Because we still have parts (the outer for-loop), we know:
-        // - There is a template in the stack
-        // - The walker will find a nextNode outside the template
+        // * There is a template in the stack
+        // * The walker will find a nextNode outside the template
         walker.currentNode = stack.pop()!;
         continue;
       }
-      index++;
 
       if (node.nodeType === 1 /* Node.ELEMENT_NODE */) {
         if ((node as Element).hasAttributes()) {
@@ -88,6 +98,10 @@ export class Template {
             if (endsWith(attributes[i].name, boundAttributeSuffix)) {
               count++;
             }
+          }
+
+          if (count > 0) {
+            insertPartMarker(node, partIndex, count);
           }
           while (count-- > 0) {
             // Get the template literal section leading up to the first
@@ -108,7 +122,6 @@ export class Template {
             const statics = attributeValue.split(markerRegex);
             this.parts.push({
               type: 'attribute',
-              index,
               name,
               strings: statics,
               sanitizer: undefined
@@ -116,8 +129,18 @@ export class Template {
             partIndex += statics.length - 1;
           }
         }
+
         if ((node as Element).tagName === 'TEMPLATE') {
-          stack.push(node);
+          // Insert a template marker _after_ the template. This is so that we
+          // don't get confused if the template also has an attribute binding
+          // (which would have inserted a partMarker before the template).
+          //
+          // TODO If we could figure out if this template holds no bindings, we
+          // could skip generating this template marker. That'll speed up
+          // TemplateInstance cloning later on.
+          const tm = createMarker(templateMarker);
+          node.parentNode!.insertBefore(tm, node.nextSibling);
+          stack.push(tm);
           walker.currentNode = (node as HTMLTemplateElement).content;
         }
       } else if (node.nodeType === 3 /* Node.TEXT_NODE */) {
@@ -126,13 +149,14 @@ export class Template {
           const parent = node.parentNode!;
           const strings = data.split(markerRegex);
           const lastIndex = strings.length - 1;
+
           // Generate a new text node for each literal section
           // These nodes are also used as the markers for node parts
           for (let i = 0; i < lastIndex; i++) {
             let insert: Node;
             let s = strings[i];
             if (s === '') {
-              insert = createMarker();
+              insert = createMarker('');
             } else {
               const match = lastAttributeNameRegex.exec(s);
               if (match !== null && endsWith(match[2], boundAttributeSuffix)) {
@@ -142,41 +166,42 @@ export class Template {
               insert = document.createTextNode(s);
             }
             parent.insertBefore(insert, node);
-            this.parts.push({type: 'node', index: ++index});
+            insertPartMarker(node, partIndex++, 0);
+            this.parts.push({type: 'node'});
           }
+
           // If there's no text, we must insert a comment to mark our place.
           // Else, we can trust it will stick around after cloning.
           if (strings[lastIndex] === '') {
-            parent.insertBefore(createMarker(), node);
+            parent.insertBefore(createMarker(''), node);
             nodesToRemove.push(node);
           } else {
             (node as Text).data = strings[lastIndex];
           }
-          // We have a part for each match found
-          partIndex += lastIndex;
         }
       } else if (node.nodeType === 8 /* Node.COMMENT_NODE */) {
         if ((node as Comment).data === marker) {
           const parent = node.parentNode!;
+
           // Add a new marker node to be the startNode of the Part if any of
           // the following are true:
           //  * We don't have a previousSibling
           //  * The previousSibling is already the start of a previous part
-          if (node.previousSibling === null || index === lastPartIndex) {
-            index++;
-            parent.insertBefore(createMarker(), node);
+          const {previousSibling} = node;
+          if (previousSibling === null || previousSibling === lastPartStart) {
+            lastPartStart = parent.insertBefore(createMarker(''), node);
           }
-          lastPartIndex = index;
-          this.parts.push({type: 'node', index});
+          insertPartMarker(node, partIndex++, 0);
+          this.parts.push({type: 'node'});
+
           // If we don't have a nextSibling, keep this node so we have an end.
           // Else, we can remove it to save future costs.
           if (node.nextSibling === null) {
             (node as Comment).data = '';
           } else {
+            lastPartStart = node;
             nodesToRemove.push(node);
-            index--;
           }
-          partIndex++;
         } else {
           let i = -1;
           while ((i = (node as Comment).data.indexOf(marker, i + 1)) !== -1) {
@@ -184,7 +209,7 @@ export class Template {
             // The binding won't work, but subsequent bindings will
             // TODO (justinfagnani): consider whether it's even worth it to
             // make bindings in comments work
-            this.parts.push({type: 'node', index: -1});
+            this.parts.push(undefined);
             partIndex++;
           }
         }
@@ -222,22 +247,28 @@ const endsWith = (str: string, suffix: string): boolean => {
 export type TemplatePart = NodeTemplatePart|AttributeTemplatePart;
 export interface NodeTemplatePart {
   readonly type: 'node';
-  index: number;
 }
 
 export interface AttributeTemplatePart {
   readonly type: 'attribute';
-  index: number;
   readonly name: string;
   readonly strings: readonly string[];
   // Lazily initialized in the default-template-processor.
   sanitizer?: ValueSanitizer;
 }
-export const isTemplatePartActive = (part: TemplatePart) => part.index !== -1;
 
 // Allows `document.createComment('')` to be renamed for a
 // small manual size-savings.
-export const createMarker = () => document.createComment('');
+export const createMarker = (data: string) => document.createComment(data);
+
+// Creates a comment with the part index and number of attributes. The
+// attribute count occupies the 16 high bits, and the part index the 16 low
+// bits.
+export const insertPartMarker =
+    (node: Node, partIndex: number, attributeCount: number) =>
+        node.parentNode!.insertBefore(
+            createMarker(`${partMarker}${attributeCount << 16 | partIndex}`),
+            node);
 
 /**
  * This regex extracts the attribute name preceding an attribute-position

--- a/src/lit-html.ts
+++ b/src/lit-html.ts
@@ -45,7 +45,7 @@ export {templateCaches, templateFactory} from './lib/template-factory.js';
 export {TemplateInstance} from './lib/template-instance.js';
 export {TemplateProcessor} from './lib/template-processor.js';
 export {SVGTemplateResult, TemplateResult} from './lib/template-result.js';
-export {createMarker, isTemplatePartActive, Template} from './lib/template.js';
+export {createMarker, Template} from './lib/template.js';
 
 declare global {
   interface Window {

--- a/src/test/lib/parts_test.ts
+++ b/src/test/lib/parts_test.ts
@@ -92,8 +92,8 @@ suite('Parts', () => {
 
     setup(() => {
       container = document.createElement('div');
-      startNode = createMarker();
-      endNode = createMarker();
+      startNode = createMarker('');
+      endNode = createMarker('');
       container.appendChild(startNode);
       container.appendChild(endNode);
       part = new NodePart({templateFactory});
@@ -438,7 +438,7 @@ suite('Parts', () => {
       test(
           'inserts part and sets values between ref node and its next sibling',
           () => {
-            const testEndNode = createMarker();
+            const testEndNode = createMarker('');
             container.appendChild(testEndNode);
             const testPart = new NodePart({templateFactory});
             testPart.insertAfterNode(endNode);

--- a/src/test/lib/template_test.ts
+++ b/src/test/lib/template_test.ts
@@ -28,15 +28,15 @@ suite('Template', () => {
 
     assert.equal(
         countNodes(html`<div>${0}</div>`, (c) => c.childNodes[0].childNodes),
-        2);
-    assert.equal(countNodes(html`${0}`, (c) => c.childNodes), 2);
-    assert.equal(countNodes(html`a${0}`, (c) => c.childNodes), 2);
-    assert.equal(countNodes(html`${0}a`, (c) => c.childNodes), 2);
-    assert.equal(countNodes(html`${0}${0}`, (c) => c.childNodes), 3);
-    assert.equal(countNodes(html`a${0}${0}`, (c) => c.childNodes), 3);
-    assert.equal(countNodes(html`${0}b${0}`, (c) => c.childNodes), 3);
-    assert.equal(countNodes(html`${0}${0}c`, (c) => c.childNodes), 3);
-    assert.equal(countNodes(html`a${0}b${0}c`, (c) => c.childNodes), 3);
+        3);
+    assert.equal(countNodes(html`${0}`, (c) => c.childNodes), 3);
+    assert.equal(countNodes(html`a${0}`, (c) => c.childNodes), 3);
+    assert.equal(countNodes(html`${0}a`, (c) => c.childNodes), 3);
+    assert.equal(countNodes(html`${0}${0}`, (c) => c.childNodes), 5);
+    assert.equal(countNodes(html`a${0}${0}`, (c) => c.childNodes), 5);
+    assert.equal(countNodes(html`${0}b${0}`, (c) => c.childNodes), 5);
+    assert.equal(countNodes(html`${0}${0}c`, (c) => c.childNodes), 5);
+    assert.equal(countNodes(html`a${0}b${0}c`, (c) => c.childNodes), 5);
   });
 
   test('parses parts for multiple expressions', () => {


### PR DESCRIPTION
Instead of traversing over every single `Element`, `Comment`, and `Text` node, this looks only for comment nodes that mark part positions. This likely allows us to skip **tons** of nodes in the walker (I'm assuming comments are the least used nodes in a page).

Additionally, I'm using a comment node to mark the spot after a template element, so that we know to go back and traverse the template.

By paying about 120 bytes, we can anywhere between a 2-10x speedup (for every browser) with this: https://jsbench.github.io/#d26f5d42b64a4c21dda947adcaaa1570

Additionally, this allows me to delete a significant amount of code from the shady-render module. We're no longer tied to walking nodes by `nodeIndex`, so we don't need to update every later part's `index` when we remove a single node, so removal is pretty trivial. We also don't need to pay for an expensive insertion function anymore.

(This replaces #847, which was on my personal fork and couldn't run Tach)