### PR TITLE
named part

### DIFF
--- a/src/directives/part-ref.ts
+++ b/src/directives/part-ref.ts
@@ -12,7 +12,7 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {directive, Part, AttributePart, BooleanAttributePart, NodePart, EventPart} from '../lit-html.js';
+import {AttributePart, BooleanAttributePart, directive, EventPart, NodePart, Part} from '../lit-html.js';
 
 /**
  * For AttributeParts, NodeParts, sets the reference of parts on partRefs
@@ -21,7 +21,8 @@ import {directive, Part, AttributePart, BooleanAttributePart, NodePart, EventPar
  *
  * ```js
  * let tpl = html`
- * <div id="btn" class=${partRef('cls1', 'class')}>${partRef('contents', 'body')}</div>
+ * <div id="btn" class=${partRef('cls1', 'class')}>${partRef('contents',
+ 'body')}</div>
  * `
  * render(tpl, document.body);
 
@@ -34,24 +35,28 @@ import {directive, Part, AttributePart, BooleanAttributePart, NodePart, EventPar
  * ```
  *
  */
-export const partRef = directive((value: unknown, key: string, element?: Partial<object>) => (part: Part) =>{
-  part.setValue(value);
-  if(!element){
-    if((part instanceof BooleanAttributePart || part instanceof EventPart) && part.element) {
-      element = part.element
-    }else if(part instanceof AttributePart && part.committer){
-      element = part.committer.element
-    }else if(part instanceof NodePart && part.startNode){
-      element = part.startNode.parentNode as Element;
-    }
-  }
-  if(!element)
-    return
-  let parts = partRefs.get(element);
-  if(!parts){
-    partRefs.set(element, parts={});
-  }
-  parts[key] = part;
-});
+export const partRef = directive(
+    (value: unknown, key: string, element?: Partial<object>) =>
+        (part: Part) => {
+          part.setValue(value);
+          if (!element) {
+            if ((part instanceof BooleanAttributePart ||
+                 part instanceof EventPart) &&
+                part.element) {
+              element = part.element
+            } else if (part instanceof AttributePart && part.committer) {
+              element = part.committer.element
+            } else if (part instanceof NodePart && part.startNode) {
+              element = part.startNode.parentNode as Element;
+            }
+          }
+          if (!element)
+            return;
+          let parts = partRefs.get(element);
+          if (!parts) {
+            partRefs.set(element, parts = {});
+          }
+          parts[key] = part;
+        });
 
-export const partRefs =  new WeakMap<Partial<object>, {[k: string]: Part}>(); 
+export const partRefs = new WeakMap<Partial<object>, {[k: string]: Part}>();

--- a/src/directives/part-ref.ts
+++ b/src/directives/part-ref.ts
@@ -1,0 +1,57 @@
+/**
+ * @license
+ * Copyright (c) 2018 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+import {directive, Part, AttributePart, BooleanAttributePart, NodePart, EventPart} from '../lit-html.js';
+
+/**
+ * For AttributeParts, NodeParts, sets the reference of parts on partRefs
+ * partRefs.get(element)
+ * Example:
+ *
+ * ```js
+ * let tpl = html`
+ * <div id="btn" class=${partRef('cls1', 'class')}>${partRef('contents', 'body')}</div>
+ * `
+ * render(tpl, document.body);
+
+ * let parts = partRefs.get(document.getElementById('btn'))
+ * parts['class'].setValue("new class")
+ * parts['class'].commit();
+ * parts['body'].setValue("new contents")
+ * parts['body'].commit();
+
+ * ```
+ *
+ */
+export const partRef = directive((value: unknown, key: string, element?: Partial<object>) => (part: Part) =>{
+  part.setValue(value);
+  if(!element){
+    if((part instanceof BooleanAttributePart || part instanceof EventPart) && part.element) {
+      element = part.element
+    }else if(part instanceof AttributePart && part.committer){
+      element = part.committer.element
+    }else if(part instanceof NodePart && part.startNode){
+      element = part.startNode.parentNode as Element;
+    }
+  }
+  if(!element)
+    return
+  let parts = partRefs.get(element);
+  if(!parts){
+    partRefs.set(element, parts={});
+  }
+  parts[key] = part;
+});
+
+export const partRefs =  new WeakMap<Partial<object>, {[k: string]: Part}>(); 

--- a/src/test/directives/part-ref_test.ts
+++ b/src/test/directives/part-ref_test.ts
@@ -27,32 +27,40 @@ suite('partRef', () => {
   });
 
   test('normal behaviour', () => {
-    render(html`<div class="btn" foo=${partRef('old value', 'fooP')}></div>`, container);
+    render(
+        html`<div class="btn" foo=${partRef('old value', 'fooP')}></div>`,
+        container);
     assert.equal(
-        stripExpressionMarkers(container.innerHTML), '<div class="btn" foo="old value"></div>');
+        stripExpressionMarkers(container.innerHTML),
+        '<div class="btn" foo="old value"></div>');
   });
 
   test('updating part value', () => {
-    render(html`<div class="btn" foo=${partRef('old value', 'fooP')}></div>`, container);
-    const btnEl: HTMLDivElement | undefined = container.children[0] as HTMLDivElement;
-    if(btnEl && partRefs.has(btnEl)){
-      const parts: {[k: string]: Part} | undefined = partRefs.get(btnEl);
-      if(parts){
+    render(
+        html`<div class="btn" foo=${partRef('old value', 'fooP')}></div>`,
+        container);
+    const btnEl: HTMLDivElement|undefined =
+        container.children[0] as HTMLDivElement;
+    if (btnEl && partRefs.has(btnEl)) {
+      const parts: {[k: string]: Part}|undefined = partRefs.get(btnEl);
+      if (parts) {
         const part: Part = parts.fooP;
-        if(part){
+        if (part) {
           part.setValue('value-changed');
           part.commit();
         }
       }
     }
     assert.equal(
-        stripExpressionMarkers(container.innerHTML), '<div class="btn" foo="value-changed"></div>');
+        stripExpressionMarkers(container.innerHTML),
+        '<div class="btn" foo="value-changed"></div>');
   });
 });
 
 /*
 * let tpl = html`
-* <div id="btn" class=${partRef('cls1', 'class')}>${partRef('contents', 'body')}</div>
+* <div id="btn" class=${partRef('cls1', 'class')}>${partRef('contents',
+'body')}</div>
 * `
 * render(tpl, document.body);
 

--- a/src/test/directives/part-ref_test.ts
+++ b/src/test/directives/part-ref_test.ts
@@ -1,0 +1,64 @@
+/**
+ * @license
+ * Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+import {partRef, partRefs} from '../../directives/part-ref.js';
+import {render} from '../../lib/render.js';
+import {html, Part} from '../../lit-html.js';
+import {stripExpressionMarkers} from '../test-utils/strip-markers.js';
+
+const assert = chai.assert;
+
+suite('partRef', () => {
+  let container: HTMLDivElement;
+
+  setup(() => {
+    container = document.createElement('div');
+  });
+
+  test('normal behaviour', () => {
+    render(html`<div class="btn" foo=${partRef('old value', 'fooP')}></div>`, container);
+    assert.equal(
+        stripExpressionMarkers(container.innerHTML), '<div class="btn" foo="old value"></div>');
+  });
+
+  test('updating part value', () => {
+    render(html`<div class="btn" foo=${partRef('old value', 'fooP')}></div>`, container);
+    const btnEl: HTMLDivElement | undefined = container.children[0] as HTMLDivElement;
+    if(btnEl && partRefs.has(btnEl)){
+      const parts: {[k: string]: Part} | undefined = partRefs.get(btnEl);
+      if(parts){
+        const part: Part = parts.fooP;
+        if(part){
+          part.setValue('value-changed');
+          part.commit();
+        }
+      }
+    }
+    assert.equal(
+        stripExpressionMarkers(container.innerHTML), '<div class="btn" foo="value-changed"></div>');
+  });
+});
+
+/*
+* let tpl = html`
+* <div id="btn" class=${partRef('cls1', 'class')}>${partRef('contents', 'body')}</div>
+* `
+* render(tpl, document.body);
+
+* let parts = partRefs.get(document.getElementById('btn'))
+* parts['class'].setValue("new class")
+* parts['class'].commit();
+* parts['body'].setValue("new contents")
+* parts['body'].commit();
+*/

--- a/test/index.html
+++ b/test/index.html
@@ -19,6 +19,7 @@
     <script type="module" src="./directives/cache_test.js"></script>
     <script type="module" src="./directives/guard_test.js"></script>
     <script type="module" src="./directives/if-defined_test.js"></script>
+    <script type="module" src="./directives/part-ref_test.js"></script>
     <script type="module" src="./directives/live_test.js"></script>
     <script type="module" src="./directives/repeat_test.js"></script>
     <script type="module" src="./directives/template-content_test.js"></script>


### PR DESCRIPTION
Fixes #1081 

```js
let tpl = html`<div id="btn" class=${partRef('cls1',  'class')}>${partRef('body contents',  'body')}</div>`;
render(tpl, document.body);

let parts = partRefs.get(document.getElementById('btn'))

parts['class'].setValue("new class")
parts['class'].commit();
parts['body'].setValue("new contents")
parts['body'].commit();
```