### PR TITLE
Add arthure as codeowner for docs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
 * @justinfagnani
+/docs/ @arthurevans


### PR DESCRIPTION
Did this on LitElement, realized I hadn't done it for lit-html. 

Typo fixes to docs pages probably don't need signoff from @justinfagnani ... 