### PR TITLE
Update terser to drop all comments

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "mocha": "^7.0.1",
     "rollup": "^1.19.0",
     "rollup-plugin-filesize": "^6.2.0",
-    "rollup-plugin-terser": "^5.1.0",
+    "rollup-plugin-terser": "^5.2.0",
     "tachometer": "^0.4.15",
     "typescript": "^3.4.1",
     "uglify-es": "^3.3.5",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -13,7 +13,7 @@
  */
 
 import filesize from 'rollup-plugin-filesize';
-import {terser} from 'rollup-plugin-terser';
+import { terser } from 'rollup-plugin-terser';
 
 export default {
   input: 'lit-html.js',
@@ -24,6 +24,13 @@ export default {
   plugins: [
     terser({
       warnings: true,
+      ecma: 2017,
+      compress: {
+        unsafe: true,
+      },
+      output: {
+        comments: false,
+      },
       mangle: {
         properties: {
           regex: /^__/,


### PR DESCRIPTION
Terser started preserving license comments by default, so our bundle size checks over time aren't comparable. This reverts the behavior to what we had at the 1.1.2 release. Because we don't publish the bundle, and only use it for size tracking, it's ok to remove the license comments.