### PR TITLE
Add sanitization hooks and trusted types support

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,8 @@
 {
-  "typescript.tsdk": "node_modules/typescript/lib"
+  "typescript.tsdk": "node_modules/typescript/lib",
+  "editor.formatOnSave": true,
+  "editor.formatOnPaste": true,
+  "editor.formatOnType": true,
+  // Need to test the behavior of otherwise invalid code.
+  "lit-plugin.disable": true
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 <!-- ### Changed -->
-<!-- ### Added -->
 <!-- ### Removed -->
 ### Added
 * Added `unsafeSVG` directive to bind SVG source inside SVGs. ([#304](https://github.com/Polymer/lit-html/issues/304))
 * Added interop with the proposed Trusted Types spec: https://github.com/WICG/trusted-types ([#970](https://github.com/Polymer/lit-html/pull/970))
+* Added a sanitization system, for integrating with DOM value sanitizers to prevent XSS attacks. See the docs on the SanitizerFactory type and the setSanitizerFactory function for details.
 * Added `templateContent()` directive for stamping out the contents of an HTML template into a text binding. ([#1058](https://github.com/Polymer/lit-html/issues/1058))
 * Added the `live()` directive. Fixes #877
 
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 * Fixed a bug where `classMap` and `styleMap` directives wouldn't render mutated objects. ([#972](https://github.com/Polymer/lit-html/issues/972))
 * Fixed a bug where ifDefined() would set an attribute even when the value didn't change. ([#890](https://github.com/Polymer/lit-html/issues/890))
 * Change `classMap` directive to set classes correctly on SVGs ([1070#](https://github.com/Polymer/lit-html/issues/1070)).
+
 
 ## [1.1.2] - 2019-08-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,13 +10,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
    Unreleased section, uncommenting the header as necessary.
 -->
 
+## `security` Branch
+
+### Added
+* Added interop with the proposed Trusted Types spec: https://github.com/WICG/trusted-types ([#970](https://github.com/Polymer/lit-html/pull/970))
+* Added a sanitization system, for integrating with DOM value sanitizers to prevent XSS attacks. See the docs on the SanitizerFactory type and the setSanitizerFactory function for details.
+
 ## Unreleased
 <!-- ### Changed -->
 <!-- ### Removed -->
 ### Added
 * Added `unsafeSVG` directive to bind SVG source inside SVGs. ([#304](https://github.com/Polymer/lit-html/issues/304))
-* Added interop with the proposed Trusted Types spec: https://github.com/WICG/trusted-types ([#970](https://github.com/Polymer/lit-html/pull/970))
-* Added a sanitization system, for integrating with DOM value sanitizers to prevent XSS attacks. See the docs on the SanitizerFactory type and the setSanitizerFactory function for details.
 * Added `templateContent()` directive for stamping out the contents of an HTML template into a text binding. ([#1058](https://github.com/Polymer/lit-html/issues/1058))
 * Added the `live()` directive. Fixes #877
 

--- a/docs/_includes/release-notes.html
+++ b/docs/_includes/release-notes.html
@@ -1,0 +1,30 @@
+---
+layout: default
+---
+{% include topnav.html %}
+
+<main class="wrapper">
+  <nav class="side-nav">
+    <button id="toggleNavButton">Menu</button>
+    <ul>
+      {% for guide in collections.guide %}
+        <li class="{% if page.url == guide.url %}active{% endif %}">
+          <a href="{{site.baseurl}}{{ guide.url | removeExtension }}">{{guide.data.title}}</a>
+        </li>
+      {% endfor %}
+    </ul>
+  </nav>
+
+  <article>
+    <h1>{{ title }}</h1>
+    
+    {{ content }}
+  </article>
+</main>
+
+<script>
+  toggleNavButton.addEventListener('click', function(event) {
+    const nav = event.target.parentElement;
+    nav.classList.toggle('open');
+  });
+</script>

--- a/docs/guide/10-release-notes.md
+++ b/docs/guide/10-release-notes.md
@@ -1,0 +1,21 @@
+---
+title: Release Notes
+slug: release-notes
+layout: release-notes
+---
+
+<ul>
+{%- for release in collections.release -%}
+  <li><a href="{{ release.url }}">{{ release.data.title }}</a></li>
+{%- endfor -%}
+</ul>
+
+<h3>Releases Prior to 1.2.0</h3>
+
+We don't have written release notes for releases prior to 1.2.0. Please see the [changelog](https://github.com/Polymer/lit-html/blob/master/CHANGELOG.md) for those releases.
+
+
+{%- for release in collections.release -%}
+  <h1>{{ release.data.title }}</h1>
+  {{ release.templateContent }}
+{%- endfor -%}

--- a/docs/guide/release-notes/1.2.0.md
+++ b/docs/guide/release-notes/1.2.0.md
@@ -1,0 +1,75 @@
+---
+title: lit-html 1.2.0
+slug: lit-html-1-2-0
+tags: release
+---
+
+See the [changelog](https://github.com/Polymer/lit-html/blob/master/CHANGELOG.md) for a complete list of changes.
+
+## `live` directive
+
+[Documentation](../template-reference#live)
+
+The `live` directive solves the problem of DOM state changing from underneath lit-html, for example with an `<input>` that a user can type into:
+
+```js
+html`<input .value=${live(x)}>`
+```
+
+In some cases you will want `x` to overwrite what the user has typed in. lit-html tracks the previous value of a binding and only updates the DOM if the value has changed. Without the live directive, lit-html will not detect that the `value` property of the input has changed and won't update the DOM.
+
+The live directive ignores the previous value of the binding and always checks the current value in the DOM, causing the binding to update the input.
+
+We still recommend that you handle user input so that the state and the DOM agree:
+
+```ts
+let text = '';
+const onInput = (e) => {
+  text = e.target.value;
+  go();
+};
+
+const go = () => {
+  render(html`<input .value=${text} @input=${onInput}>`, document.body);
+}
+go();
+```
+
+## `templateContent` directive
+
+[Documentation](../template-reference#templatecontent)
+
+The `templateContent` directive lets you stamp out HTML templates into lit-html templates. This is useful in a number of cases where HTML `<template>` elements are provided by users of elements or parts of a build system.
+
+HTML:
+```html
+<template id="example">
+  <p>HTML Template</p>
+</template>
+```
+
+JavaScript:
+```js
+const template = document.querySelector('#example');
+html`
+  <h1>Example</h1>
+  ${templateContent(template)}
+`;
+```
+
+## `unsafeSVG` directive
+
+[Documentation](../template-reference#unsafesvg)
+
+`unsaveSVG` is the missing partner of [`unsafeHTML`](../template-reference#unsafehtml). It lets you render a frangment of SVG text as SVG elements rather than text. As with `unsafeHTML` this directive not safe to use with user-provided input, since if the input has `<script>` tags in it, there may be ways to get them to execute, etc.
+
+`unsafeSVG` creates elements in the SVG namespace, so it's for use inside of `<svg>` tags or inside of lit-html [`svg`](/api/modules/lit_html.html#svg) templates. If the input contains an `<svg>` tag itself, continute to use `unsafeHTML`.
+
+```js
+// shape is SVG partial text, with no <svg> element
+const renderShape = (shape) => html`
+  <svg  width="100" height="100" viewBox="0 0 100 100">
+    ${unsafeSVG(shape)}
+  </svg>
+`;
+```

--- a/docs/guide/release-notes/release-notes.json
+++ b/docs/guide/release-notes/release-notes.json
@@ -1,0 +1,5 @@
+
+{
+  "layout": "post",
+  "permalink": "{{page.filePathStem}}.html"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -688,7 +688,7 @@
     },
     "@polymer/test-fixture": {
       "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/@polymer/test-fixture/-/test-fixture-0.0.3.tgz",
+      "resolved": "http://registry.npmjs.org/@polymer/test-fixture/-/test-fixture-0.0.3.tgz",
       "integrity": "sha1-REN1JpfU2Sk7vEEuoLXk00HxSdk=",
       "dev": true
     },
@@ -1326,12 +1326,6 @@
       "integrity": "sha512-wHNBMnkoEBiRAd3s8KTKwIuO9biFtTf0LehITzBhSco+HQI0xkXZbLOD55SW3Aqw3oUkHstkm5SPv58yaAdFPQ==",
       "dev": true
     },
-    "@types/trusted-types": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-1.0.4.tgz",
-      "integrity": "sha512-6jtHrHpmiXOXoJ31Cg9R+iEVwuEKPf0XHwFUI93eEPXx492/J2JHyafkleKE2EYzZprayk9FSjTyK1GDqcwDng==",
-      "dev": true
-    },
     "@types/ua-parser-js": {
       "version": "0.7.33",
       "resolved": "https://registry.npmjs.org/@types/ua-parser-js/-/ua-parser-js-0.7.33.tgz",
@@ -1451,9 +1445,9 @@
       "dev": true
     },
     "@webcomponents/webcomponentsjs": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@webcomponents/webcomponentsjs/-/webcomponentsjs-2.4.1.tgz",
-      "integrity": "sha512-7jxBb+KoWncKb/JGFyTY40PjV4yRx2zd35ZLuvRP+6WndJDL7X32ZIZ7bN3sSQIl+NzJkCo7chfXJyzn+6WZaQ==",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@webcomponents/webcomponentsjs/-/webcomponentsjs-2.4.2.tgz",
+      "integrity": "sha512-3nGTTljmHHwfxBDppjbvUrKAmy78skC6nHwx3mYrbz677HXMAREh0aeJvoT4EnuomYJtLU3lS3RYvtB2MSz+NQ==",
       "dev": true
     },
     "abbrev": {
@@ -1893,7 +1887,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
@@ -2685,7 +2679,7 @@
         },
         "readable-stream": {
           "version": "1.1.14",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "dev": true,
           "requires": {
@@ -4034,7 +4028,7 @@
         },
         "readable-stream": {
           "version": "1.1.14",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "dev": true,
           "requires": {
@@ -4200,7 +4194,7 @@
     },
     "enabled": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/enabled/-/enabled-1.0.2.tgz",
+      "resolved": "http://registry.npmjs.org/enabled/-/enabled-1.0.2.tgz",
       "integrity": "sha1-ll9lE9LC0cX0ZStkouM5ZGf8L5M=",
       "dev": true,
       "requires": {
@@ -4930,7 +4924,7 @@
     },
     "fecha": {
       "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/fecha/-/fecha-2.3.3.tgz",
+      "resolved": "http://registry.npmjs.org/fecha/-/fecha-2.3.3.tgz",
       "integrity": "sha512-lUGBnIamTAwk4znq5BcqsDaxSmZ9nDVJaij6NvRt/Tg4R69gERA+otPKbS86ROw9nxVMw2/mp1fnaiWqbs6Sdg==",
       "dev": true
     },
@@ -9432,7 +9426,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
@@ -11480,7 +11474,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
@@ -12929,7 +12923,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -688,7 +688,7 @@
     },
     "@polymer/test-fixture": {
       "version": "0.0.3",
-      "resolved": "http://registry.npmjs.org/@polymer/test-fixture/-/test-fixture-0.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/@polymer/test-fixture/-/test-fixture-0.0.3.tgz",
       "integrity": "sha1-REN1JpfU2Sk7vEEuoLXk00HxSdk=",
       "dev": true
     },
@@ -1326,6 +1326,12 @@
       "integrity": "sha512-wHNBMnkoEBiRAd3s8KTKwIuO9biFtTf0LehITzBhSco+HQI0xkXZbLOD55SW3Aqw3oUkHstkm5SPv58yaAdFPQ==",
       "dev": true
     },
+    "@types/trusted-types": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-1.0.4.tgz",
+      "integrity": "sha512-6jtHrHpmiXOXoJ31Cg9R+iEVwuEKPf0XHwFUI93eEPXx492/J2JHyafkleKE2EYzZprayk9FSjTyK1GDqcwDng==",
+      "dev": true
+    },
     "@types/ua-parser-js": {
       "version": "0.7.33",
       "resolved": "https://registry.npmjs.org/@types/ua-parser-js/-/ua-parser-js-0.7.33.tgz",
@@ -1887,7 +1893,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
@@ -2679,7 +2685,7 @@
         },
         "readable-stream": {
           "version": "1.1.14",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "dev": true,
           "requires": {
@@ -4028,7 +4034,7 @@
         },
         "readable-stream": {
           "version": "1.1.14",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "dev": true,
           "requires": {
@@ -4194,7 +4200,7 @@
     },
     "enabled": {
       "version": "1.0.2",
-      "resolved": "http://registry.npmjs.org/enabled/-/enabled-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/enabled/-/enabled-1.0.2.tgz",
       "integrity": "sha1-ll9lE9LC0cX0ZStkouM5ZGf8L5M=",
       "dev": true,
       "requires": {
@@ -4924,7 +4930,7 @@
     },
     "fecha": {
       "version": "2.3.3",
-      "resolved": "http://registry.npmjs.org/fecha/-/fecha-2.3.3.tgz",
+      "resolved": "https://registry.npmjs.org/fecha/-/fecha-2.3.3.tgz",
       "integrity": "sha512-lUGBnIamTAwk4znq5BcqsDaxSmZ9nDVJaij6NvRt/Tg4R69gERA+otPKbS86ROw9nxVMw2/mp1fnaiWqbs6Sdg==",
       "dev": true
     },
@@ -9426,7 +9432,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
@@ -11474,7 +11480,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
@@ -12923,7 +12929,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10092,9 +10092,9 @@
       }
     },
     "readable-stream": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
       "dev": true,
       "requires": {
         "core-util-is": "~1.0.0",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@typescript-eslint/eslint-plugin": "^2.10.0",
     "@typescript-eslint/parser": "^2.10.0",
     "@webcomponents/shadycss": "^1.8.0",
-    "@webcomponents/webcomponentsjs": "^2.4.0",
+    "@webcomponents/webcomponentsjs": "^2.4.2",
     "chai": "^4.1.2",
     "clang-format": "~1.2.4",
     "eslint": "^6.7.0",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   "devDependencies": {
     "@types/chai": "^4.1.0",
     "@types/mocha": "^7.0.1",
+    "@types/trusted-types": "^1.0.1",
     "@typescript-eslint/eslint-plugin": "^2.10.0",
     "@typescript-eslint/parser": "^2.10.0",
     "@webcomponents/shadycss": "^1.8.0",

--- a/src/directives/async-append.ts
+++ b/src/directives/async-append.ts
@@ -91,7 +91,7 @@ export const asyncAppend = directive(
           itemPart.endNode = itemStartNode;
           part.endNode.parentNode!.insertBefore(itemStartNode, part.endNode);
         }
-        itemPart = new NodePart(part.options);
+        itemPart = new NodePart(part.options, part.templatePart);
         itemPart.insertAfterNode(itemStartNode);
         itemPart.setValue(v);
         itemPart.commit();

--- a/src/directives/async-replace.ts
+++ b/src/directives/async-replace.ts
@@ -46,7 +46,7 @@ export const asyncReplace = directive(
 
           // We nest a new part to keep track of previous item values separately
           // of the iterable as a value itself.
-          const itemPart = new NodePart(part.options);
+          const itemPart = new NodePart(part.options, part.templatePart);
           part.value = value;
 
           let i = 0;

--- a/src/directives/class-map.ts
+++ b/src/directives/class-map.ts
@@ -14,6 +14,38 @@
 
 import {AttributePart, directive, Part, PropertyPart} from '../lit-html.js';
 
+// IE11 doesn't support classList on SVG elements, so we emulate it with a Set
+class ClassList {
+  element: Element;
+  classes: Set<String> = new Set();
+  changed = false;
+
+  constructor(element: Element) {
+    this.element = element;
+    const classList = (element.getAttribute('class') || '').split(/\s+/);
+    for (const cls of classList) {
+      this.classes.add(cls);
+    }
+  }
+  add(cls: string) {
+    this.classes.add(cls);
+    this.changed = true;
+  }
+
+  remove(cls: string) {
+    this.classes.delete(cls);
+    this.changed = true;
+  }
+
+  commit() {
+    if (this.changed) {
+      let classString = '';
+      this.classes.forEach((cls) => classString += cls + ' ');
+      this.element.setAttribute('class', classString);
+    }
+  };
+}
+
 export interface ClassInfo {
   readonly [name: string]: string|boolean|number;
 }
@@ -21,27 +53,8 @@ export interface ClassInfo {
 /**
  * Stores the ClassInfo object applied to a given AttributePart.
  * Used to unset existing values when a new ClassInfo object is applied.
- *
- * The map contains two possible class values:
- * 1. Static (given through the template literal), which are set to true
- * 2. Dynamic (given through ClassInfo) which are set to false
- *
- * Only Dynamic classes can be removed by being omitted from the ClassInfo, but
- * both Static and Dynamic classes can be removed by setting class to falsey in
- * the ClassInfo.
  */
-const previousClassesCache = new WeakMap<Part, Map<string, boolean>>();
-
-/**
- * Classes are parsed as a series of tokens separated by ASCII whitespace. This
- * token parser allows us to extract the tokens from the static classes given
- * in the template literal.
- *
- * https://html.spec.whatwg.org/multipage/dom.html#classes
- * https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#set-of-space-separated-tokens
- * https://infra.spec.whatwg.org/#ascii-whitespace
- */
-const tokens = /[^\t\n\f\r ]+/g;
+const previousClassesCache = new WeakMap<Part, Set<string>>();
 
 /**
  * A directive that applies CSS classes. This must be used in the `class`
@@ -53,7 +66,7 @@ const tokens = /[^\t\n\f\r ]+/g;
  * @param classInfo {ClassInfo}
  */
 export const classMap = directive((classInfo: ClassInfo) => (part: Part) => {
-  if (!(part instanceof AttributePart) || part instanceof PropertyPart ||
+  if (!(part instanceof AttributePart) || (part instanceof PropertyPart) ||
       part.committer.name !== 'class' || part.committer.parts.length > 1) {
     throw new Error(
         'The `classMap` directive must be used in the `class` attribute ' +
@@ -62,59 +75,44 @@ export const classMap = directive((classInfo: ClassInfo) => (part: Part) => {
 
   const {committer} = part;
   const {element} = committer;
-  let changed = false;
 
   let previousClasses = previousClassesCache.get(part);
   if (previousClasses === undefined) {
-    previousClasses = new Map();
-    previousClassesCache.set(part, previousClasses);
-    // Normalize all static classes into individual tokens. This is necessary
-    // since each individual string could contain multiple tokens.
-    const strings = committer.strings.join(' ');
-    let match;
-    while ((match = tokens.exec(strings))) {
-      // Ensure static classes are never removed, by setting them to true
-      previousClasses!.set(match[0], true);
-    }
-    changed = true;
+    // Write static classes once
+    // Use setAttribute() because className isn't a string on SVG elements
+    element.setAttribute('class', committer.strings.join(' '));
+    previousClassesCache.set(part, previousClasses = new Set());
   }
+
+  const classList =
+      (element.classList || new ClassList(element)) as DOMTokenList | ClassList;
 
   // Remove old classes that no longer apply
   // We use forEach() instead of for-of so that re don't require down-level
   // iteration.
-  previousClasses.forEach((value: unknown, name: string) => {
-    // If the value is true, then it was a static class, which we do not remove
-    // unless the ClassInfo specifically overrides it.
-    if (value !== true && !(name in classInfo)) {
-      changed = true;
+  previousClasses.forEach((name) => {
+    if (!(name in classInfo)) {
+      classList.remove(name);
       previousClasses!.delete(name);
     }
   });
 
-  // Add or remove classes based on their ClassInfo value
+  // Add or remove classes based on their classMap value
   for (const name in classInfo) {
     const value = classInfo[name];
-    const cached = previousClasses.get(name);
-    // We explicitly want a loose truthy check of `value` because it seems more
-    // convenient that '' and 0 are skipped.
-    if (value) {
-      // Dynamic classes are set to false, so we know to remove them when
-      // omitted from the ClassInfo.
-      if (cached !== false) {
-        previousClasses.set(name, false);
+    if (value != previousClasses.has(name)) {
+      // We explicitly want a loose truthy check of `value` because it seems
+      // more convenient that '' and 0 are skipped.
+      if (value) {
+        classList.add(name);
+        previousClasses.add(name);
+      } else {
+        classList.remove(name);
+        previousClasses.delete(name);
       }
-      if (cached === undefined) {
-        changed = true;
-      }
-    } else if (cached !== undefined) {
-      changed = true;
-      previousClasses.delete(name);
     }
   }
-
-  if (changed) {
-    const classes: string[] = [];
-    previousClasses.forEach((_: unknown, key: string) => classes.push(key));
-    element.setAttribute('class', classes.join(' '));
+  if (typeof (classList as ClassList).commit === 'function') {
+    (classList as ClassList).commit();
   }
 });

--- a/src/directives/repeat.ts
+++ b/src/directives/repeat.ts
@@ -21,13 +21,13 @@ export type ItemTemplate<T> = (item: T, index: number) => unknown;
 // Helper functions for manipulating parts
 // TODO(kschaaf): Refactor into Part API?
 const createAndInsertPart =
-    (containerPart: NodePart, beforePart?: NodePart): NodePart => {
+    (containerPart: NodePart, beforePart?: NodePart|null): NodePart => {
       const container = containerPart.startNode.parentNode as Node;
-      const beforeNode = beforePart === undefined ? containerPart.endNode :
-                                                    beforePart.startNode;
+      const beforeNode =
+          beforePart == null ? containerPart.endNode : beforePart.startNode;
       const startNode = container.insertBefore(createMarker(), beforeNode);
       container.insertBefore(createMarker(), beforeNode);
-      const newPart = new NodePart(containerPart.options);
+      const newPart = new NodePart(containerPart.options, undefined);
       newPart.insertAfterNode(startNode);
       return newPart;
     };
@@ -399,7 +399,7 @@ export const repeat =
                         // No old part for this value; create a new one and
                         // insert it
                         const newPart = createAndInsertPart(
-                            containerPart, oldParts[oldHead]!);
+                            containerPart, oldParts[oldHead]);
                         updatePart(newPart, newValues[newHead]);
                         newParts[newHead] = newPart;
                       } else {

--- a/src/lib/default-template-processor.ts
+++ b/src/lib/default-template-processor.ts
@@ -20,6 +20,7 @@ import {Part} from './part.js';
 import {AttributeCommitter, BooleanAttributePart, EventPart, NodePart, PropertyCommitter} from './parts.js';
 import {RenderOptions} from './render-options.js';
 import {TemplateProcessor} from './template-processor.js';
+import {AttributeTemplatePart, NodeTemplatePart} from './template.js';
 
 /**
  * Creates Parts when a template is instantiated.
@@ -35,11 +36,12 @@ export class DefaultTemplateProcessor implements TemplateProcessor {
    *   event for fully-controlled bindings with a single expression.
    */
   handleAttributeExpressions(
-      element: Element, name: string, strings: string[],
-      options: RenderOptions): ReadonlyArray<Part> {
+      element: Element, name: string, strings: string[], options: RenderOptions,
+      templatePart?: AttributeTemplatePart): readonly Part[] {
     const prefix = name[0];
     if (prefix === '.') {
-      const committer = new PropertyCommitter(element, name.slice(1), strings);
+      const committer =
+          new PropertyCommitter(element, name.slice(1), strings, templatePart);
       return committer.parts;
     }
     if (prefix === '@') {
@@ -48,15 +50,17 @@ export class DefaultTemplateProcessor implements TemplateProcessor {
     if (prefix === '?') {
       return [new BooleanAttributePart(element, name.slice(1), strings)];
     }
-    const committer = new AttributeCommitter(element, name, strings);
+    const committer =
+        new AttributeCommitter(element, name, strings, templatePart);
     return committer.parts;
   }
   /**
    * Create parts for a text-position binding.
    * @param templateFactory
    */
-  handleTextExpression(options: RenderOptions) {
-    return new NodePart(options);
+  handleTextExpression(
+      options: RenderOptions, nodeTemplatePart: NodeTemplatePart) {
+    return new NodePart(options, nodeTemplatePart);
   }
 }
 

--- a/src/lib/parts.ts
+++ b/src/lib/parts.ts
@@ -22,7 +22,7 @@ import {noChange, nothing, Part} from './part.js';
 import {RenderOptions} from './render-options.js';
 import {TemplateInstance} from './template-instance.js';
 import {TemplateResult} from './template-result.js';
-import {createMarker} from './template.js';
+import {AttributeTemplatePart, createMarker, NodeTemplatePart} from './template.js';
 
 // https://tc39.github.io/ecma262/#sec-typeof-operator
 export type Primitive = null|undefined|boolean|number|string|symbol|bigint;
@@ -38,6 +38,71 @@ export const isIterable = (value: unknown): value is Iterable<unknown> => {
 };
 
 /**
+ * Used to sanitize any value before it is written into the DOM. This can be
+ * used to implement a security policy of allowed and disallowed values in
+ * order to prevent XSS attacks.
+ *
+ * One way of using this callback would be to check attributes and properties
+ * against a list of high risk fields, and require that values written to such
+ * fields be instances of a class which is safe by construction. Closure's Safe
+ * HTML Types is one implementation of this technique (
+ * https://github.com/google/safe-html-types/blob/master/doc/safehtml-types.md).
+ * The TrustedTypes polyfill in API-only mode could also be used as a basis
+ * for this technique (https://github.com/WICG/trusted-types).
+ *
+ * @param node The HTML node (usually either a #text node or an Element) that
+ *   is being written to. Note that this is just an exemplar node, the write
+ *   may take place against another instance of the same class of node.
+ * @param name The name of an attribute or property (for example, 'href').
+ * @param type Indicates whether the write that's about to be performed will
+ *   be to a property or a node.
+ * @returns A function that will sanitize this class of writes.
+ */
+export type SanitizerFactory =
+    (node: Node, name: string, type: 'property'|'attribute') => ValueSanitizer;
+
+/**
+ * A function which can sanitize values that will be written to a specific kind
+ * of DOM sink.
+ *
+ * See SanitizerFactory.
+ *
+ * @param value The value to sanitize. Will be the actual value passed into
+ *   the lit-html template literal, so this could be of any type.
+ * @returns The value to write to the DOM. Usually the same as the input value,
+ *   unless sanitization is needed.
+ */
+export type ValueSanitizer = (value: unknown) => unknown;
+
+const identityFunction: ValueSanitizer = (value: unknown) => value;
+const noopSanitizer: SanitizerFactory =
+    (_node: Node, _name: string, _type: 'property'|'attribute') =>
+        identityFunction;
+
+/**
+ * A global callback used to get a sanitizer for a given field.
+ */
+export let sanitizerFactory: SanitizerFactory = noopSanitizer;
+
+/** Sets the global sanitizer factory. */
+export const setSanitizerFactory = (newSanitizer: SanitizerFactory) => {
+  if (sanitizerFactory !== noopSanitizer) {
+    throw new Error(
+        `Attempted to overwrite existing lit-html security policy.` +
+        ` setSanitizeDOMValueFactory should be called at most once.`);
+  }
+  sanitizerFactory = newSanitizer;
+};
+
+/**
+ * Only used in internal tests, not a part of the public API.
+ * The name and implementation may change at any time.
+ */
+export const __testOnlyClearSanitizerFactoryDoNotCallOrElse = () => {
+  sanitizerFactory = noopSanitizer;
+};
+
+/**
  * Writes attribute values to the DOM for a group of AttributeParts bound to a
  * single attribute. The value is only set once even if there are multiple parts
  * for an attribute.
@@ -45,15 +110,28 @@ export const isIterable = (value: unknown): value is Iterable<unknown> => {
 export class AttributeCommitter {
   readonly element: Element;
   readonly name: string;
-  readonly strings: ReadonlyArray<string>;
-  readonly parts: ReadonlyArray<AttributePart>;
+  readonly strings: readonly string[];
+  readonly parts: readonly AttributePart[];
+  readonly sanitizer: ValueSanitizer;
   dirty = true;
 
-  constructor(element: Element, name: string, strings: ReadonlyArray<string>) {
+  constructor(
+      element: Element, name: string, strings: readonly string[],
+      // Next breaking change, consider making this param required.
+      templatePart?: AttributeTemplatePart,
+      kind: 'property'|'attribute' = 'attribute') {
     this.element = element;
     this.name = name;
     this.strings = strings;
     this.parts = [];
+    let sanitizer = templatePart && templatePart.sanitizer;
+    if (sanitizer === undefined) {
+      sanitizer = sanitizerFactory(element, name, kind);
+      if (templatePart !== undefined) {
+        templatePart.sanitizer = sanitizer;
+      }
+    }
+    this.sanitizer = sanitizer;
     for (let i = 0; i < strings.length - 1; i++) {
       (this.parts as AttributePart[])[i] = this._createPart();
     }
@@ -68,12 +146,34 @@ export class AttributeCommitter {
 
   protected _getValue(): unknown {
     const strings = this.strings;
+    const parts = this.parts;
     const l = strings.length - 1;
+
+    // If we're assigning an attribute via syntax like:
+    //    attr="${foo}"  or  attr=${foo}
+    // but not
+    //    attr="${foo} ${bar}" or attr="${foo} baz"
+    // then we don't want to coerce the attribute value into one long
+    // string. Instead we want to just return the value itself directly,
+    // so that sanitizeDOMValue can get the actual value rather than
+    // String(value)
+    // The exception is if v is an array, in which case we do want to smash
+    // it together into a string without calling String() on the array.
+    //
+    // This also allows trusted values (when using TrustedTypes) being
+    // assigned to DOM sinks without being stringified in the process.
+    if (l === 1 && strings[0] === '' && strings[1] === '' &&
+        parts[0] !== undefined) {
+      const v = parts[0].value;
+      if (!isIterable(v)) {
+        return v;
+      }
+    }
     let text = '';
 
     for (let i = 0; i < l; i++) {
       text += strings[i];
-      const part = this.parts[i];
+      const part = parts[i];
       if (part !== undefined) {
         const v = part.value;
         if (isPrimitive(v) || !isIterable(v)) {
@@ -93,7 +193,13 @@ export class AttributeCommitter {
   commit(): void {
     if (this.dirty) {
       this.dirty = false;
-      this.element.setAttribute(this.name, this._getValue() as string);
+      let value = this._getValue();
+      value = this.sanitizer(value);
+      if (typeof value === 'symbol') {
+        // Native Symbols throw if they're coerced to string.
+        value = String(value);
+      }
+      this.element.setAttribute(this.name, value as string);
     }
   }
 }
@@ -147,10 +253,22 @@ export class NodePart implements Part {
   startNode!: Node;
   endNode!: Node;
   value: unknown = undefined;
+  readonly templatePart: NodeTemplatePart|undefined;
   private __pendingValue: unknown = undefined;
+  /**
+   * The sanitizer to use when writing text contents into this NodePart.
+   *
+   * We have to initialize this here rather than at the template literal level
+   * because the security of text content depends on the context into which
+   * it's written. e.g. the same text has different security requirements
+   * when a child of a <script> vs a <style> vs a <div>.
+   */
+  private textSanitizer: ValueSanitizer|undefined = undefined;
 
-  constructor(options: RenderOptions) {
+  constructor(
+      options: RenderOptions, templatePart?: NodeTemplatePart|undefined) {
     this.options = options;
+    this.templatePart = templatePart;
   }
 
   /**
@@ -248,18 +366,30 @@ export class NodePart implements Part {
   private __commitText(value: unknown): void {
     const node = this.startNode.nextSibling!;
     value = value == null ? '' : value;
-    // If `value` isn't already a string, we explicitly convert it here in case
-    // it can't be implicitly converted - i.e. it's a symbol.
-    const valueAsString: string =
-        typeof value === 'string' ? value : String(value);
     if (node === this.endNode.previousSibling &&
         node.nodeType === 3 /* Node.TEXT_NODE */) {
       // If we only have a single text node between the markers, we can just
       // set its value, rather than replacing it.
-      // TODO(justinfagnani): Can we just check if this.value is primitive?
-      (node as Text).data = valueAsString;
+      if (this.textSanitizer === undefined) {
+        this.textSanitizer = sanitizerFactory(node, 'data', 'property');
+      }
+      const renderedValue = this.textSanitizer(value);
+      (node as Text).data = typeof renderedValue === 'string' ?
+          renderedValue :
+          String(renderedValue);
     } else {
-      this.__commitNode(document.createTextNode(valueAsString));
+      // When setting text content, for security purposes it matters a lot what
+      // the parent is. For example, <style> and <script> need to be handled
+      // with care, while <span> does not. So first we need to put a text node
+      // into the document, then we can sanitize its contentx.
+      const textNode = document.createTextNode('');
+      this.__commitNode(textNode);
+      if (this.textSanitizer === undefined) {
+        this.textSanitizer = sanitizerFactory(textNode, 'data', 'property');
+      }
+      const renderedValue = this.textSanitizer(value) as string;
+      textNode.data = typeof renderedValue === 'string' ? renderedValue :
+                                                          String(renderedValue);
     }
     this.value = value;
   }
@@ -270,6 +400,22 @@ export class NodePart implements Part {
         this.value.template === template) {
       this.value.update(value.values);
     } else {
+      // `value` is a template result that was constructed without knowledge of
+      // the parent we're about to write it into. sanitizeDOMValue hasn't been
+      // made aware of this relationship, and for scripts and style specifically
+      // this is known to be unsafe. So in the case where the user is in
+      // "secure mode" (i.e. when there's a sanitizeDOMValue set), we just want
+      // to forbid this because it's not a use case we want to support.
+      // We only apply this policy when sanitizerFactory has been set to
+      // prevent this from being a breaking change to the library.
+      const parent = this.endNode.parentNode!;
+      if (sanitizerFactory !== noopSanitizer && parent.nodeName === 'STYLE' ||
+          parent.nodeName === 'SCRIPT') {
+        this.__commitText(
+            '/* lit-html will not write ' +
+            'TemplateResults to scripts and styles */');
+        return;
+      }
       // Make sure we propagate the template processor from the TemplateResult
       // so that we use its syntax extension, etc. The template factory comes
       // from the render function options so that it can control template
@@ -311,7 +457,7 @@ export class NodePart implements Part {
 
       // If no existing part, create a new one
       if (itemPart === undefined) {
-        itemPart = new NodePart(this.options);
+        itemPart = new NodePart(this.options, this.templatePart);
         itemParts.push(itemPart);
         if (partIndex === 0) {
           itemPart.appendIntoPart(this);
@@ -399,8 +545,11 @@ export class BooleanAttributePart implements Part {
 export class PropertyCommitter extends AttributeCommitter {
   readonly single: boolean;
 
-  constructor(element: Element, name: string, strings: ReadonlyArray<string>) {
-    super(element, name, strings);
+  constructor(
+      element: Element, name: string, strings: readonly string[],
+      // Next breaking change, consider making this param required.
+      templatePart?: AttributeTemplatePart) {
+    super(element, name, strings, templatePart, 'property');
     this.single =
         (strings.length === 2 && strings[0] === '' && strings[1] === '');
   }
@@ -419,8 +568,10 @@ export class PropertyCommitter extends AttributeCommitter {
   commit(): void {
     if (this.dirty) {
       this.dirty = false;
+      let value = this._getValue();
+      value = this.sanitizer(value);
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (this.element as any)[this.name] = this._getValue();
+      (this.element as any)[this.name] = value;
     }
   }
 }

--- a/src/lib/render.ts
+++ b/src/lib/render.ts
@@ -45,10 +45,14 @@ export const render =
       let part = parts.get(container);
       if (part === undefined) {
         removeNodes(container, container.firstChild);
-        parts.set(container, part = new NodePart({
-                               templateFactory,
-                               ...options,
-                             }));
+        parts.set(
+            container,
+            part = new NodePart(
+                {
+                  templateFactory,
+                  ...options,
+                },
+                undefined));
         part.appendInto(container);
       }
       part.setValue(result);

--- a/src/lib/template-instance.ts
+++ b/src/lib/template-instance.ts
@@ -140,12 +140,13 @@ export class TemplateInstance {
 
       // We've arrived at our part's node.
       if (part.type === 'node') {
-        const part = this.processor.handleTextExpression(this.options);
-        part.insertAfterNode(node!.previousSibling!);
-        this.__parts.push(part);
+        const textPart =
+            this.processor.handleTextExpression(this.options, part);
+        textPart.insertAfterNode(node!.previousSibling!);
+        this.__parts.push(textPart);
       } else {
         this.__parts.push(...this.processor.handleAttributeExpressions(
-            node as Element, part.name, part.strings, this.options));
+            node as Element, part.name, part.strings, this.options, part));
       }
       partIndex++;
     }

--- a/src/lib/template-processor.ts
+++ b/src/lib/template-processor.ts
@@ -19,6 +19,7 @@
 import {Part} from './part.js';
 import {NodePart} from './parts.js';
 import {RenderOptions} from './render-options.js';
+import {AttributeTemplatePart, NodeTemplatePart} from './template.js';
 
 export interface TemplateProcessor {
   /**
@@ -29,14 +30,22 @@ export interface TemplateProcessor {
    * @param name  The attribute name
    * @param strings The string literals. There are always at least two strings,
    *   event for fully-controlled bindings with a single expression.
+   * @param templatePart The AttributeTemplatePart for this expression
+   *     as extracted by the Template class. Can be used to cache information
+   *     that should be computed once per template literal in the source code.
    */
   handleAttributeExpressions(
-      element: Element, name: string, strings: ReadonlyArray<string>,
-      options: RenderOptions): ReadonlyArray<Part>;
+      element: Element, name: string, strings: readonly string[],
+      options: RenderOptions,
+      // TODO: next breaking change, consider making this required
+      templatePart?: AttributeTemplatePart): readonly Part[];
 
   /**
    * Create parts for a text-position binding.
    * @param partOptions
    */
-  handleTextExpression(options: RenderOptions): NodePart;
+  handleTextExpression(
+      options: RenderOptions,
+      // TODO: next breaking change, consider making this required
+      templatePart?: NodeTemplatePart): NodePart;
 }

--- a/src/lib/template-result.ts
+++ b/src/lib/template-result.ts
@@ -20,6 +20,28 @@ import {reparentNodes} from './dom.js';
 import {TemplateProcessor} from './template-processor.js';
 import {boundAttributeSuffix, lastAttributeNameRegex, marker, nodeMarker} from './template.js';
 
+let policy: Pick<TrustedTypePolicy, 'createHTML'>|undefined;
+
+/**
+ * Turns the value to trusted HTML. If the application uses Trusted Types the
+ * value is transformed into TrustedHTML, which can be assigned to execution
+ * sink. If the application doesn't use Trusted Types, the return value is the
+ * same as the argument.
+ */
+function convertConstantTemplateStringToTrustedHTML(value: string): string|
+    TrustedHTML {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const w = window as any
+  // TrustedTypes have been renamed to trustedTypes
+  // (https://github.com/WICG/trusted-types/issues/177)
+  const trustedTypes =
+      (w.trustedTypes || w.TrustedTypes) as TrustedTypePolicyFactory;
+  if (trustedTypes && !policy) {
+    policy = trustedTypes.createPolicy('lit-html', {createHTML: (s) => s});
+  }
+  return policy ? policy.createHTML(value) : value;
+}
+
 const commentMarker = ` ${marker} `;
 
 /**
@@ -100,7 +122,11 @@ export class TemplateResult {
 
   getTemplateElement(): HTMLTemplateElement {
     const template = document.createElement('template');
-    template.innerHTML = this.getHTML();
+    // this is secure because `this.strings` is a TemplateStringsArray.
+    // TODO: validate this when
+    // https://github.com/tc39/proposal-array-is-template-object is implemented.
+    template.innerHTML =
+        convertConstantTemplateStringToTrustedHTML(this.getHTML()) as string;
     return template;
   }
 }

--- a/src/lib/template.ts
+++ b/src/lib/template.ts
@@ -15,7 +15,7 @@
 /**
  * @module lit-html
  */
-
+import {ValueSanitizer} from './parts.js';
 import {TemplateResult} from './template-result.js';
 
 /**
@@ -106,7 +106,13 @@ export class Template {
                 (node as Element).getAttribute(attributeLookupName)!;
             (node as Element).removeAttribute(attributeLookupName);
             const statics = attributeValue.split(markerRegex);
-            this.parts.push({type: 'attribute', index, name, strings: statics});
+            this.parts.push({
+              type: 'attribute',
+              index,
+              name,
+              strings: statics,
+              sanitizer: undefined
+            });
             partIndex += statics.length - 1;
           }
         }
@@ -213,15 +219,20 @@ const endsWith = (str: string, suffix: string): boolean => {
  * TemplateInstance could instead be more careful about which values it gives
  * to Part.update().
  */
-export type TemplatePart = {
-  readonly type: 'node'; index: number;
-}|{
+export type TemplatePart = NodeTemplatePart|AttributeTemplatePart;
+export interface NodeTemplatePart {
+  readonly type: 'node';
+  index: number;
+}
+
+export interface AttributeTemplatePart {
   readonly type: 'attribute';
   index: number;
   readonly name: string;
-  readonly strings: ReadonlyArray<string>;
-};
-
+  readonly strings: readonly string[];
+  // Lazily initialized in the default-template-processor.
+  sanitizer?: ValueSanitizer;
+}
 export const isTemplatePartActive = (part: TemplatePart) => part.index !== -1;
 
 // Allows `document.createComment('')` to be renamed for a

--- a/src/lit-html.ts
+++ b/src/lit-html.ts
@@ -38,7 +38,7 @@ export {directive, DirectiveFn, isDirective} from './lib/directive.js';
 // TODO(justinfagnani): remove line when we get NodePart moving methods
 export {removeNodes, reparentNodes} from './lib/dom.js';
 export {noChange, nothing, Part} from './lib/part.js';
-export {AttributeCommitter, AttributePart, BooleanAttributePart, EventPart, isIterable, isPrimitive, NodePart, PropertyCommitter, PropertyPart} from './lib/parts.js';
+export {AttributeCommitter, AttributePart, BooleanAttributePart, EventPart, isIterable, isPrimitive, NodePart, PropertyCommitter, PropertyPart, SanitizerFactory as DOMSanitizerFactory, sanitizerFactory, setSanitizerFactory, ValueSanitizer as DOMValueSanitizer} from './lib/parts.js';
 export {RenderOptions} from './lib/render-options.js';
 export {parts, render} from './lib/render.js';
 export {templateCaches, templateFactory} from './lib/template-factory.js';

--- a/src/test/directives/class-map_test.ts
+++ b/src/test/directives/class-map_test.ts
@@ -81,14 +81,24 @@ suite('classMap', () => {
     assert.isFalse(el.classList.contains('foo'));
   });
 
-  test('can override static classes', () => {
+  test('works with imperatively added classes', () => {
+    renderClassMap({foo: true});
+    const el = container.firstElementChild!;
+    assert.isTrue(el.classList.contains('foo'));
+
+    el.classList.add('bar');
+    assert.isTrue(el.classList.contains('bar'));
+
+    renderClassMap({foo: false});
+    assert.isFalse(el.classList.contains('foo'));
+    assert.isTrue(el.classList.contains('bar'));
+  });
+
+  test('can not override static classes', () => {
     renderClassMapStatic({aa: false, bb: true});
     const el = container.firstElementChild!;
-    assert.isFalse(el.classList.contains('aa'));
+    assert.isTrue(el.classList.contains('aa'));
     assert.isTrue(el.classList.contains('bb'));
-    renderClassMapStatic({});
-    assert.isFalse(el.classList.contains('aa'));
-    assert.isFalse(el.classList.contains('bb'));
   });
 
   test('changes classes when used with the same object', () => {

--- a/src/test/lib/shady-render_test.ts
+++ b/src/test/lib/shady-render_test.ts
@@ -375,4 +375,37 @@ suite('shady-render', () => {
         assert.equal(error3.message, 'The `scopeName` option is required.');
         document.body.removeChild(container);
       });
+
+  test('parts around <slot> elemnets', () => {
+    const el = document.createElement('slot-host');
+    document.body.appendChild(el);
+    const render = (title: string) => {
+      renderShadowRoot(
+          html
+          `<slot name="before" > </slot>${title}<slot name="after"></slot >`,
+          el);
+    };
+    render('foo');
+    assert.equal(el.shadowRoot?.textContent, ' foo');
+    render('bar');
+    assert.equal(el.shadowRoot?.textContent, ' bar');
+    render('');
+    assert.equal(el.shadowRoot?.textContent, ' ');
+    render('zot');
+    assert.equal(el.shadowRoot?.textContent, ' zot');
+    const c1 = document.createElement('div');
+    c1.setAttribute('slot', 'before');
+    el.appendChild(c1);
+    assert.equal(el.shadowRoot?.textContent, ' zot');
+    render('c1');
+    assert.equal(el.shadowRoot?.textContent, ' c1');
+    const c2 = document.createElement('div');
+    c2.setAttribute('slot', 'after');
+    el.appendChild(c2);
+    render('c1c2');
+    assert.equal(el.shadowRoot?.textContent, ' c1c2');
+    el.textContent = '';
+    assert.equal(el.shadowRoot?.textContent, ' c1c2');
+    document.body.removeChild(el);
+  });
 });

--- a/src/test/lib/trusted-types_test.ts
+++ b/src/test/lib/trusted-types_test.ts
@@ -1,0 +1,182 @@
+/**
+ * @license
+ * Copyright (c) 2019 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+import {unsafeHTML} from '../../directives/unsafe-html';
+import {html, render} from '../../lit-html.js';
+import {stripExpressionMarkers} from '../test-utils/strip-markers';
+
+const assert = chai.assert;
+
+const createTrustedValue = (value: string) => `TRUSTED${value}`;
+const isTrustedValue = (value: string) => value.startsWith('TRUSTED');
+const unwrapTrustedValue = (value: string) => value.substr('TRUSTED'.length);
+
+const unsafeHTMLString = '<img src=x onerror="alert(0)">';
+const unsafeScriptString = 'alert(0)';
+
+// Trusted types emulation does not work in IE11 or Chrome 41.
+const isIE = /Trident\/\d/.test(navigator.userAgent);
+const isChrome41 = /Chrome\/41/.test(navigator.userAgent);
+
+// TODO: replace trusted types emulation with trusted types polyfill,
+//   then re-enable these tests in IE and old Chrome.
+if (!(isIE || isChrome41)) {
+  suite('rendering with trusted types enforced', () => {
+    let container: HTMLDivElement;
+    let descriptorEntries: {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      object: any;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      prop: any;
+      desc: PropertyDescriptor;
+    }[] = [];
+    let setAttributeDescriptor: PropertyDescriptor;
+    let policy: TrustedTypePolicy;
+
+    function emulateSetAttribute() {
+      // enforce trusted values only on properties in this array
+      const unsafeAttributeList = ['srcdoc'];
+      setAttributeDescriptor =
+          Object.getOwnPropertyDescriptor(Element.prototype, 'setAttribute')!;
+      Object.defineProperty(Element.prototype, 'setAttribute', {
+        value: function(name: string, value: string) {
+          let args = [name, value];
+          unsafeAttributeList.forEach((attr) => {
+            if (attr === name) {
+              if (isTrustedValue(value)) {
+                args = [name, unwrapTrustedValue(value)];
+              } else {
+                throw new Error(value);
+              }
+            }
+          });
+          setAttributeDescriptor.value.apply(this, args);
+        }
+      });
+    }
+
+    function emulateTrustedTypesOnProperty<Obj, K extends keyof Obj>(
+        object: Obj, prop: K) {
+      const desc = Object.getOwnPropertyDescriptor(object, prop)!;
+      descriptorEntries.push({object, prop, desc});
+      Object.defineProperty(object, prop, {
+        set: function(value: string) {
+          if (isTrustedValue(value)) {
+            desc.set!.apply(this, [unwrapTrustedValue(value)]);
+          } else {
+            throw new Error(value);
+          }
+        },
+      });
+    }
+
+    function removeAllTrustedTypesEmulation() {
+      descriptorEntries.forEach(({object, prop, desc}) => {
+        Object.defineProperty(object, prop, desc);
+      });
+      descriptorEntries = [];
+
+      Object.defineProperty(
+          Element.prototype, 'setAttribute', setAttributeDescriptor);
+    }
+
+    suiteSetup(() => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (window as any).trustedTypes = {
+        isHTML: (v: string) => isTrustedValue(v),
+        createPolicy: () => {
+          return {
+            createHTML: createTrustedValue,
+            createScript: createTrustedValue,
+            createScriptURL: createTrustedValue,
+          };
+        },
+        isScript: (v: string) => isTrustedValue(v),
+        isScriptURL: (v: string) => isTrustedValue(v),
+      };
+
+      emulateTrustedTypesOnProperty(Element.prototype, 'innerHTML');
+      emulateSetAttribute();
+
+      // create app root in the DOM
+      container = document.createElement('div');
+      document.body.appendChild(container);
+
+      // TODO: signature will change once we use trusted types polyfill
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      policy = (window as any).trustedTypes.createPolicy()
+    });
+
+    suiteTeardown(() => {
+      removeAllTrustedTypesEmulation();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      delete (window as any).trustedTypes;
+      document.body.removeChild(container);
+    });
+
+    test('Trusted types emulation works', () => {
+      const el = document.createElement('div');
+      assert.equal(el.innerHTML, '');
+      el.innerHTML = policy.createHTML('<span>val</span>') as unknown as string;
+      assert.equal(el.innerHTML, '<span>val</span>');
+
+      assert.throws(() => {
+        el.innerHTML = unsafeHTMLString;
+      });
+    });
+
+    suite('throws on untrusted values', () => {
+      test('unsafe html', () => {
+        const template = html`${unsafeHTML('<b>unsafe bold</b>')}`;
+        assert.throws(() => {
+          render(template, container);
+        });
+      });
+
+      test('unsafe attribute', () => {
+        const template = html`<iframe srcdoc=${unsafeScriptString}></iframe>`;
+        assert.throws(() => {
+          render(template, container);
+        });
+      });
+    });
+
+    suite('runs without error on trusted values', () => {
+      test('unsafe html', () => {
+        const template =
+            html`${unsafeHTML(policy.createHTML('<b>safe bold</b>'))}`;
+        render(template, container);
+        assert.equal(
+            stripExpressionMarkers(container.innerHTML), '<b>safe bold</b>');
+      });
+
+      test('unsafe attribute', () => {
+        const template =
+            html`<iframe srcdoc=${policy.createHTML('<b>safe bold</b>')}>`;
+        render(template, container);
+        assert.equal(
+            stripExpressionMarkers(container.innerHTML),
+            '<iframe srcdoc="<b>safe bold</b>"></iframe>');
+      });
+    });
+  });
+}
+
+if (isIE || isChrome41) {
+  suite('a suite that makes IE and Chrome41 not time out', () => {
+    test('has a test', () => {
+      assert.equal(1 + 1, 2);
+    });
+  });
+}

--- a/src/test/lit-html_test.ts
+++ b/src/test/lit-html_test.ts
@@ -58,9 +58,11 @@ suite('index.js', () => {
   });
 
   test('exports everything from lib/parts.js', () => {
-    Object.keys(LibParts).forEach((key) => {
-      assert.property(LitHtml, key);
-    });
+    Object.keys(LibParts)
+        .filter((k) => !/^__testOnly/.test(k))
+        .forEach((key) => {
+          assert.property(LitHtml, key);
+        });
   });
 
   test('exports everything from lib/directive.js', () => {

--- a/test/index.html
+++ b/test/index.html
@@ -40,6 +40,7 @@
         'shady-scoping-shim.html?shadydom=true&shimcssproperties=true',
         'no-template.html',
         'shady_no-wc.html',
+        'trusted-types.html',
       ]);
     </script>
   </body>

--- a/test/trusted-types.html
+++ b/test/trusted-types.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html>
+  <head>
+    <script src="../node_modules/mocha/mocha.js"></script>
+    <script src="../node_modules/chai/chai.js"></script>
+    <script src="../node_modules/wct-mocha/wct-mocha.js"></script>
+    <script src="../node_modules/@webcomponents/webcomponentsjs/webcomponents-bundle.js"></script>
+  </head>
+  <body>
+    <script type="module" src="./lib/trusted-types_test.js"></script>
+  </body>
+</html>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "target": "es2017",
     "module": "es2015",
     "lib": ["es2017", "esnext.asynciterable", "dom"],
-    "types": ["chai", "mocha"],
+    "types": ["chai", "mocha", "trusted-types"],
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,


### PR DESCRIPTION
This is a revert of the revert of the sanitization hooks and trusted types support.

I generated this with:

```bash
git revert -n cc6e67ea1d082582a4236fdcee453e446289ec97^..f4c1a6db6e51264e1edb08a8e600c69f589fbc7e
```

This PR isn't to be merged until we attempt some lighter weight ways of integrating the hooks.