### PR TITLE
WIP: Add a generic for directive factories to type check against

### DIFF
--- a/src/directives/live.ts
+++ b/src/directives/live.ts
@@ -37,7 +37,7 @@ import {AttributePart, BooleanAttributePart, directive, EventPart, NodePart, Pro
  * passed in, or the binding will update every render.
  */
 export const live = directive(
-    (value: unknown) => (part: AttributePart|PropertyPart|
+    <T>(value: T) => (part: AttributePart|PropertyPart|
                          BooleanAttributePart) => {
       let previousValue: unknown;
       if (part instanceof EventPart || part instanceof NodePart) {

--- a/src/directives/live.ts
+++ b/src/directives/live.ts
@@ -12,7 +12,7 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {AttributePart, BooleanAttributePart, directive, EventPart, NodePart, PropertyPart} from '../lit-html.js';
+import {AttributePart, BooleanAttributePart, directive, DirectiveFn, EventPart, NodePart, PropertyPart} from '../lit-html.js';
 
 /**
  * Checks binding values against live DOM values, instead of previously bound
@@ -37,37 +37,37 @@ import {AttributePart, BooleanAttributePart, directive, EventPart, NodePart, Pro
  * passed in, or the binding will update every render.
  */
 export const live = directive(
-    <T>(value: T) => (part: AttributePart|PropertyPart|
-                         BooleanAttributePart) => {
-      let previousValue: unknown;
-      if (part instanceof EventPart || part instanceof NodePart) {
-        throw new Error(
-            'The `live` directive is not allowed on text or event bindings');
-      }
-      if (part instanceof BooleanAttributePart) {
-        checkStrings(part.strings);
-        previousValue = part.element.hasAttribute(part.name);
-        // This is a hack needed because BooleanAttributePart doesn't have a
-        // committer and does its own dirty checking after directives
-        part.value = previousValue;
-      } else {
-        const {element, name, strings} = part.committer;
-        checkStrings(strings);
-        if (part instanceof PropertyPart) {
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          previousValue = (element as any)[name];
-          if (previousValue === value) {
-            return;
+    <T>(value: T) =>
+        ((part: AttributePart|PropertyPart|BooleanAttributePart) => {
+          let previousValue: unknown;
+          if (part instanceof EventPart || part instanceof NodePart) {
+            throw new Error(
+                'The `live` directive is not allowed on text or event bindings');
           }
-        } else if (part instanceof AttributePart) {
-          previousValue = element.getAttribute(name);
-        }
-        if (previousValue === String(value)) {
-          return;
-        }
-      }
-      part.setValue(value);
-    });
+          if (part instanceof BooleanAttributePart) {
+            checkStrings(part.strings);
+            previousValue = part.element.hasAttribute(part.name);
+            // This is a hack needed because BooleanAttributePart doesn't have a
+            // committer and does its own dirty checking after directives
+            part.value = previousValue;
+          } else {
+            const {element, name, strings} = part.committer;
+            checkStrings(strings);
+            if (part instanceof PropertyPart) {
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              previousValue = (element as any)[name];
+              if (previousValue === value) {
+                return;
+              }
+            } else if (part instanceof AttributePart) {
+              previousValue = element.getAttribute(name);
+            }
+            if (previousValue === String(value)) {
+              return;
+            }
+          }
+          part.setValue(value);
+        }) as DirectiveFn<T>);
 
 const checkStrings = (strings: readonly string[]) => {
   if (strings.length !== 2 || strings[0] !== '' || strings[1] !== '') {

--- a/src/lib/directive.ts
+++ b/src/lib/directive.ts
@@ -21,7 +21,7 @@ import {Part} from './part.js';
 const directives = new WeakMap<object, true>();
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type DirectiveFactory = (...args: any[]) => object;
+export type DirectiveFactory<T = unknown> = (...args: Array<any | T>) => object;
 
 export type DirectiveFn = (part: Part) => void;
 
@@ -65,7 +65,7 @@ export type DirectiveFn = (part: Part) => void;
  *   }
  * });
  */
-export const directive = <F extends DirectiveFactory>(f: F): F =>
+export const directive = <F extends DirectiveFactory<T>, T>(f: F): F =>
     ((...args: unknown[]) => {
       const d = f(...args);
       directives.set(d, true);

--- a/src/lib/directive.ts
+++ b/src/lib/directive.ts
@@ -21,9 +21,9 @@ import {Part} from './part.js';
 const directives = new WeakMap<object, true>();
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type DirectiveFactory<T = unknown> = (...args: Array<any | T>) => object;
+export type DirectiveFactory<T = unknown> = (...args: Array<any|T>) => object;
 
-export type DirectiveFn = (part: Part) => void;
+export type DirectiveFn<_T = unknown> = (part: Part) => void;
 
 /**
  * Brands a function as a directive factory function so that lit-html will call


### PR DESCRIPTION
I'm hoping that something like this is sufficient to type-check directives generically.

The idea is directive factories would mark which parameters might be assigned to the property with the generic, and lit-analyzer would check assignability against the property.

@rictic @runem wdyt?