### PR TITLE
Restore trusted types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## Unreleased
 
 ### Added
-* Added support for running with enforced Trusted Types: https://github.com/WICG/trusted-types
+* Added support for [Trusted Types](https://github.com/WICG/trusted-types). This support uses a policy named 'lit-html' for parsing the static parts of html literals, and ensures that we pass trusted type values through to the DOM when used in bindings.
 
 ## [1.2.1] - 2020-03-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,10 +17,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 <!-- ### Fixed -->
 <!-- ### Removed -->
 
+## Unreleased
+
+### Added
+* Added support for running with enforced Trusted Types: https://github.com/WICG/trusted-types
+
 ## [1.2.1] - 2020-03-19
 
 ### Fixed
-* Add TypeScript type declarations for older versions of TypeScript. We're currently testing back to TS 3.4. We can't commit to never breaking TypeScript builds, but we'll be supporting older versions as best we can.
+* Added TypeScript type declarations for older versions of TypeScript. We're currently testing back to TS 3.4. We can't commit to never breaking TypeScript builds, but we'll be supporting older versions as best we can.
 
 ## [1.2.0] - 2020-03-18
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13000,9 +13000,9 @@
       }
     },
     "wct-mocha": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/wct-mocha/-/wct-mocha-1.0.1.tgz",
-      "integrity": "sha512-7k4krdiFcODjdo9uAxHDNpFm8AwFZUhKdUXMIdoJZzF6NHq3aONrvv/uPYvTDGYZxap4mEO53kSl/RDKIv8b8g==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/wct-mocha/-/wct-mocha-1.1.0.tgz",
+      "integrity": "sha512-Wq7xtXFtsCs4bZxjjgRp1PKV3sx7NrSl1JqEVI4zF0/yavlYa9hRMO/+73u1ZScnHc5kIKNPT3KBsoCaQI3+MQ==",
       "dev": true
     },
     "wct-sauce": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -707,7 +707,7 @@
     },
     "@polymer/test-fixture": {
       "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/@polymer/test-fixture/-/test-fixture-0.0.3.tgz",
+      "resolved": "http://registry.npmjs.org/@polymer/test-fixture/-/test-fixture-0.0.3.tgz",
       "integrity": "sha1-REN1JpfU2Sk7vEEuoLXk00HxSdk=",
       "dev": true
     },
@@ -1351,6 +1351,12 @@
       "integrity": "sha512-wHNBMnkoEBiRAd3s8KTKwIuO9biFtTf0LehITzBhSco+HQI0xkXZbLOD55SW3Aqw3oUkHstkm5SPv58yaAdFPQ==",
       "dev": true
     },
+    "@types/trusted-types": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-1.0.4.tgz",
+      "integrity": "sha512-6jtHrHpmiXOXoJ31Cg9R+iEVwuEKPf0XHwFUI93eEPXx492/J2JHyafkleKE2EYzZprayk9FSjTyK1GDqcwDng==",
+      "dev": true
+    },
     "@types/ua-parser-js": {
       "version": "0.7.33",
       "resolved": "https://registry.npmjs.org/@types/ua-parser-js/-/ua-parser-js-0.7.33.tgz",
@@ -1922,7 +1928,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
@@ -2714,7 +2720,7 @@
         },
         "readable-stream": {
           "version": "1.1.14",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "dev": true,
           "requires": {
@@ -3967,7 +3973,7 @@
         },
         "readable-stream": {
           "version": "1.1.14",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "dev": true,
           "requires": {
@@ -4143,7 +4149,7 @@
     },
     "enabled": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/enabled/-/enabled-1.0.2.tgz",
+      "resolved": "http://registry.npmjs.org/enabled/-/enabled-1.0.2.tgz",
       "integrity": "sha1-ll9lE9LC0cX0ZStkouM5ZGf8L5M=",
       "dev": true,
       "requires": {
@@ -4988,7 +4994,7 @@
     },
     "fecha": {
       "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/fecha/-/fecha-2.3.3.tgz",
+      "resolved": "http://registry.npmjs.org/fecha/-/fecha-2.3.3.tgz",
       "integrity": "sha512-lUGBnIamTAwk4znq5BcqsDaxSmZ9nDVJaij6NvRt/Tg4R69gERA+otPKbS86ROw9nxVMw2/mp1fnaiWqbs6Sdg==",
       "dev": true
     },
@@ -9607,7 +9613,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
@@ -11698,7 +11704,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
@@ -13194,7 +13200,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
   "devDependencies": {
     "@types/chai": "^4.1.0",
     "@types/mocha": "^7.0.1",
+    "@types/trusted-types": "^1.0.1",
     "@typescript-eslint/eslint-plugin": "^2.26.0",
     "@typescript-eslint/parser": "^2.26.0",
     "@webcomponents/shadycss": "^1.8.0",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "tachometer": "^0.4.15",
     "typescript": "~3.8.0",
     "uglify-es": "^3.3.5",
-    "wct-mocha": "^1.0.0",
+    "wct-mocha": "^1.1.0",
     "web-component-tester": "^6.9.0"
   },
   "husky": {

--- a/src/lib/parts.ts
+++ b/src/lib/parts.ts
@@ -69,11 +69,33 @@ export class AttributeCommitter {
   protected _getValue(): unknown {
     const strings = this.strings;
     const l = strings.length - 1;
+    const parts = this.parts;
+
+    // If we're assigning an attribute via syntax like:
+    //    attr="${foo}"  or  attr=${foo}
+    // but not
+    //    attr="${foo} ${bar}" or attr="${foo} baz"
+    // then we don't want to coerce the attribute value into one long
+    // string. Instead we want to just return the value itself directly,
+    // so that sanitizeDOMValue can get the actual value rather than
+    // String(value)
+    // The exception is if v is an array, in which case we do want to smash
+    // it together into a string without calling String() on the array.
+    //
+    // This also allows trusted values (when using TrustedTypes) being
+    // assigned to DOM sinks without being stringified in the process.
+    if (l === 1 && strings[0] === '' && strings[1] === '' &&
+        parts[0] !== undefined) {
+      const v = parts[0].value;
+      if (!isIterable(v)) {
+        return v;
+      }
+    }
     let text = '';
 
     for (let i = 0; i < l; i++) {
       text += strings[i];
-      const part = this.parts[i];
+      const part = parts[i];
       if (part !== undefined) {
         const v = part.value;
         if (isPrimitive(v) || !isIterable(v)) {
@@ -93,7 +115,12 @@ export class AttributeCommitter {
   commit(): void {
     if (this.dirty) {
       this.dirty = false;
-      this.element.setAttribute(this.name, this._getValue() as string);
+      let value = this._getValue() as string;
+      if (typeof value === 'symbol') {
+        // Native Symbols throw if they're coerced to string.
+        value = String(value);
+      }
+      this.element.setAttribute(this.name, value);
     }
   }
 }

--- a/src/lib/parts.ts
+++ b/src/lib/parts.ts
@@ -84,10 +84,12 @@ export class AttributeCommitter {
     //
     // This also allows trusted values (when using TrustedTypes) being
     // assigned to DOM sinks without being stringified in the process.
-    if (l === 1 && strings[0] === '' && strings[1] === '' &&
-        parts[0] !== undefined) {
+    if (l === 1 && strings[0] === '' && strings[1] === '') {
       const v = parts[0].value;
-      if (!isIterable(v)) {
+      if (typeof v === 'symbol') {
+        return String(v);
+      }
+      if (typeof v === 'string' || !isIterable(v)) {
         return v;
       }
     }
@@ -115,12 +117,7 @@ export class AttributeCommitter {
   commit(): void {
     if (this.dirty) {
       this.dirty = false;
-      let value = this._getValue() as string;
-      if (typeof value === 'symbol') {
-        // Native Symbols throw if they're coerced to string.
-        value = String(value);
-      }
-      this.element.setAttribute(this.name, value);
+      this.element.setAttribute(this.name, this._getValue() as string);
     }
   }
 }

--- a/src/lib/template-result.ts
+++ b/src/lib/template-result.ts
@@ -20,6 +20,7 @@ import {reparentNodes} from './dom.js';
 import {TemplateProcessor} from './template-processor.js';
 import {boundAttributeSuffix, lastAttributeNameRegex, marker, nodeMarker} from './template.js';
 
+declare const trustedTypes: typeof window.trustedTypes;
 /**
  * Our TrustedTypePolicy for HTML which is declared using the html template
  * tag function.
@@ -28,12 +29,8 @@ import {boundAttributeSuffix, lastAttributeNameRegex, marker, nodeMarker} from '
  * before any untrusted expressions have been mixed in. Therefor it is
  * considered safe by construction.
  */
-const policy = ((): Pick<TrustedTypePolicy, 'createHTML'>|void => {
-  const tt = window.trustedTypes;
-  if (tt !== undefined) {
-    return tt.createPolicy('lit-html', {createHTML: (s) => s});
-  }
-})();
+const policy = trustedTypes &&
+    trustedTypes.createPolicy('lit-html', {createHTML: (s) => s});
 
 const commentMarker = ` ${marker} `;
 

--- a/src/lib/template-result.ts
+++ b/src/lib/template-result.ts
@@ -20,27 +20,15 @@ import {reparentNodes} from './dom.js';
 import {TemplateProcessor} from './template-processor.js';
 import {boundAttributeSuffix, lastAttributeNameRegex, marker, nodeMarker} from './template.js';
 
-let policy: Pick<TrustedTypePolicy, 'createHTML'>|undefined;
-
 /**
- * Turns the value to trusted HTML. If the application uses Trusted Types the
- * value is transformed into TrustedHTML, which can be assigned to execution
- * sink. If the application doesn't use Trusted Types, the return value is the
- * same as the argument.
+ * Our TrustedTypePolicy for HTML which is declared using the html template
+ * tag function.
+ *
+ * That HTML is a developer-authored constant, and is parsed with innerHTML
+ * before any untrusted expressions have been mixed in. Therefor it is
+ * considered safe by construction.
  */
-function convertConstantTemplateStringToTrustedHTML(value: string): string|
-    TrustedHTML {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const w = window as any
-  // TrustedTypes have been renamed to trustedTypes
-  // (https://github.com/WICG/trusted-types/issues/177)
-  const trustedTypes =
-      (w.trustedTypes || w.trustedTypes) as TrustedTypePolicyFactory;
-  if (trustedTypes && !policy) {
-    policy = trustedTypes.createPolicy('lit-html', {createHTML: (s) => s});
-  }
-  return policy ? policy.createHTML(value) : value;
-}
+let policy: Pick<TrustedTypePolicy, 'createHTML'>|undefined;
 
 const commentMarker = ` ${marker} `;
 
@@ -122,11 +110,17 @@ export class TemplateResult {
 
   getTemplateElement(): HTMLTemplateElement {
     const template = document.createElement('template');
+    let value = this.getHTML();
+    const trustedTypes = window.trustedTypes;
+    if (trustedTypes && !policy) {
+      policy = trustedTypes.createPolicy('lit-html', {createHTML: (s) => s});
+    }
     // this is secure because `this.strings` is a TemplateStringsArray.
     // TODO: validate this when
     // https://github.com/tc39/proposal-array-is-template-object is implemented.
-    template.innerHTML =
-        convertConstantTemplateStringToTrustedHTML(this.getHTML()) as string;
+    value = policy ? (policy.createHTML(value) as unknown as string) : value;
+
+    template.innerHTML = value;
     return template;
   }
 }

--- a/src/lib/template-result.ts
+++ b/src/lib/template-result.ts
@@ -20,6 +20,28 @@ import {reparentNodes} from './dom.js';
 import {TemplateProcessor} from './template-processor.js';
 import {boundAttributeSuffix, lastAttributeNameRegex, marker, nodeMarker} from './template.js';
 
+let policy: Pick<TrustedTypePolicy, 'createHTML'>|undefined;
+
+/**
+ * Turns the value to trusted HTML. If the application uses Trusted Types the
+ * value is transformed into TrustedHTML, which can be assigned to execution
+ * sink. If the application doesn't use Trusted Types, the return value is the
+ * same as the argument.
+ */
+function convertConstantTemplateStringToTrustedHTML(value: string): string|
+    TrustedHTML {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const w = window as any
+  // TrustedTypes have been renamed to trustedTypes
+  // (https://github.com/WICG/trusted-types/issues/177)
+  const trustedTypes =
+      (w.trustedTypes || w.trustedTypes) as TrustedTypePolicyFactory;
+  if (trustedTypes && !policy) {
+    policy = trustedTypes.createPolicy('lit-html', {createHTML: (s) => s});
+  }
+  return policy ? policy.createHTML(value) : value;
+}
+
 const commentMarker = ` ${marker} `;
 
 /**
@@ -100,7 +122,11 @@ export class TemplateResult {
 
   getTemplateElement(): HTMLTemplateElement {
     const template = document.createElement('template');
-    template.innerHTML = this.getHTML();
+    // this is secure because `this.strings` is a TemplateStringsArray.
+    // TODO: validate this when
+    // https://github.com/tc39/proposal-array-is-template-object is implemented.
+    template.innerHTML =
+        convertConstantTemplateStringToTrustedHTML(this.getHTML()) as string;
     return template;
   }
 }

--- a/src/lib/template-result.ts
+++ b/src/lib/template-result.ts
@@ -29,8 +29,8 @@ declare const trustedTypes: typeof window.trustedTypes;
  * before any untrusted expressions have been mixed in. Therefor it is
  * considered safe by construction.
  */
-const policy = trustedTypes &&
-    trustedTypes.createPolicy('lit-html', {createHTML: (s) => s});
+const policy = window.trustedTypes &&
+    trustedTypes!.createPolicy('lit-html', {createHTML: (s) => s});
 
 const commentMarker = ` ${marker} `;
 

--- a/src/test/lib/modify-template_test.ts
+++ b/src/test/lib/modify-template_test.ts
@@ -15,6 +15,7 @@
 import {insertNodeIntoTemplate, removeNodesFromTemplate} from '../../lib/modify-template.js';
 import {render} from '../../lib/render.js';
 import {html, templateFactory} from '../../lit-html.js';
+import {policy} from '../test-utils/security.js';
 import {stripExpressionMarkers} from '../test-utils/strip-markers.js';
 
 const assert = chai.assert;
@@ -39,15 +40,15 @@ suite('add/remove nodes from template', () => {
         const result = getResult('bar', 'baz', 'qux');
         const template = templateFactory(result);
         const div1 = document.createElement('div');
-        div1.innerHTML = '<span>1</span>';
+        div1.innerHTML = policy.createHTML('<span>1</span>');
         insertNodeIntoTemplate(
             template, div1, template.element.content.firstChild);
         const div2 = document.createElement('div');
-        div2.innerHTML = '<span>2</span>';
+        div2.innerHTML = policy.createHTML('<span>2</span>');
         insertNodeIntoTemplate(
             template, div2, template.element.content.querySelector('p'));
         const div3 = document.createElement('div');
-        div3.innerHTML = '<span>3</span>';
+        div3.innerHTML = policy.createHTML('<span>3</span>');
         insertNodeIntoTemplate(template, div3);
         render(result, container);
         assert.equal(
@@ -74,7 +75,8 @@ suite('add/remove nodes from template', () => {
     const template = templateFactory(result);
     const fragment1 = document.createDocumentFragment();
     fragment1.appendChild(document.createElement('div'));
-    (fragment1.firstChild as HTMLElement).innerHTML = '<span>1</span>';
+    (fragment1.firstChild as HTMLElement).innerHTML =
+        policy.createHTML('<span>1</span>');
     insertNodeIntoTemplate(
         template, fragment1, template.element.content.firstChild);
     const fragment2 = document.createDocumentFragment();

--- a/src/test/lib/shady-render-apply_test.ts
+++ b/src/test/lib/shady-render-apply_test.ts
@@ -15,6 +15,7 @@
 // Rename the html tag so that CSS linting doesn't warn on the non-standard
 // @apply syntax
 import {html as htmlWithApply} from '../../lib/shady-render.js';
+import {policy} from '../test-utils/security.js';
 import {renderShadowRoot} from '../test-utils/shadow-root.js';
 
 const assert = chai.assert;
@@ -55,7 +56,7 @@ suite('shady-render @apply', () => {
     const container = document.createElement('scope-6');
     document.body.appendChild(container);
     const style = document.createElement('style');
-    style.innerHTML = `
+    style.innerHTML = policy.createHTML(`
       :host {
         --batch: {
           border: 3px solid orange;
@@ -65,7 +66,7 @@ suite('shady-render @apply', () => {
       div {
         @apply --batch;
       }
-    `;
+    `);
     const result = [style, htmlWithApply`<div>Testing...</div>`];
     renderShadowRoot(result, container);
     const div = (container.shadowRoot!).querySelector('div');

--- a/src/test/lib/shady-render-scoping-shim_test.ts
+++ b/src/test/lib/shady-render-scoping-shim_test.ts
@@ -13,6 +13,7 @@
  */
 
 import {html} from '../../lib/shady-render.js';
+import {policy} from '../test-utils/security.js';
 import {renderShadowRoot} from '../test-utils/shadow-root.js';
 
 const assert = chai.assert;
@@ -71,8 +72,8 @@ suite('shady-render scoping shim', () => {
       'scoped.';
   test(testName, function() {
     const style = document.createElement('style');
-    style.innerHTML =
-        ':host { border-top: 2px solid black; } button { font-size: 7px; }';
+    style.innerHTML = policy.createHTML(
+        ':host { border-top: 2px solid black; } button { font-size: 7px; }');
     const container = document.createElement('scope-3');
     document.body.appendChild(container);
     renderShadowRoot(

--- a/src/test/lib/trusted-types_test.ts
+++ b/src/test/lib/trusted-types_test.ts
@@ -1,0 +1,119 @@
+/**
+ * @license
+ * Copyright (c) 2019 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+import {unsafeHTML} from '../../directives/unsafe-html';
+import {html, render} from '../../lit-html.js';
+import {stripExpressionMarkers} from '../test-utils/strip-markers';
+
+const assert = chai.assert;
+
+
+const unsafeScriptString = 'alert(0)';
+
+function trustedTypesIsEnforced() {
+  const div = document.createElement('div');
+  try {
+    div.innerHTML = '<img src="#">';
+  } catch {
+    return true;
+  }
+  return false;
+}
+
+if (window.trustedTypes !== undefined) {
+  const policy: TrustedTypePolicy =
+      window.trustedTypes.createPolicy('lit-html-test', {
+        createHTML(input) {
+          return input;
+        },
+        createScript(input) {
+          return input;
+        },
+        createScriptURL(input) {
+          return input;
+        },
+        createURL(input) {
+          return input;
+        },
+      });
+  suite('rendering with trusted type values', () => {
+    let container: HTMLDivElement;
+    suiteSetup(() => {
+      // create app root in the DOM
+      container = document.createElement('div');
+      document.body.appendChild(container);
+    });
+
+    suiteTeardown(() => {
+      document.body.removeChild(container);
+    });
+
+    test('trusted types works with native APIs', () => {
+      const el = document.createElement('div');
+      assert.equal(el.innerHTML, '');
+      el.innerHTML = policy.createHTML('<span>val</span>') as unknown as string;
+      assert.equal(el.innerHTML, '<span>val</span>');
+    });
+
+    if (trustedTypesIsEnforced()) {
+      suite('throws on untrusted values', () => {
+        test('unsafe html', () => {
+          const template = html`${unsafeHTML('<b>unsafe bold</b>')}`;
+          assert.throws(() => {
+            render(template, container);
+          });
+        });
+
+        test('unsafe attribute', () => {
+          const template = html`<iframe srcdoc=${unsafeScriptString}></iframe>`;
+          assert.throws(() => {
+            render(template, container);
+          });
+        });
+      });
+    }
+
+    suite('runs without error on trusted values', () => {
+      test('unsafeHTML() with blessed input', () => {
+        const template =
+            html`${unsafeHTML(policy.createHTML('<b>safe bold</b>'))}`;
+        render(template, container);
+        assert.equal(
+            stripExpressionMarkers(container.innerHTML), '<b>safe bold</b>');
+      });
+
+      test('blessed input on unsafe attribute', () => {
+        const safeHtml =
+            policy.createHTML('<b>safe bold</b>') as unknown as string;
+        const template = html`<iframe srcdoc=${safeHtml}>`;
+        render(template, container);
+        assert.equal(
+            stripExpressionMarkers(container.innerHTML),
+            '<iframe srcdoc="<b>safe bold</b>"></iframe>');
+      });
+
+      test('blessed input on unsafe property', () => {
+        const safeHtml =
+            policy.createHTML('<b>safe bold</b>') as unknown as string;
+        const template = html`<iframe .srcdoc=${safeHtml}>`;
+        render(template, container);
+        assert.equal(
+            stripExpressionMarkers(container.innerHTML),
+            '<iframe srcdoc="<b>safe bold</b>"></iframe>');
+      });
+    });
+  });
+} else {
+  it('trusted types not present in this browser', () => null);
+}

--- a/src/test/lib/trusted-types_test.ts
+++ b/src/test/lib/trusted-types_test.ts
@@ -12,24 +12,14 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {unsafeHTML} from '../../directives/unsafe-html';
+import {unsafeHTML} from '../../directives/unsafe-html.js';
 import {html, render} from '../../lit-html.js';
-import {stripExpressionMarkers} from '../test-utils/strip-markers';
+import {trustedTypesIsEnforced} from '../test-utils/security.js';
+import {stripExpressionMarkers} from '../test-utils/strip-markers.js';
 
 const assert = chai.assert;
 
-
 const unsafeScriptString = 'alert(0)';
-
-function trustedTypesIsEnforced() {
-  const div = document.createElement('div');
-  try {
-    div.innerHTML = '<img src="#">';
-  } catch {
-    return true;
-  }
-  return false;
-}
 
 if (window.trustedTypes !== undefined) {
   const policy: TrustedTypePolicy =

--- a/src/test/polyfills/template_polyfill_test.ts
+++ b/src/test/polyfills/template_polyfill_test.ts
@@ -1,3 +1,5 @@
+import {policy} from '../test-utils/security.js';
+
 const assert = chai.assert;
 
 suite('Template', function() {
@@ -7,7 +9,8 @@ suite('Template', function() {
     const container = document.createElement('div');
     document.body.appendChild(container);
     template = document.createElement('template');
-    template.innerHTML = '<span id="content">Hello World!</span>';
+    template.innerHTML =
+        policy.createHTML('<span id="content">Hello World!</span>');
     container.appendChild(template);
   });
 
@@ -36,11 +39,11 @@ suite('Template', function() {
   test('innerHTML', function() {
     const imp = document.createElement('template');
     let s = 'pre<div>Hi</div><div>Bye</div>post';
-    imp.innerHTML = s;
+    imp.innerHTML = policy.createHTML(s);
     assert.equal(imp.content.childNodes.length, 4);
     assert.equal(imp.content.firstChild!.textContent, 'pre');
     s = 'foo';
-    imp.innerHTML = s;
+    imp.innerHTML = policy.createHTML(s);
     assert.equal(imp.content.childNodes.length, 1);
     assert.equal(imp.content.firstChild!.textContent, s);
   });

--- a/src/test/test-utils/security.ts
+++ b/src/test/test-utils/security.ts
@@ -1,0 +1,38 @@
+/**
+ * @license
+ * Copyright (c) 2020 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+export function trustedTypesIsEnforced(): boolean {
+  const div = document.createElement('div');
+  try {
+    div.innerHTML = '<img src="#">';
+  } catch {
+    return true;
+  }
+  return false;
+}
+
+function getPolicy() {
+  let policy = {
+    createHTML(rawHtml: string) {
+      return rawHtml;
+    }
+  };
+  if (window.trustedTypes !== undefined) {
+    policy = window.trustedTypes.createPolicy('unsafehtml-test', policy) as
+        unknown as typeof policy;
+  }
+  return policy;
+}
+
+export const policy = getPolicy();

--- a/test/incompatible-shady.html
+++ b/test/incompatible-shady.html
@@ -1,6 +1,8 @@
 <!doctype html>
 <html>
   <head>
+    <meta http-equiv="Content-Security-Policy"
+        content="require-trusted-types-for 'script';">
     <script>
       if (location.search.match('shadydom')) {
         window.ShadyDOM = {force: true};

--- a/test/index.html
+++ b/test/index.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html>
   <head>
+    <!-- No trusted types enforcement meta tag. -->
     <script src="../node_modules/mocha/mocha.js"></script>
     <script src="../node_modules/chai/chai.js"></script>
     <script src="../node_modules/wct-mocha/wct-mocha.js"></script>
@@ -40,7 +41,6 @@
         'shady-scoping-shim.html?shadydom=true&shimcssproperties=true',
         'no-template.html',
         'shady_no-wc.html',
-        'trusted-types.html',
       ]);
     </script>
   </body>

--- a/test/index.html
+++ b/test/index.html
@@ -40,6 +40,7 @@
         'shady-scoping-shim.html?shadydom=true&shimcssproperties=true',
         'no-template.html',
         'shady_no-wc.html',
+        'trusted-types.html',
       ]);
     </script>
   </body>

--- a/test/no-template.html
+++ b/test/no-template.html
@@ -1,6 +1,8 @@
 <!doctype html>
 <html>
   <head>
+    <meta http-equiv="Content-Security-Policy"
+        content="require-trusted-types-for 'script';">
     <script src="../node_modules/mocha/mocha.js"></script>
     <script src="../node_modules/chai/chai.js"></script>
     <script src="../node_modules/wct-mocha/wct-mocha.js"></script>

--- a/test/shady-apply.html
+++ b/test/shady-apply.html
@@ -1,6 +1,8 @@
 <!doctype html>
 <html>
   <head>
+    <meta http-equiv="Content-Security-Policy"
+        content="require-trusted-types-for 'script';">
     <script>
       if (location.search.match('shadydom')) {
         window.ShadyDOM = {force: true};

--- a/test/shady-scoping-shim.html
+++ b/test/shady-scoping-shim.html
@@ -1,6 +1,9 @@
 <!doctype html>
 <html>
   <head>
+    <meta http-equiv="Content-Security-Policy"
+        content="require-trusted-types-for 'script';">
+
     <script>
       if (location.search.match('shadydom')) {
         window.ShadyDOM = {force: true};

--- a/test/shady.html
+++ b/test/shady.html
@@ -1,6 +1,8 @@
 <!doctype html>
 <html>
   <head>
+    <meta http-equiv="Content-Security-Policy"
+        content="require-trusted-types-for 'script';">
     <script>
       if (location.search.match('shadydom')) {
         window.ShadyDOM = {force: true};

--- a/test/shady_no-wc.html
+++ b/test/shady_no-wc.html
@@ -1,6 +1,8 @@
 <!doctype html>
 <html>
   <head>
+    <meta http-equiv="Content-Security-Policy"
+        content="require-trusted-types-for 'script';">
     <script>
       window.ShadyDOM = {
         noPatch: true,

--- a/test/trusted-types.html
+++ b/test/trusted-types.html
@@ -1,12 +1,54 @@
 <!doctype html>
 <html>
-  <head>
-    <script src="../node_modules/mocha/mocha.js"></script>
-    <script src="../node_modules/chai/chai.js"></script>
-    <script src="../node_modules/wct-mocha/wct-mocha.js"></script>
-    <script src="../node_modules/@webcomponents/webcomponentsjs/webcomponents-bundle.js"></script>
-  </head>
-  <body>
-    <script type="module" src="./lib/trusted-types_test.js"></script>
-  </body>
+
+<head>
+  <meta http-equiv="Content-Security-Policy"
+    content="require-trusted-types-for 'script';">
+  <script src="../node_modules/mocha/mocha.js"></script>
+  <script src="../node_modules/chai/chai.js"></script>
+  <script src="../node_modules/wct-mocha/wct-mocha.js"></script>
+  <script
+    src="../node_modules/@webcomponents/webcomponentsjs/webcomponents-bundle.js"></script>
+</head>
+
+<body>
+  <script type="module" src="./lit-html_test.js"></script>
+  <script type="module" src="./lib/template-result_test.js"></script>
+  <script type="module" src="./lib/template_test.js"></script>
+  <script type="module" src="./lib/template-factory_test.js"></script>
+  <script type="module" src="./lib/parts_test.js"></script>
+  <script type="module" src="./lib/render_test.js"></script>
+  <script type="module" src="./lib/trusted-types_test.js"></script>
+  <script type="module" src="./lib/modify-template_test.js"></script>
+  <script type="module" src="./directives/async-append_test.js"></script>
+  <script type="module" src="./directives/async-replace_test.js"></script>
+  <script type="module" src="./directives/cache_test.js"></script>
+  <script type="module" src="./directives/guard_test.js"></script>
+  <script type="module" src="./directives/if-defined_test.js"></script>
+  <script type="module" src="./directives/live_test.js"></script>
+  <script type="module" src="./directives/repeat_test.js"></script>
+  <script type="module" src="./directives/template-content_test.js"></script>
+  <script type="module" src="./directives/until_test.js"></script>
+  <script type="module" src="./directives/unsafe-html_test.js"></script>
+  <script type="module" src="./directives/unsafe-svg_test.js"></script>
+  <script type="module" src="./directives/class-map_test.js"></script>
+  <script type="module" src="./directives/style-map_test.js"></script>
+
+  <script>
+    WCT.loadSuites([
+      'shady.html',
+      'shady.html?shadydom=true',
+      'shady.html?shadydom=true&shimcssproperties=true',
+      'shady-apply.html',
+      'shady-apply.html?shadydom=true',
+      'shady-apply.html?shadydom=true&shimcssproperties=true',
+      'shady-scoping-shim.html',
+      'shady-scoping-shim.html?shadydom=true',
+      'shady-scoping-shim.html?shadydom=true&shimcssproperties=true',
+      'no-template.html',
+      'shady_no-wc.html',
+    ]);
+  </script>
+</body>
+
 </html>

--- a/test/trusted-types.html
+++ b/test/trusted-types.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html>
+  <head>
+    <script src="../node_modules/mocha/mocha.js"></script>
+    <script src="../node_modules/chai/chai.js"></script>
+    <script src="../node_modules/wct-mocha/wct-mocha.js"></script>
+    <script src="../node_modules/@webcomponents/webcomponentsjs/webcomponents-bundle.js"></script>
+  </head>
+  <body>
+    <script type="module" src="./lib/trusted-types_test.js"></script>
+  </body>
+</html>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "target": "es2017",
     "module": "es2015",
     "lib": ["es2017", "esnext.asynciterable", "dom"],
-    "types": ["chai", "mocha"],
+    "types": ["chai", "mocha", "trusted-types"],
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,


### PR DESCRIPTION
Re-adds trusted type support now that it's soon to land in Chrome stable

Size at master:
```
┌──────────────────────────────────────┐
│                                      │
│   Destination: lit-html.bundled.js   │
│   Bundle Size:  9.13 KB              │
│   Minified Size:  9.11 KB            │
│   Gzipped Size:  3.33 KB             │
│   Brotli size: 3.01 KB               │
│                                      │
└──────────────────────────────────────┘
created lit-html.bundled.js in 601ms
    3416
```

Size at c5199ab0f1f85fc93ce3bc2d48a409b63c9360a7:
```
lit-html.js → lit-html.bundled.js...
┌──────────────────────────────────────┐
│                                      │
│   Destination: lit-html.bundled.js   │
│   Bundle Size:  9.37 KB              │
│   Minified Size:  9.35 KB            │
│   Gzipped Size:  3.43 KB             │
│   Brotli size: 3.1 KB                │
│                                      │
└──────────────────────────────────────┘
created lit-html.bundled.js in 598ms
    3518
```

Fixes #1145