### PR TITLE
Adds the correct path information to the release notes links for #1163

### DIFF
--- a/docs/guide/release-notes/1.2.0.md
+++ b/docs/guide/release-notes/1.2.0.md
@@ -37,7 +37,7 @@ go();
 
 ## `templateContent` directive
 
-[Documentation](template-reference#templatecontent)
+[Documentation](/guide/template-reference#templatecontent)
 
 The `templateContent` directive lets you stamp out HTML templates into lit-html templates. This is useful in a number of cases where HTML `<template>` elements are provided by users of elements or parts of a build system.
 

--- a/docs/guide/release-notes/1.2.0.md
+++ b/docs/guide/release-notes/1.2.0.md
@@ -8,7 +8,7 @@ See the [changelog](https://github.com/Polymer/lit-html/blob/master/CHANGELOG.md
 
 ## `live` directive
 
-[Documentation](../guide/template-reference#live)
+[Documentation](template-reference#live)
 
 The `live` directive solves the problem of DOM state changing from underneath lit-html, for example with an `<input>` that a user can type into:
 
@@ -37,7 +37,7 @@ go();
 
 ## `templateContent` directive
 
-[Documentation](../guide/template-reference#templatecontent)
+[Documentation](template-reference#templatecontent)
 
 The `templateContent` directive lets you stamp out HTML templates into lit-html templates. This is useful in a number of cases where HTML `<template>` elements are provided by users of elements or parts of a build system.
 
@@ -59,7 +59,7 @@ html`
 
 ## `unsafeSVG` directive
 
-[Documentation](../guide/template-reference#unsafesvg)
+[Documentation](template-reference#unsafesvg)
 
 `unsaveSVG` is the missing partner of [`unsafeHTML`](../template-reference#unsafehtml). It lets you render a frangment of SVG text as SVG elements rather than text. As with `unsafeHTML` this directive not safe to use with user-provided input, since if the input has `<script>` tags in it, there may be ways to get them to execute, etc.
 

--- a/docs/guide/release-notes/1.2.0.md
+++ b/docs/guide/release-notes/1.2.0.md
@@ -59,7 +59,7 @@ html`
 
 ## `unsafeSVG` directive
 
-[Documentation](template-reference#unsafesvg)
+[Documentation](/guide/template-reference#unsafesvg)
 
 `unsaveSVG` is the missing partner of [`unsafeHTML`](../template-reference#unsafehtml). It lets you render a frangment of SVG text as SVG elements rather than text. As with `unsafeHTML` this directive not safe to use with user-provided input, since if the input has `<script>` tags in it, there may be ways to get them to execute, etc.
 

--- a/docs/guide/release-notes/1.2.0.md
+++ b/docs/guide/release-notes/1.2.0.md
@@ -8,7 +8,7 @@ See the [changelog](https://github.com/Polymer/lit-html/blob/master/CHANGELOG.md
 
 ## `live` directive
 
-[Documentation](../template-reference#live)
+[Documentation](../guide/template-reference#live)
 
 The `live` directive solves the problem of DOM state changing from underneath lit-html, for example with an `<input>` that a user can type into:
 
@@ -37,7 +37,7 @@ go();
 
 ## `templateContent` directive
 
-[Documentation](../template-reference#templatecontent)
+[Documentation](../guide/template-reference#templatecontent)
 
 The `templateContent` directive lets you stamp out HTML templates into lit-html templates. This is useful in a number of cases where HTML `<template>` elements are provided by users of elements or parts of a build system.
 
@@ -59,7 +59,7 @@ html`
 
 ## `unsafeSVG` directive
 
-[Documentation](../template-reference#unsafesvg)
+[Documentation](../guide/template-reference#unsafesvg)
 
 `unsaveSVG` is the missing partner of [`unsafeHTML`](../template-reference#unsafehtml). It lets you render a frangment of SVG text as SVG elements rather than text. As with `unsafeHTML` this directive not safe to use with user-provided input, since if the input has `<script>` tags in it, there may be ways to get them to execute, etc.
 

--- a/docs/guide/release-notes/1.2.0.md
+++ b/docs/guide/release-notes/1.2.0.md
@@ -8,7 +8,7 @@ See the [changelog](https://github.com/Polymer/lit-html/blob/master/CHANGELOG.md
 
 ## `live` directive
 
-[Documentation](template-reference#live)
+[Documentation](/guide/template-reference#live)
 
 The `live` directive solves the problem of DOM state changing from underneath lit-html, for example with an `<input>` that a user can type into:
 


### PR DESCRIPTION
The release notes md file is in a separate directory so the links added have a ../ in front of them, however when rendered on the site the release notes are at the root of the guides folder.

This change just fixes that.

