### PR TITLE
Adds SSR support for unsafeHTML/SVG

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   ],
   "scripts": {
     "build": "tsc",
+    "build:watch": "tsc --watch",
     "checksize": "rollup -c ; cat lit-html.bundled.js | gzip -9 | wc -c ; rm lit-html.bundled.js",
     "test": "npm run build && npm run lint && wct --npm",
     "quicktest": "wct -l chrome -p --npm",

--- a/src/directives/unsafe-html.ts
+++ b/src/directives/unsafe-html.ts
@@ -12,10 +12,10 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
+import {defaultTemplateProcessor} from '../lib/default-template-processor.js';
 import {isPrimitive} from '../lib/parts.js';
 import {directive, NodePart, Part} from '../lit-html.js';
 import {TemplateResult} from '../lit-html.js';
-import { defaultTemplateProcessor } from '../lib/default-template-processor.js';
 
 interface PreviousValue {
   readonly value: unknown;

--- a/src/directives/unsafe-html.ts
+++ b/src/directives/unsafe-html.ts
@@ -14,10 +14,12 @@
 
 import {isPrimitive} from '../lib/parts.js';
 import {directive, NodePart, Part} from '../lit-html.js';
+import {TemplateResult} from '../lit-html.js';
+import { defaultTemplateProcessor } from '../lib/default-template-processor.js';
 
 interface PreviousValue {
   readonly value: unknown;
-  readonly fragment: DocumentFragment;
+  readonly result: TemplateResult;
 }
 
 // For each part, remember the value that was last rendered to the part by the
@@ -39,23 +41,19 @@ export const unsafeHTML = directive((value: unknown) => (part: Part): void => {
     throw new Error('unsafeHTML can only be used in text bindings');
   }
 
-  // We don't support `unsafeHTML` on the server because there's no way to
-  // create a TemplateResult to pass to setValue using non-literal strings
-  // without coercing types (`html` only accepts a `TemplateStringsArray`).
-  if (part.isServerRendering) {
-    throw new Error('unsafeHTML does not support SSR');
-  }
-
   const previousValue = previousValues.get(part);
 
+  let result;
   if (previousValue !== undefined && isPrimitive(value) &&
-      value === previousValue.value && part.value === previousValue.fragment) {
-    return;
+      value === previousValue.value) {
+    result = previousValue.result;
+  } else {
+    // DO NOT COPY THIS CODE. IT IS UNSAFE TO CONSTRUCT TEMPLATE RESULTS THIS
+    // WAY (HENCE THE NAME).
+    const string = String(value);
+    const strings = Object.assign([string], {raw: [string]});
+    result = new TemplateResult(strings, [], 'html', defaultTemplateProcessor)
+    previousValues.set(part, {value, result});
   }
-
-  const template = document.createElement('template');
-  template.innerHTML = value as string;  // innerHTML casts to string internally
-  const fragment = document.importNode(template.content, true);
-  part.setValue(fragment);
-  previousValues.set(part, {value, fragment});
+  part.setValue(result);
 });

--- a/src/directives/unsafe-svg.ts
+++ b/src/directives/unsafe-svg.ts
@@ -12,10 +12,10 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
+import {defaultTemplateProcessor} from '../lib/default-template-processor.js';
 import {isPrimitive} from '../lib/parts.js';
 import {directive, NodePart, Part} from '../lit-html.js';
 import {SVGTemplateResult} from '../lit-html.js';
-import {defaultTemplateProcessor} from '../lib/default-template-processor.js';
 
 interface PreviousValue {
   readonly value: unknown;

--- a/src/directives/unsafe-svg.ts
+++ b/src/directives/unsafe-svg.ts
@@ -12,20 +12,21 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {reparentNodes} from '../lib/dom.js';
 import {isPrimitive} from '../lib/parts.js';
 import {directive, NodePart, Part} from '../lit-html.js';
+import {SVGTemplateResult} from '../lit-html.js';
+import {defaultTemplateProcessor} from '../lib/default-template-processor.js';
 
 interface PreviousValue {
   readonly value: unknown;
-  readonly fragment: DocumentFragment;
+  readonly result: SVGTemplateResult;
 }
 
 // For each part, remember the value that was last rendered to the part by the
-// unsafeSVG directive, and the DocumentFragment that was last set as a value.
+// unsafeHTML directive, and the DocumentFragment that was last set as a value.
 // The DocumentFragment is used as a unique key to check if the last value
-// rendered to the part was with unsafeSVG. If not, we'll always re-render the
-// value passed to unsafeSVG.
+// rendered to the part was with unsafeHTML. If not, we'll always re-render the
+// value passed to unsafeHTML.
 const previousValues = new WeakMap<NodePart, PreviousValue>();
 
 /**
@@ -40,27 +41,19 @@ export const unsafeSVG = directive((value: unknown) => (part: Part): void => {
     throw new Error('unsafeSVG can only be used in text bindings');
   }
 
-  // We don't support `unsafeSVG` on the server because there's no way to
-  // create a TemplateResult to pass to setValue using non-literal strings
-  // without coercing types (`html` only accepts a `TemplateStringsArray`).
-  if (part.isServerRendering) {
-    throw new Error('unsafeSVG does not support SSR');
-  }
-
   const previousValue = previousValues.get(part);
 
+  let result;
   if (previousValue !== undefined && isPrimitive(value) &&
-      value === previousValue.value && part.value === previousValue.fragment) {
-    return;
+      value === previousValue.value) {
+    result = previousValue.result;
+  } else {
+    // DO NOT COPY THIS CODE. IT IS UNSAFE TO CONSTRUCT TEMPLATE RESULTS THIS
+    // WAY (HENCE THE NAME).
+    const string = String(value);
+    const strings = Object.assign([string], {raw: [string]});
+    result = new SVGTemplateResult(strings, [], 'svg', defaultTemplateProcessor)
+    previousValues.set(part, {value, result});
   }
-
-  const template = document.createElement('template');
-  template.innerHTML = `<svg>${value}</svg>`;
-  const content = template.content;
-  const svgElement = content.firstChild!;
-  content.removeChild(svgElement);
-  reparentNodes(content, svgElement.firstChild);
-  const fragment = document.importNode(content, true);
-  part.setValue(fragment);
-  previousValues.set(part, {value, fragment});
+  part.setValue(result);
 });


### PR DESCRIPTION
Updates for integration with lit-ssr-hacker-news app:
* Adds SSR support for unsafeHTML/SVG

Associated PRs:
* https://github.com/PolymerLabs/lit-ssr-hacker-news/pull/1
* https://github.com/PolymerLabs/lit-ssr/pull/64