### PR TITLE
[lit-next] Optimize regexes, make them more readable

### DIFF
--- a/packages/lit-html/package.json
+++ b/packages/lit-html/package.json
@@ -27,7 +27,7 @@
     "test": "wtr test/**/*_test.js --node-resolve",
     "test:watch": "wtr test/**/*_test.js --node-resolve --watch",
     "format": "prettier src/* --write",
-    "checksize": "rollup -c ; cat lit-html.bundled.js | gzip -9 | wc -c ; rm lit-html.bundled.js",
+    "checksize": "rollup -c ; cat lit-html.bundled.js | wc -c ; rm lit-html.bundled.js",
     "check-version": "node check-version-tracker.js"
   },
   "author": "The Polymer Authors",


### PR DESCRIPTION
Removes the `lastAttributeNameRegex` too, so we do less string scanning work overall.

Also moves the bound attribute name prefix check (checking for `.` or `?`) to template prep time and stores the constructor to use with the TemplatePart, moving a little instance work to template work.