### PR TITLE
[lit-html] Add directives

### DIFF
--- a/packages/lit-html/package.json
+++ b/packages/lit-html/package.json
@@ -24,8 +24,8 @@
   "scripts": {
     "build": "tsc",
     "build:watch": "tsc --watch",
-    "test": "wtr test/**/*_test.js --node-resolve",
-    "test:watch": "wtr test/**/*_test.js --node-resolve --watch",
+    "test": "wtr \"test/**/*_test.js\" --node-resolve",
+    "test:watch": "wtr \"test/**/*_test.js\" --node-resolve --watch",
     "format": "prettier src/* --write",
     "checksize": "rollup -c ; cat lit-html.bundled.js | wc -c ; rm lit-html.bundled.js",
     "check-version": "node check-version-tracker.js"


### PR DESCRIPTION
This adds the class-based, stateful directive design.

Currently the `update()` method accepts a part, and we haven't determined what the public API of parts are yet.

Also, nested directives are not support in either attribute or node parts. To support that we'll need to slightly change the way directive state is kept and when values are resolved in order to run directives. I'm holding off on that so we discuss alternatives, such as some kinds of direct composition support.