### PR TITLE
[lit-element] Changes `requestUpdate` to no longer return a promise

### DIFF
--- a/packages/lit-element/CHANGELOG.md
+++ b/packages/lit-element/CHANGELOG.md
@@ -23,6 +23,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 * [Breaking] Removed build support for TypeScript 3.4.
 * [Breaking] Decorators are no longer exported from the `lit-element` module. Instead import any decorators you use from `lit-element/decorators/*`.
 * [Breaking] `lit-html` has been updated to 2.x. Note, shady-render support has been removed. Import the shady-render package to support Shady DOM.
+* [Breaking] For simplicity, `requestUpdate` no longer returns a Promise. Instead await the `updateComplete` Promise.
+
+### Removed
+* [Breaking] Removed `requestUpdateInternal`. The `requestUpdate` method is now identical to this method and should be used instead.
 
 ## [2.4.0] - 2020-08-19
 

--- a/packages/lit-element/src/lib/updating-element.ts
+++ b/packages/lit-element/src/lib/updating-element.ts
@@ -690,7 +690,7 @@ export abstract class UpdatingElement extends HTMLElement {
   /**
    * Requests an update which is processed asynchronously. This should
    * be called when an element should update based on some state not triggered
-   * by setting a property. In this case, pass no arguments. It should also be
+   * by setting a reactive property. In this case, pass no arguments. It should also be
    * called when manually implementing a property setter. In this case, pass the
    * property `name` and `oldValue` to ensure that any configured property
    * options are honored. Returns the `updateComplete` Promise which is resolved

--- a/packages/lit-element/src/lib/updating-element.ts
+++ b/packages/lit-element/src/lib/updating-element.ts
@@ -380,7 +380,7 @@ export abstract class UpdatingElement extends HTMLElement {
           name as string
         ];
         ((this as {}) as {[key: string]: unknown})[key as string] = value;
-        ((this as unknown) as UpdatingElement).requestUpdateInternal(
+        ((this as unknown) as UpdatingElement).requestUpdate(
           name,
           oldValue,
           options
@@ -556,7 +556,7 @@ export abstract class UpdatingElement extends HTMLElement {
     this._saveInstanceProperties();
     // ensures first update will be caught by an early access of
     // `updateComplete`
-    this.requestUpdateInternal();
+    this.requestUpdate();
   }
 
   /**
@@ -688,11 +688,19 @@ export abstract class UpdatingElement extends HTMLElement {
   }
 
   /**
-   * This protected version of `requestUpdate` does not access or return the
-   * `updateComplete` promise. This promise can be overridden and is therefore
-   * not free to access.
+   * Requests an update which is processed asynchronously. This should
+   * be called when an element should update based on some state not triggered
+   * by setting a property. In this case, pass no arguments. It should also be
+   * called when manually implementing a property setter. In this case, pass the
+   * property `name` and `oldValue` to ensure that any configured property
+   * options are honored. Returns the `updateComplete` Promise which is resolved
+   * when the update completes.
+   *
+   * @param name {PropertyKey} (optional) name of requesting property
+   * @param oldValue {any} (optional) old value of requesting property
+   * @returns {Promise} A Promise that is resolved when the update completes.
    */
-  protected requestUpdateInternal(
+  requestUpdate(
     name?: PropertyKey,
     oldValue?: unknown,
     options?: PropertyDeclaration
@@ -733,24 +741,6 @@ export abstract class UpdatingElement extends HTMLElement {
     if (!this._hasRequestedUpdate && shouldRequestUpdate) {
       this._updatePromise = this._enqueueUpdate();
     }
-  }
-
-  /**
-   * Requests an update which is processed asynchronously. This should
-   * be called when an element should update based on some state not triggered
-   * by setting a property. In this case, pass no arguments. It should also be
-   * called when manually implementing a property setter. In this case, pass the
-   * property `name` and `oldValue` to ensure that any configured property
-   * options are honored. Returns the `updateComplete` Promise which is resolved
-   * when the update completes.
-   *
-   * @param name {PropertyKey} (optional) name of requesting property
-   * @param oldValue {any} (optional) old value of requesting property
-   * @returns {Promise} A Promise that is resolved when the update completes.
-   */
-  requestUpdate(name?: PropertyKey, oldValue?: unknown) {
-    this.requestUpdateInternal(name, oldValue);
-    return this.updateComplete;
   }
 
   /**

--- a/packages/lit-element/src/test/updating-element_test.ts
+++ b/packages/lit-element/src/test/updating-element_test.ts
@@ -40,24 +40,6 @@ suite('UpdatingElement', () => {
     }
   });
 
-  test('`requestUpdate` waits until update', async () => {
-    class E extends UpdatingElement {
-      updateCount = 0;
-      updated() {
-        this.updateCount++;
-      }
-    }
-    customElements.define(generateElementName(), E);
-    const el = new E();
-    container.appendChild(el);
-    await el.requestUpdate();
-    assert.equal(el.updateCount, 1);
-    await el.requestUpdate();
-    assert.equal(el.updateCount, 2);
-    await el.requestUpdate();
-    assert.equal(el.updateCount, 3);
-  });
-
   test('`updateComplete` waits for `requestUpdate` but does not trigger update, async', async () => {
     class E extends UpdatingElement {
       updateCount = 0;
@@ -98,12 +80,15 @@ suite('UpdatingElement', () => {
     await el.updateComplete;
     assert.equal(el.updateCount, 1);
     el.needsUpdate = false;
-    await el.requestUpdate();
+    el.requestUpdate();
+    await el.updateComplete;
     assert.equal(el.updateCount, 1);
     el.needsUpdate = true;
-    await el.requestUpdate();
+    el.requestUpdate();
+    await el.updateComplete;
     assert.equal(el.updateCount, 2);
-    await el.requestUpdate();
+    el.requestUpdate();
+    await el.updateComplete;
     assert.equal(el.updateCount, 3);
   });
 
@@ -1299,10 +1284,12 @@ suite('UpdatingElement', () => {
     assert.deepEqual(el.changedProperties, testMap);
     assert.equal(el.wasUpdatedCount, 1);
     assert.equal(el.wasFirstUpdated, 1);
-    await el.requestUpdate();
+    el.requestUpdate();
+    await el.updateComplete;
     assert.equal(el.wasUpdatedCount, 2);
     assert.equal(el.wasFirstUpdated, 1);
-    await el.requestUpdate();
+    el.requestUpdate();
+    await el.updateComplete;
     assert.equal(el.wasUpdatedCount, 3);
     assert.equal(el.wasFirstUpdated, 1);
   });
@@ -1339,13 +1326,15 @@ suite('UpdatingElement', () => {
     assert.equal(el.triedToUpdatedCount, 1);
     assert.equal(el.wasUpdatedCount, 0);
     assert.equal(el.wasFirstUpdated, 0);
-    await el.requestUpdate();
+    el.requestUpdate();
+    await el.updateComplete;
     const testMap = new Map();
     assert.deepEqual(el.changedProperties, testMap);
     assert.equal(el.triedToUpdatedCount, 2);
     assert.equal(el.wasUpdatedCount, 1);
     assert.equal(el.wasFirstUpdated, 1);
-    await el.requestUpdate();
+    el.requestUpdate();
+    await el.updateComplete;
     assert.equal(el.triedToUpdatedCount, 3);
     assert.equal(el.wasUpdatedCount, 2);
     assert.equal(el.wasFirstUpdated, 1);
@@ -2304,39 +2293,6 @@ suite('UpdatingElement', () => {
     assert.isTrue(el.promiseFulfilled);
   });
 
-  test('`requestUpdate` resolved at `updateComplete` time', async () => {
-    class E extends UpdatingElement {
-      static get properties() {
-        return {foo: {}};
-      }
-      promiseFulfilled = false;
-
-      get updateComplete() {
-        return (async () => {
-          return (
-            (await super.updateComplete) &&
-            (await new Promise((resolve) => {
-              setTimeout(() => {
-                this.promiseFulfilled = true;
-                resolve(true);
-              }, 1);
-            }))
-          );
-        })();
-      }
-    }
-    customElements.define(generateElementName(), E);
-    const el = new E();
-    container.appendChild(el);
-    let result = await el.updateComplete;
-    assert.isTrue(result);
-    assert.isTrue(el.promiseFulfilled);
-    el.promiseFulfilled = false;
-    result = (await el.requestUpdate()) as boolean;
-    assert.isTrue(result);
-    assert.isTrue(el.promiseFulfilled);
-  });
-
   test('can await sub-element `updateComplete`', async () => {
     class E extends UpdatingElement {
       static get properties() {
@@ -2633,7 +2589,8 @@ suite('UpdatingElement', () => {
     assert.isFalse(a.firstUpdatedCalled);
     assert.isFalse(a.updatedCalled);
     shouldThrow = false;
-    await a.requestUpdate();
+    a.requestUpdate();
+    await a.updateComplete;
     assert.isTrue(a.firstUpdatedCalled);
     assert.isTrue(a.updatedCalled);
   });


### PR DESCRIPTION
...and removes `requestUpdateInternal`.  Previously users customizing the property setter would call `requestUpdateInternal` and now they should call `requestUpdate` instead. It is identical to the old method.