### PR TITLE
[lit-next] Run playwright-github-action after lerna bootstrap

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,13 +13,13 @@ jobs:
         with:
           node-version: 14
 
-      - uses: microsoft/playwright-github-action@v1
-
       - name: NPM install
         run: npm ci
 
       - name: Lerna bootstrap
         run: npm run bootstrap
+
+      - uses: microsoft/playwright-github-action@v1
 
       - name: Build
         run: npm run build


### PR DESCRIPTION
The errors we've been getting with playwright seems to be an interaction with lerna, where running `lerna bootstrap` gets confused about some state that is changed by `playwright-github-action`. I filed https://github.com/microsoft/playwright-github-action/issues/32, though I'm not sure if the problem lies with the playwright action, or lerna, or somewhere else.

Anyway, simply deferring the playwright action until after lerna bootstrap seems to be doing the trick. We are still sometimes hitting errors with missing libraries like `libmozsqlite3.so` and `libxul.so`, but it's not as frequent. I filed https://github.com/microsoft/playwright-github-action/issues/31 for that.