### PR TITLE
Remove hasFinalized API, decided this is unnecessary

### DIFF
--- a/packages/lit-element/src/lib/updating-element.ts
+++ b/packages/lit-element/src/lib/updating-element.ts
@@ -384,10 +384,6 @@ export abstract class UpdatingElement extends HTMLElement {
     return this._classProperties!.get(name) || defaultPropertyDeclaration;
   }
 
-  protected static get hasFinalized() {
-    return this.hasOwnProperty(finalized);
-  }
-
   /**
    * Creates property accessors for registered properties and ensures
    * any superclasses are also finalized. Returns true if the element was


### PR DESCRIPTION
Unnecessary since `finalize` now returns true if finalization work was done.