### PR TITLE
Fix benchmark measurements

### DIFF
--- a/packages/benchmarks/lit-element/stub1/stub1.html
+++ b/packages/benchmarks/lit-element/stub1/stub1.html
@@ -10,13 +10,13 @@
   customElements.define('x-greeter', XGreeter);
 
   (async () => {
-    performance.mark('start');
+    performance.mark('render-start');
     for (let i = 0; i < 1000; i++) {
       const el = document.createElement('x-greeter');
       document.body.appendChild(el);
     }
     // Wait for LitElement render microtasks to complete.
     await Promise.resolve(null);
-    performance.measure('render', 'start');
+    performance.measure('render', 'render-start');
   })();
 </script>

--- a/packages/benchmarks/lit-html/kitchen-sink/index.ts
+++ b/packages/benchmarks/lit-html/kitchen-sink/index.ts
@@ -187,24 +187,24 @@ const renderItem: any = (data: Data) => html`
 let data = generateData(0);
 
 // Initial render
-performance.mark('render');
+performance.mark('render-start');
 render(renderItem(data), document.body);
-performance.measure('render', 'render');
+performance.measure('render', 'render-start');
 
 // Update
-performance.mark('update');
+performance.mark('update-start');
 for (let i = 0; i < updateCount; i++) {
   data = generateData(i + 1);
   render(renderItem(data), document.body);
 }
-performance.measure('update', 'update');
+performance.measure('update', 'update-start');
 
 // No-op update
-performance.mark('nop-update');
+performance.mark('nop-update-start');
 for (let i = 0; i < nopUpdateCount; i++) {
   render(renderItem(data), document.body);
 }
-performance.measure('nop-update', 'nop-update');
+performance.measure('nop-update', 'nop-update-start');
 
 // Log
 console.log(


### PR DESCRIPTION
This PR makes sure there's only one performance entry with the name specified in the Tachometer config. It seems like there's a Tachometer issue in here, where it should disambiguate between marks and measures. 