### PR TITLE
[lit-next] Unify the both check-version-tracker scripts

### DIFF
--- a/packages/lit-element/package.json
+++ b/packages/lit-element/package.json
@@ -38,10 +38,11 @@
     "checksize": "rollup -c --environment=CHECKSIZE",
     "format": "prettier src/* --write",
     "lint": "tslint --project ./",
-    "prepublishOnly": "node check-version-tracker.cjs && npm run lint && npm test",
+    "prepublishOnly": "npm run check-version && npm run lint && npm test",
     "regen-package-lock": "rm -rf node_modules package-lock.json; npm install",
     "publish-dev": "npm test && VERSION=${npm_package_version%-*}-dev.`git rev-parse --short HEAD` && npm version --no-git-tag-version $VERSION && npm publish --tag dev",
-    "release": "np --any-branch --yolo"
+    "release": "np --any-branch --yolo",
+    "check-version": "node check-version-tracker.cjs"
   },
   "author": "The Polymer Authors",
   "devDependencies": {

--- a/packages/lit-html/check-version-tracker.cjs
+++ b/packages/lit-html/check-version-tracker.cjs
@@ -12,14 +12,12 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import * as fs from 'fs';
-import * as path from 'path';
+const fs = require('fs');
+const path = require('path');
 
-const packageFile = fs.readFileSync(path.resolve('package.json'));
-const {version} = JSON.parse(packageFile);
-const ts = fs.readFileSync(path.resolve('src/lit-html.ts'));
-
-if (!ts.includes(`'${version}'`)) {
+const version = require(path.join(__dirname, 'package.json')).version;
+const ts = fs.readFileSync(path.join(__dirname, 'src', 'lit-html.ts'));
+if (!ts.includes(version)) {
   console.log(`\nExpected lit-html.ts to contain current version "${version}"`);
   console.log(
     `Don't forget to update the version tracker string before release!`

--- a/packages/lit-html/package.json
+++ b/packages/lit-html/package.json
@@ -34,7 +34,7 @@
     "test:watch": "npm run test:dev -- --watch",
     "format": "prettier src/* --write",
     "checksize": "rollup -c --environment=CHECKSIZE",
-    "check-version": "node check-version-tracker.js"
+    "check-version": "node check-version-tracker.cjs"
   },
   "author": "The Polymer Authors",
   "dependencies": {},


### PR DESCRIPTION


Extracted from https://github.com/Polymer/lit-html/pull/1297