### PR TITLE
Update the comment for `requestUpdate()`.

### DIFF
--- a/packages/lit-element/src/lib/updating-element.ts
+++ b/packages/lit-element/src/lib/updating-element.ts
@@ -601,17 +601,17 @@ export abstract class UpdatingElement extends HTMLElement {
   }
 
   /**
-   * Requests an update which is processed asynchronously. This should
-   * be called when an element should update based on some state not triggered
-   * by setting a reactive property. In this case, pass no arguments. It should also be
+   * Requests an update which is processed asynchronously. This should be called
+   * when an element should update based on some state not triggered by setting
+   * a reactive property. In this case, pass no arguments. It should also be
    * called when manually implementing a property setter. In this case, pass the
    * property `name` and `oldValue` to ensure that any configured property
-   * options are honored. Returns the `updateComplete` Promise which is resolved
-   * when the update completes.
+   * options are honored.
    *
    * @param name {PropertyKey} (optional) name of requesting property
    * @param oldValue {any} (optional) old value of requesting property
-   * @returns {Promise} A Promise that is resolved when the update completes.
+   * @param options {PropertyDeclaration} (optional) property options to use
+   * instead of the previously configured options
    */
   requestUpdate(
     name?: PropertyKey,


### PR DESCRIPTION
This comment was out of date. I wasn't sure what to put for the new `options` parameter though; it sort of looks like it's only there to avoid calling `getPropertyOptions`.