### PR TITLE
[lit-next] Document manual testing

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -54,6 +54,14 @@ jobs:
         run: npm run test
 
   tests-sauce:
+    # We can't run Sauce tests on PRs from forked repos, since they don't have
+    # access to secrets.
+    if: github.event.pull_request == null || github.event.pull_request.head.repo.full_name == github.repository
+
+    # Sauce tests are still unreliable. Run them, but don't mark a commit as
+    # failing if it fails.
+    continue-on-error: true
+
     runs-on: ubuntu-latest
 
     steps:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,22 +20,22 @@ Occasionally we'll close issues if they appear stale or are too vague - please d
 
 Pull requests are greatly appreciated! To ensure a smooth review process, please follow these steps:
 
- 1. Make sure there's an open issue that the PR addresses. Add "Fixes #(issue number)" to the PR description.
- 2. Please discuss the general shape of the change ahead of time. This can save much time for reviewers and submitters alike. Many times there may be existing ideas on how to handle an issue that are not fully written out, and asking about it will bring out more details.
- 3. All PRs that change behavior or fix bugs should have new or updated tests.
- 4. Try to create a set of descriptive commits that each do one focused change. Avoid commits like "oops", and prefer commits like "Added method foo to Bar".
- 5. When addressing review comments, try to add new commits, rather than modifying previous commits. This makes it easier for reviewers to see what changed since the last review. `git commit --fixup {SHA}` is really useful for this. Obviously, requests like "Please rebase onto master" require changing commits.
- 6. If you [allow changes to be committed to your PR branches](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) we can fix some small things in the PR for you, speeding up the review process. This is especially useful if you're new to TypeScript and need help with type annotations.
- 7. Please run `npm run lint` and `npm run format` before submitting PRs. PRs that don't lint and aren't formatted will fail continuous integration tests.
+1.  Make sure there's an open issue that the PR addresses. Add "Fixes #(issue number)" to the PR description.
+2.  Please discuss the general shape of the change ahead of time. This can save much time for reviewers and submitters alike. Many times there may be existing ideas on how to handle an issue that are not fully written out, and asking about it will bring out more details.
+3.  All PRs that change behavior or fix bugs should have new or updated tests.
+4.  Try to create a set of descriptive commits that each do one focused change. Avoid commits like "oops", and prefer commits like "Added method foo to Bar".
+5.  When addressing review comments, try to add new commits, rather than modifying previous commits. This makes it easier for reviewers to see what changed since the last review. `git commit --fixup {SHA}` is really useful for this. Obviously, requests like "Please rebase onto master" require changing commits.
+6.  If you [allow changes to be committed to your PR branches](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) we can fix some small things in the PR for you, speeding up the review process. This is especially useful if you're new to TypeScript and need help with type annotations.
+7.  Please run `npm run lint` and `npm run format` before submitting PRs. PRs that don't lint and aren't formatted will fail continuous integration tests.
 
 ## Code Style
 
 We follow the [Google JavaScript Style Guide](https://google.github.io/styleguide/jsguide.html), but there are a couple of points worth emphasizing:
 
- 1. Clear is better than clever. Optimize for simple, readable code first.
- 2. Prefer longer, more descriptive names, over shorter names. For most variables, minification means we don't pay for extra characters in production.
- 3. Always err on the side of too many comments. When commenting, "why" is more important than "what".
- 4. If you're tempted to add a "what" comment, see if you can't restructure the code and use more descriptive names so that the comment is unnecessary.
+1.  Clear is better than clever. Optimize for simple, readable code first.
+2.  Prefer longer, more descriptive names, over shorter names. For most variables, minification means we don't pay for extra characters in production.
+3.  Always err on the side of too many comments. When commenting, "why" is more important than "what".
+4.  If you're tempted to add a "what" comment, see if you can't restructure the code and use more descriptive names so that the comment is unnecessary.
 
 ## TypeScript
 
@@ -44,18 +44,19 @@ We use TypeScript on lit-html in order to automatically check the code for type 
 TypeScript is hopefully relatively easy to pick up, but if you have any problems we're more than happy to help. You can submit a pull request with type warnings and we'll either help you fix them, or if you allow commits to your PR branch, fix them for you. VS Code is a very nice IDE for TypeScript development if you care to try it.
 
 We stick to subset of TypeScript that is more strict and closer to standard JavaScript.
- 1. We have strict compiler options turned on. Do not change them.
- 2. Prefer the `unknown` type over `any`.
- 3. Prefer the `object` type over `Object`
- 4. Prefer named type alias over complex inline types.
- 5. Use web-compatible, full URLs as import specifiers, including file extensions. ie, `import * as foo from './foo.js`, not `import * as foo from './foo`
- 6. Only use TypeScript for types:
+
+1.  We have strict compiler options turned on. Do not change them.
+2.  Prefer the `unknown` type over `any`.
+3.  Prefer the `object` type over `Object`
+4.  Prefer named type alias over complex inline types.
+5.  Use web-compatible, full URLs as import specifiers, including file extensions. ie, `import * as foo from './foo.js`, not `import * as foo from './foo`
+6.  Only use TypeScript for types:
     1. We compile to the `esnext` target and don't use TypeScript for "downlevel" compilation. Do not change that.
     2. Don't use features that are not part of the type system:
-        1. `namespace`
-        2. `enum`
-        3. Parameter properties (initialize class fields in the constructor parameter list)
- 7. Prefix private members with `_`. (don't assume clients are using TypeScript)
+       1. `namespace`
+       2. `enum`
+       3. Parameter properties (initialize class fields in the constructor parameter list)
+7.  Prefix private members with `_`. (don't assume clients are using TypeScript)
 
 ## Contributor License Agreement
 
@@ -65,3 +66,66 @@ If you've already signed a CLA but are still getting bothered by the awfully ins
 
 [Complete the CLA](https://cla.developers.google.com/clas)
 
+## Set up
+
+```bash
+git clone https://github.com/Polymer/lit-html.git
+cd lit-html
+git checkout lit-next
+npm install
+npm run bootstrap
+npm run build
+```
+
+## Tests
+
+### Test using Playwright chromium/firefox/webkit
+
+1. `npm test`
+
+### Test on the Sauce browsers we test in CI
+
+1. `export SAUCE_USERNAME=your-username SAUCE_ACCESS_KEY=xxx`
+2. `BROWSERS=preset:sauce npm test`
+
+### Test on a custom set of browsers
+
+1. `BROWSERS="chromium,sauce:Windows 10/firefox@68" npm test`
+
+   Examples:
+
+   ```
+   sauce:macOS 10.15/safari@13
+   sauce:Windows 10/MicrosoftEdge@18
+   sauce:Windows 7/internet explorer@11
+   sauce:Linux/chrome@latest-3
+   sauce:Linux/firefox@68
+   ```
+
+   See https://wiki.saucelabs.com/display/DOCS/Platform+Configurator for all
+   options.
+
+### Test manually in any browser
+
+1. `BROWSERS=chromium npm test`
+2. Wait for the chromium tests to pass. There is not yet a way to bypass running
+   the tests at least once, see https://github.com/modernweb-dev/web/issues/592
+3. Press `M` to enter manual mode
+4. Copy/paste the address into a browser of your choice.
+
+### Set up a Sauce tunnel for manual testing
+
+1. Download _Sauce Connect_ from https://wiki.saucelabs.com/display/DOCS/Sauce+Connect+Proxy
+2. Unzip the archive. Optionally move it somewhere you prefer. Optionally add
+   its `bin` directory to your `$PATH`, or symlink the `sc` binary to your own
+   `bin` directory if you have one.
+3. `export SAUCE_USERNAME=your-username SAUCE_ACCESS_KEY=xxx`
+4. Run `sc`. If successful, Sauce Labs VMs can now access local services.
+5. See [Test manually in any browser](#test-manually-in-any-browser) to get
+   `@web/test-runner` running in manual mode.
+6. Visit https://app.saucelabs.com/live/web-testing to configure and start a new
+   interactive VM session.
+   - Select your tunnel from the _SAUCE CONNECT PROXY_ dropdown. The tunnel ID
+     is shown in the console output of `sc`.
+   - Copy/paste the URL with your IP address (instead of the `localhost` URL)
+     reported by `@web/test-runner` into the _URL_ field.


### PR DESCRIPTION
Also, makes it so the Sauce job won't fail a commit (since it's still flaky), and disables the Sauce job on forked PRs (since they can't access secrets).

Fixes https://github.com/Polymer/lit-html/issues/1306