### PR TITLE
[lit-next] Unify the both check-version-tracker scripts

### DIFF
--- a/packages/lit-element/package.json
+++ b/packages/lit-element/package.json
@@ -48,7 +48,8 @@
     "checksize": "rollup -c --environment=CHECKSIZE",
     "format": "prettier src/* --write",
     "lint": "tslint --project ./",
-    "prepublishOnly": "node check-version-tracker.cjs && npm run lint && npm test",
+    "check-version": "node scripts/check-version-tracker.js",
+    "prepublishOnly": "npm run check-version && npm run lint && npm test",
     "regen-package-lock": "rm -rf node_modules package-lock.json; npm install",
     "publish-dev": "npm test && VERSION=${npm_package_version%-*}-dev.`git rev-parse --short HEAD` && npm version --no-git-tag-version $VERSION && npm publish --tag dev",
     "release": "np --any-branch --yolo"

--- a/packages/lit-element/scripts/check-version-tracker.js
+++ b/packages/lit-element/scripts/check-version-tracker.js
@@ -12,15 +12,17 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-const fs = require('fs');
-const path = require('path');
+import * as fs from 'fs';
+import * as path from 'path';
 
-const version = require(path.join(__dirname, 'package.json')).version;
-const ts = fs.readFileSync(path.join(__dirname, 'src', 'lit-element.ts'));
-if (!ts.includes(version)) {
+const packageFile = fs.readFileSync(path.resolve('package.json'));
+const {version} = JSON.parse(packageFile);
+const ts = fs.readFileSync(path.resolve('src/lit-element.ts'));
+
+if (!ts.includes(`'${version}'`)) {
+  console.log(`\nExpected lit-element.ts to contain current version "${version}"`);
   console.log(
-      `\nExpected lit-element.ts to contain current version "${version}"`);
-  console.log(
-      `Don't forget to update the version tracker string before release!`);
+    `Don't forget to update the version tracker string before release!`
+  );
   process.exit(1);
 }


### PR DESCRIPTION
Now with modules as requested here: https://github.com/Polymer/lit-html/pull/1298#discussion_r493071519