### PR TITLE
[lit-next] Inject version number at build time

### DIFF
--- a/packages/lit-element/rollup.config.js
+++ b/packages/lit-element/rollup.config.js
@@ -19,6 +19,8 @@ import * as pathLib from 'path';
 import sourcemaps from 'rollup-plugin-sourcemaps';
 import replace from '@rollup/plugin-replace';
 
+import * as packageJson from './package.json';
+
 // In CHECKSIZE mode we:
 // 1) Don't emit any files.
 // 2) Don't include copyright header comments.
@@ -89,6 +91,10 @@ export default {
     // itself.
     replace({
       'const DEV_MODE = true': 'const DEV_MODE = false',
+    }),
+    // Inject package version number
+    replace({
+      __DEV_VERSION_NUMBER__: packageJson.version,
     }),
     // This plugin automatically composes the existing TypeScript -> raw JS
     // sourcemap with the raw JS -> minified JS one that we're generating here.

--- a/packages/lit-element/src/lit-element.ts
+++ b/packages/lit-element/src/lit-element.ts
@@ -81,9 +81,8 @@ declare global {
 
 // IMPORTANT: do not change the property name or the assignment expression.
 // This line will be used in regexes to search for LitElement usage.
-// TODO(justinfagnani): inject version number at build time
 (window['litElementVersions'] || (window['litElementVersions'] = [])).push(
-  '3.0.0-pre.1'
+  '__DEV_VERSION_NUMBER__'
 );
 
 type CSSResultFlatArray = CSSResultOrNative[];

--- a/packages/lit-html/rollup.config.js
+++ b/packages/lit-html/rollup.config.js
@@ -20,6 +20,8 @@ import sourcemaps from 'rollup-plugin-sourcemaps';
 import replace from '@rollup/plugin-replace';
 import virtual from '@rollup/plugin-virtual';
 
+import * as packageJson from './package.json';
+
 // In CHECKSIZE mode we:
 // 1) Don't emit any files.
 // 2) Don't include copyright header comments.
@@ -160,6 +162,10 @@ export default [
       // itself.
       replace({
         'const DEV_MODE = true': 'const DEV_MODE = false',
+      }),
+      // Inject package version number
+      replace({
+        __DEV_VERSION_NUMBER__: packageJson.version,
       }),
       // This plugin automatically composes the existing TypeScript -> raw JS
       // sourcemap with the raw JS -> minified JS one that we're generating here.

--- a/packages/lit-html/src/lit-html.ts
+++ b/packages/lit-html/src/lit-html.ts
@@ -1071,5 +1071,4 @@ export class EventPart extends AttributePart {
 
 // IMPORTANT: do not change the property name or the assignment expression.
 // This line will be used in regexes to search for lit-html usage.
-// TODO(justinfagnani): inject version number at build time
-((globalThis as any)['litHtmlVersions'] ??= []).push('2.0.0-pre.3');
+((globalThis as any)['litHtmlVersions'] ??= []).push('__DEV_VERSION_NUMBER__');


### PR DESCRIPTION
I use the `__DEV_VERSION_NUMBER__` string. Let me know if you prefer another.