### PR TITLE
[lit-next] Mangle more lit-html properties by fixing Terser name mangling problem

### DIFF
--- a/packages/lit-html/package-lock.json
+++ b/packages/lit-html/package-lock.json
@@ -157,6 +157,12 @@
 				"magic-string": "^0.25.5"
 			}
 		},
+		"@rollup/plugin-virtual": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/@rollup/plugin-virtual/-/plugin-virtual-2.0.3.tgz",
+			"integrity": "sha512-pw6ziJcyjZtntQ//bkad9qXaBx665SgEL8C8KI5wO8G5iU5MPxvdWrQyVaAvjojGm9tJoS8M9Z/EEepbqieYmw==",
+			"dev": true
+		},
 		"@rollup/pluginutils": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",

--- a/packages/lit-html/package.json
+++ b/packages/lit-html/package.json
@@ -46,6 +46,7 @@
   "devDependencies": {
     "@esm-bundle/chai": "^4.1.5",
     "@rollup/plugin-replace": "^2.3.3",
+    "@rollup/plugin-virtual": "^2.0.3",
     "@types/mocha": "^8.0.3",
     "chokidar-cli": "^2.1.0",
     "concurrently": "^5.3.0",

--- a/packages/lit-html/rollup.config.js
+++ b/packages/lit-html/rollup.config.js
@@ -18,6 +18,7 @@ import copy from 'rollup-plugin-copy';
 import * as pathLib from 'path';
 import sourcemaps from 'rollup-plugin-sourcemaps';
 import replace from '@rollup/plugin-replace';
+import virtual from '@rollup/plugin-virtual';
 
 // In CHECKSIZE mode we:
 // 1) Don't emit any files.
@@ -53,82 +54,129 @@ const entryPoints = [
   'parts',
 ];
 
-// Shared name cache
-// Ideally we'd share this only between lit-html.js and parts.js and force
-// directives to use the public APIs.
+// The Terser shared name cache allows us to mangle the names of properties
+// consistently across modules, so that e.g. parts.js can safely access internal
+// details of lit-html.js.
+//
+// However, we still have to account for the problem of mangled names getting
+// re-used for different properties across files, because Terser does not
+// consult the nameCache to decide whether a mangled name is available or not.
+//
+// For example:
+//
+// file1:
+//   obj.foo -> A
+//   obj.bar -> B
+//
+// file2:
+//   obj.bar -> B (Correctly chosen from nameCache.)
+//   obj.baz -> A (Oops, foo and baz are different properties on the same
+//                 object, but now they both have the same mangled name,
+//                 which could result in very unpredictable behavior).
+//
+// To trick Terser into doing what we need here, we first create a giant bundle
+// of all our code in a single file, tell Terser to minify that, and then throw
+// it away. This seeds the name cache in a way that guarantees every property
+// gets a unique mangled name.
 const nameCache = {};
+const nameCacheSeederInfile = 'name-cache-seeder-virtual-input.js';
+const nameCacheSeederOutfile = 'name-cache-seeder-throwaway-output.js';
+const nameCacheSeederContents = entryPoints
+  .map((name) => `import './development/${name}.js';`)
+  .join('\n');
 
-export default {
-  input: entryPoints.map((name) => `development/${name}.js`),
-  output: {
-    dir: './',
-    format: 'esm',
-    // Preserve existing module structure (e.g. preserve the "directives/"
-    // directory).
-    preserveModules: true,
-    sourcemap: !CHECKSIZE,
+const terserOptions = {
+  warnings: true,
+  ecma: 2017,
+  compress: {
+    unsafe: true,
+    // An extra pass can squeeze out an extra byte or two.
+    passes: 2,
   },
-  plugins: [
-    // Switch all DEV_MODE variable assignment values to false. Terser's dead
-    // code removal will then remove any blocks that are conditioned on this
-    // variable.
-    //
-    // Code in our development/ directory looks like this:
-    //
-    //   const DEV_MODE = true;
-    //   if (DEV_MODE) { // dev mode stuff }
-    //
-    // Note we want the transformation to `goog.define` syntax for Closure
-    // Compiler to be trivial, and that would look something like this:
-    //
-    //   const DEV_MODE = goog.define('lit-html.DEV_MODE', false);
-    //
-    // We can't use terser's compress.global_defs option, because it won't
-    // replace the value of a variable that is already defined in scope (see
-    // https://github.com/terser/terser#conditional-compilation). It seems to be
-    // designed assuming that you are _always_ using terser to set the def one
-    // way or another, so it's difficult to define a default in the source code
-    // itself.
-    replace({
-      'const DEV_MODE = true': 'const DEV_MODE = false',
-    }),
-    // This plugin automatically composes the existing TypeScript -> raw JS
-    // sourcemap with the raw JS -> minified JS one that we're generating here.
-    sourcemaps(),
-    terser({
-      warnings: true,
-      ecma: 2017,
-      compress: {
-        unsafe: true,
-        // An extra pass can squeeze out an extra byte or two.
-        passes: 2,
-      },
-      output: {
-        // "some" preserves @license and @preserve comments
-        comments: CHECKSIZE ? false : 'some',
-        inline_script: false,
-      },
-      // This is NOT working for some reason
-      nameCache,
-      mangle: {
-        properties: {
-          regex: /^__/,
-          // Set to true to mangle to readable names
-          debug: false,
-        },
-      },
-    }),
-    summary(),
-    ...(CHECKSIZE
-      ? [skipBundleOutput]
-      : [
-          // Place a copy of each d.ts file adjacent to its minified module.
-          copy({
-            targets: entryPoints.map((name) => ({
-              src: `development/${name}.d.ts`,
-              dest: pathLib.dirname(name),
-            })),
-          }),
-        ]),
-  ],
+  output: {
+    // "some" preserves @license and @preserve comments
+    comments: CHECKSIZE ? false : 'some',
+    inline_script: false,
+  },
+  nameCache,
+  mangle: {
+    properties: {
+      regex: /^__/,
+      // Set to true to mangle to readable names
+      debug: false,
+    },
+  },
 };
+
+export default [
+  {
+    input: nameCacheSeederInfile,
+    output: {
+      file: nameCacheSeederOutfile,
+      format: 'esm',
+    },
+    // Since our virtual name cache seeder module doesn't export anything,
+    // almost everything gets tree shaken out, and terser wouldn't see any
+    // properties.
+    treeshake: false,
+    plugins: [
+      virtual({
+        [nameCacheSeederInfile]: nameCacheSeederContents,
+      }),
+      terser(terserOptions),
+      skipBundleOutput,
+    ],
+  },
+  {
+    input: entryPoints.map((name) => `development/${name}.js`),
+    output: {
+      dir: './',
+      format: 'esm',
+      // Preserve existing module structure (e.g. preserve the "directives/"
+      // directory).
+      preserveModules: true,
+      sourcemap: !CHECKSIZE,
+    },
+    plugins: [
+      // Switch all DEV_MODE variable assignment values to false. Terser's dead
+      // code removal will then remove any blocks that are conditioned on this
+      // variable.
+      //
+      // Code in our development/ directory looks like this:
+      //
+      //   const DEV_MODE = true;
+      //   if (DEV_MODE) { // dev mode stuff }
+      //
+      // Note we want the transformation to `goog.define` syntax for Closure
+      // Compiler to be trivial, and that would look something like this:
+      //
+      //   const DEV_MODE = goog.define('lit-html.DEV_MODE', false);
+      //
+      // We can't use terser's compress.global_defs option, because it won't
+      // replace the value of a variable that is already defined in scope (see
+      // https://github.com/terser/terser#conditional-compilation). It seems to be
+      // designed assuming that you are _always_ using terser to set the def one
+      // way or another, so it's difficult to define a default in the source code
+      // itself.
+      replace({
+        'const DEV_MODE = true': 'const DEV_MODE = false',
+      }),
+      // This plugin automatically composes the existing TypeScript -> raw JS
+      // sourcemap with the raw JS -> minified JS one that we're generating here.
+      sourcemaps(),
+      terser(terserOptions),
+      summary(),
+      ...(CHECKSIZE
+        ? [skipBundleOutput]
+        : [
+            // Place a copy of each d.ts file adjacent to its minified module.
+            copy({
+              targets: entryPoints.map((name) => ({
+                src: `development/${name}.d.ts`,
+                dest: pathLib.dirname(name),
+              })),
+            }),
+          ]),
+    ],
+  },
+];

--- a/packages/lit-html/src/directives/repeat.ts
+++ b/packages/lit-html/src/directives/repeat.ts
@@ -71,7 +71,7 @@ class RepeatDirective extends Directive {
     }
   }
 
-  _getValuesAndKeys<T>(
+  __getValuesAndKeys<T>(
     items: Iterable<T>,
     keyFnOrTemplate: KeyFn<T> | ItemTemplate<T>,
     template?: ItemTemplate<T>
@@ -101,7 +101,7 @@ class RepeatDirective extends Directive {
     keyFnOrTemplate: KeyFn<T> | ItemTemplate<T>,
     template?: ItemTemplate<T>
   ) {
-    return this._getValuesAndKeys(items, keyFnOrTemplate, template).values;
+    return this.__getValuesAndKeys(items, keyFnOrTemplate, template).values;
   }
 
   update<T>(
@@ -115,7 +115,7 @@ class RepeatDirective extends Directive {
     // Old part & key lists are retrieved from the last update
     // TODO: deal with directive being swapped out?
     let oldParts = getPartValue(containerPart) as Array<NodePart | null>;
-    const {values: newValues, keys: newKeys} = this._getValuesAndKeys(
+    const {values: newValues, keys: newKeys} = this.__getValuesAndKeys(
       items,
       keyFnOrTemplate,
       template

--- a/packages/lit-html/src/lit-html.ts
+++ b/packages/lit-html/src/lit-html.ts
@@ -671,8 +671,8 @@ export class NodePart {
   protected __directive?: Directive;
 
   constructor(
-    public _startNode: ChildNode,
-    public _endNode: ChildNode | null,
+    public __startNode: ChildNode,
+    public __endNode: ChildNode | null,
     public options: RenderOptions | undefined
   ) {}
 
@@ -689,7 +689,7 @@ export class NodePart {
     } else if ((value as DirectiveResult)._$litDirective$ !== undefined) {
       this.__commitDirective(value as DirectiveResult);
     } else if ((value as Node).nodeType !== undefined) {
-      this._commitNode(value as Node);
+      this.__commitNode(value as Node);
     } else if (isIterable(value)) {
       this.__commitIterable(value);
     } else if (value === nothing) {
@@ -701,8 +701,8 @@ export class NodePart {
     }
   }
 
-  private __insert<T extends Node>(node: T, ref = this._endNode) {
-    return this._startNode.parentNode!.insertBefore(node, ref);
+  private __insert<T extends Node>(node: T, ref = this.__endNode) {
+    return this.__startNode.parentNode!.insertBefore(node, ref);
   }
 
   private __commitDirective(value: DirectiveResult) {
@@ -717,7 +717,7 @@ export class NodePart {
     this._setValue(this.__directive.update(this, value.values));
   }
 
-  private _commitNode(value: Node): void {
+  private __commitNode(value: Node): void {
     if (this._value !== value) {
       this.__clear();
       this._value = this.__insert(value);
@@ -725,7 +725,7 @@ export class NodePart {
   }
 
   private __commitText(value: unknown): void {
-    const node = this._startNode.nextSibling;
+    const node = this.__startNode.nextSibling;
     // Make sure undefined and null render as an empty string
     // TODO: use `nothing` to clear the node?
     value ??= '';
@@ -733,15 +733,15 @@ export class NodePart {
     if (
       node !== null &&
       node.nodeType === 3 /* Node.TEXT_NODE */ &&
-      (this._endNode === null
+      (this.__endNode === null
         ? node.nextSibling === null
-        : node === this._endNode.previousSibling)
+        : node === this.__endNode.previousSibling)
     ) {
       // If we only have a single text node between the markers, we can just
       // set its value, rather than replacing it.
       (node as Text).data = value as string;
     } else {
-      this._commitNode(new Text(value as string));
+      this.__commitNode(new Text(value as string));
     }
     this._value = value;
   }
@@ -761,7 +761,7 @@ export class NodePart {
       const instance = new TemplateInstance(template!);
       const fragment = instance.__clone(this.options);
       instance.__update(values);
-      this._commitNode(fragment);
+      this.__commitNode(fragment);
       this._value = instance;
     }
   }
@@ -813,12 +813,12 @@ export class NodePart {
       // Truncate the parts array so _value reflects the current state
       itemParts.length = partIndex;
       // itemParts always have end nodes
-      this.__clear(itemPart?._endNode!.nextSibling);
+      this.__clear(itemPart?.__endNode!.nextSibling);
     }
   }
 
-  __clear(start: ChildNode | null = this._startNode.nextSibling) {
-    while (start && start !== this._endNode) {
+  __clear(start: ChildNode | null = this.__startNode.nextSibling) {
+    while (start && start !== this.__endNode) {
       const n = start!.nextSibling;
       start!.remove();
       start = n;

--- a/packages/lit-html/src/lit-html.ts
+++ b/packages/lit-html/src/lit-html.ts
@@ -671,8 +671,8 @@ export class NodePart {
   protected __directive?: Directive;
 
   constructor(
-    public __startNode: ChildNode,
-    public __endNode: ChildNode | null,
+    private __startNode: ChildNode,
+    private __endNode: ChildNode | null,
     public options: RenderOptions | undefined
   ) {}
 

--- a/packages/lit-html/src/parts.ts
+++ b/packages/lit-html/src/parts.ts
@@ -19,9 +19,9 @@ export const detachNodePart = (part: NodePart): NodePartState => {
     __value: part._value,
     __fragment: fragment,
   };
-  let start = part._startNode.nextSibling;
+  let start = part.__startNode.nextSibling;
   let nextNode;
-  while (start !== part._endNode) {
+  while (start !== part.__endNode) {
     nextNode = start!.nextSibling;
     fragment.append(start!);
     start = nextNode;
@@ -32,7 +32,7 @@ export const detachNodePart = (part: NodePart): NodePartState => {
 
 export const restoreNodePart = (part: NodePart, state: NodePartState) => {
   // TODO (justinfagnani): make an interal-only interface
-  (part as any)._commitNode((state as NodePartStateInternal).__fragment);
+  (part as any).__commitNode((state as NodePartStateInternal).__fragment);
   part._value = (state as NodePartStateInternal).__value;
 };
 
@@ -42,10 +42,10 @@ export const createAndInsertPart = (
   containerPart: NodePart,
   refPart?: NodePart
 ): NodePart => {
-  const container = containerPart._startNode.parentNode as Node;
+  const container = containerPart.__startNode.parentNode as Node;
 
   const refNode =
-    refPart === undefined ? containerPart._endNode : refPart._startNode;
+    refPart === undefined ? containerPart.__endNode : refPart.__startNode;
 
   const startNode = container.insertBefore(createMarker(), refNode);
   const endNode = container.insertBefore(createMarker(), refNode);
@@ -64,19 +64,19 @@ export const insertPartBefore = (
   part: NodePart,
   refPart?: NodePart
 ) => {
-  const container = containerPart._startNode.parentNode!;
+  const container = containerPart.__startNode.parentNode!;
 
-  const refNode = refPart ? refPart._startNode : containerPart._endNode;
+  const refNode = refPart ? refPart.__startNode : containerPart.__endNode;
 
-  const endNode = part._endNode!.nextSibling;
+  const endNode = part.__endNode!.nextSibling;
 
   if (endNode !== refNode) {
-    reparentNodes(container, part._startNode, endNode, refNode);
+    reparentNodes(container, part.__startNode, endNode, refNode);
   }
 };
 
 export const removePart = (part: NodePart) => {
-  removeNodes(part._startNode, part._endNode!.nextSibling);
+  removeNodes(part.__startNode, part.__endNode!.nextSibling);
 };
 
 /**

--- a/packages/lit-html/src/parts.ts
+++ b/packages/lit-html/src/parts.ts
@@ -13,15 +13,23 @@ type NodePartStateInternal = {
   __fragment: DocumentFragment;
 };
 
+/**
+ * Package private members of NodePart.
+ */
+type NodePartInternal = {
+  __startNode: NodePart['__startNode'];
+  __endNode: NodePart['__endNode'];
+};
+
 export const detachNodePart = (part: NodePart): NodePartState => {
   const fragment = document.createDocumentFragment();
   const state: NodePartStateInternal = {
     __value: part._value,
     __fragment: fragment,
   };
-  let start = part.__startNode.nextSibling;
+  let start = ((part as unknown) as NodePartInternal).__startNode.nextSibling;
   let nextNode;
-  while (start !== part.__endNode) {
+  while (start !== ((part as unknown) as NodePartInternal).__endNode) {
     nextNode = start!.nextSibling;
     fragment.append(start!);
     start = nextNode;
@@ -42,10 +50,13 @@ export const createAndInsertPart = (
   containerPart: NodePart,
   refPart?: NodePart
 ): NodePart => {
-  const container = containerPart.__startNode.parentNode as Node;
+  const container = ((containerPart as unknown) as NodePartInternal).__startNode
+    .parentNode as Node;
 
   const refNode =
-    refPart === undefined ? containerPart.__endNode : refPart.__startNode;
+    refPart === undefined
+      ? ((containerPart as unknown) as NodePartInternal).__endNode
+      : ((refPart as unknown) as NodePartInternal).__startNode;
 
   const startNode = container.insertBefore(createMarker(), refNode);
   const endNode = container.insertBefore(createMarker(), refNode);
@@ -64,19 +75,31 @@ export const insertPartBefore = (
   part: NodePart,
   refPart?: NodePart
 ) => {
-  const container = containerPart.__startNode.parentNode!;
+  const container = ((containerPart as unknown) as NodePartInternal).__startNode
+    .parentNode!;
 
-  const refNode = refPart ? refPart.__startNode : containerPart.__endNode;
+  const refNode = refPart
+    ? ((refPart as unknown) as NodePartInternal).__startNode
+    : ((containerPart as unknown) as NodePartInternal).__endNode;
 
-  const endNode = part.__endNode!.nextSibling;
+  const endNode = ((part as unknown) as NodePartInternal).__endNode!
+    .nextSibling;
 
   if (endNode !== refNode) {
-    reparentNodes(container, part.__startNode, endNode, refNode);
+    reparentNodes(
+      container,
+      ((part as unknown) as NodePartInternal).__startNode,
+      endNode,
+      refNode
+    );
   }
 };
 
 export const removePart = (part: NodePart) => {
-  removeNodes(part.__startNode, part.__endNode!.nextSibling);
+  removeNodes(
+    ((part as unknown) as NodePartInternal).__startNode,
+    ((part as unknown) as NodePartInternal).__endNode!.nextSibling
+  );
 };
 
 /**


### PR DESCRIPTION
The Terser shared name cache allows us to mangle the names of properties consistently across modules, so that e.g. `parts.js` can safely access internal details of `lit-html.js`.

However, we still have to account for the problem of mangled names getting _re-used for different properties across files_, because Terser does not consult the `nameCache` to decide whether a mangled name is available or not.

For example:

```
file1:
  obj.foo -> A
  obj.bar -> B

file2:
  obj.bar -> B (Correctly chosen from nameCache.)
  obj.baz -> A (Oops, foo and baz are different properties on the same
                object, but now they both have the same mangled name,
                which could result in very unpredictable behavior).
```

To trick Terser into doing what we need here, we first create a giant bundle of all our code in a single file, tell Terser to minify that, and then throw it away. This seeds the name cache in a way that guarantees every property
gets a unique mangled name.

Before:
![image](https://user-images.githubusercontent.com/48894/94310494-9153fb00-ff2e-11ea-9842-a61f20e5ffd7.png)

After:
![image](https://user-images.githubusercontent.com/48894/94310447-7e412b00-ff2e-11ea-956d-71645b77f77b.png)

### Still to do
- We can't yet mangle `_value`, because a test file accesses it, so that will fail when testing in minified mode. One solution is to generate a proxy file just for our tests that has something like `export const partValue(part) => part.__value;`.
- Haven't updated `lit-element` yet. I'm planning on unifying the two rollup configs, since they are getting kind of large, and are identical except for the list of entrypoints.

https://github.com/Polymer/lit-html/issues/1272