### PR TITLE
[lit-next] Add NPM exports configs for lit-html and lit-element

### DIFF
--- a/packages/lit-element/CHANGELOG.md
+++ b/packages/lit-element/CHANGELOG.md
@@ -32,6 +32,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 * [Breaking] The type of the `css` function has been changed to `CSSResultGroup` and is now the same as `LitElement.styles`. This avoids the need to cast the `styles` property to `any` when a subclass sets `styles` to an Array and its super class set a single value (or visa versa).
 * For efficiency, the `css` function now maintains a cache and will use a cached value if available when the same style text is requested.
 
+### Added
+* Adds development mode, which can be enabled by setting the `development` Node exports condition. See `README.md` for more details.
+
 ### Removed
 * [Breaking] Removed `requestUpdateInternal`. The `requestUpdate` method is now identical to this method and should be used instead.
 

--- a/packages/lit-element/README.md
+++ b/packages/lit-element/README.md
@@ -116,6 +116,52 @@ To install the web components polyfills needed for older browsers:
 $ npm i -D @webcomponents/webcomponentsjs
 ```
 
+## Development mode
+
+lit-element includes a development mode which adds additional checks that are
+reported in the console.
+
+To enable development mode, add the `development` exports condition to your node
+resolve configuration.
+
+#### @web/dev-server
+
+> NOTE: Requires [rollup#540](https://github.com/rollup/plugins/pull/540)
+
+```js
+{
+  nodeResolve: {
+    exportConditions: [ "development" ]
+  }
+}
+```
+
+#### Rollup
+
+> NOTE: Requires [rollup#540](https://github.com/rollup/plugins/pull/540)
+
+```js
+{
+  plugins: [
+    nodeResolve({
+      exportConditions: [ "development" ]
+    })
+  ]
+}
+```
+
+#### Webpack
+
+> NOTE: Requires [Webpack v5](https://webpack.js.org/migrate/5/)
+
+```js
+{
+  resolve: {
+    conditionNames: [ "development" ]
+  }
+}
+```
+
 ## Supported Browsers
 
 The last 2 versions of all modern browsers are supported, including

--- a/packages/lit-element/package.json
+++ b/packages/lit-element/package.json
@@ -9,6 +9,16 @@
   "main": "lit-element.js",
   "module": "lit-element.js",
   "typings": "lit-element.d.ts",
+  "exports": {
+    ".": {
+      "lit-development": "./development/lit-element.js",
+      "default": "./lit-element.js"
+    },
+    "./lib/": {
+      "lit-development": "./development/lib/",
+      "default": "./lib/"
+    }
+  },
   "directories": {
     "test": "test"
   },

--- a/packages/lit-element/package.json
+++ b/packages/lit-element/package.json
@@ -11,11 +11,11 @@
   "typings": "lit-element.d.ts",
   "exports": {
     ".": {
-      "lit-development": "./development/lit-element.js",
+      "development": "./development/lit-element.js",
       "default": "./lit-element.js"
     },
     "./lib/": {
-      "lit-development": "./development/lib/",
+      "development": "./development/lib/",
       "default": "./lib/"
     }
   },

--- a/packages/lit-html/CHANGELOG.md
+++ b/packages/lit-html/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 * Added `renderBefore` to render options. If specified, content is rendered before the node given via render options, e.g. `{renderBefore: node}`.
+* Added development mode, which can be enabled by setting the `development` Node exports condition. See `README.md` for more details.
 
 ### Fixed
 * All usage of `instanceof` has been removed, making rendering more likely to

--- a/packages/lit-html/README.md
+++ b/packages/lit-html/README.md
@@ -165,6 +165,52 @@ render(helloTemplate('Kevin'), document.body);
 $ npm install lit-html
 ```
 
+## Development mode
+
+lit-html includes a development mode which adds additional checks that are
+reported in the console.
+
+To enable development mode, add the `development` exports condition to your node
+resolve configuration.
+
+#### @web/dev-server
+
+> NOTE: Requires [rollup#540](https://github.com/rollup/plugins/pull/540)
+
+```js
+{
+  nodeResolve: {
+    exportConditions: [ "development" ]
+  }
+}
+```
+
+#### Rollup
+
+> NOTE: Requires [rollup#540](https://github.com/rollup/plugins/pull/540)
+
+```js
+{
+  plugins: [
+    nodeResolve({
+      exportConditions: [ "development" ]
+    })
+  ]
+}
+```
+
+#### Webpack
+
+> NOTE: Requires [Webpack v5](https://webpack.js.org/migrate/5/)
+
+```js
+{
+  resolve: {
+    conditionNames: [ "development" ]
+  }
+}
+```
+
 ## Contributing
 
 Please see [CONTRIBUTING.md](../../CONTRIBUTING.md).

--- a/packages/lit-html/package.json
+++ b/packages/lit-html/package.json
@@ -8,6 +8,20 @@
   "type": "module",
   "main": "lit-html.js",
   "typings": "lit-html.d.ts",
+  "exports": {
+    ".": {
+      "lit-development": "./development/lit-html.js",
+      "default": "./lit-html.js"
+    },
+    "./part.js": {
+      "lit-development": "./development/part.js",
+      "default": "./part.js"
+    },
+    "./directives/": {
+      "lit-development": "./development/directives/",
+      "default": "./directives/"
+    }
+  },
   "directories": {
     "test": "test"
   },

--- a/packages/lit-html/package.json
+++ b/packages/lit-html/package.json
@@ -10,15 +10,15 @@
   "typings": "lit-html.d.ts",
   "exports": {
     ".": {
-      "lit-development": "./development/lit-html.js",
+      "development": "./development/lit-html.js",
       "default": "./lit-html.js"
     },
     "./part.js": {
-      "lit-development": "./development/part.js",
+      "development": "./development/part.js",
       "default": "./part.js"
     },
     "./directives/": {
-      "lit-development": "./development/directives/",
+      "development": "./development/directives/",
       "default": "./directives/"
     }
   },


### PR DESCRIPTION
Adds `exports` configurations to the lit-html and lit-element `package.json` files, to enable users to switch between production and development mode using a Node export condition.

## Background

lit-html and lit-element next will be distributed with two builds:

1. A default minified build suitable for serving to users.
2. An optional development build, which will log additional correctness, debugging, performance etc. information to the console, suitable only during development.

The development builds are configured using a Node export condition (see https://nodejs.org/api/esm.html#esm_conditional_exports) named `"development"`.

<strike>Note: I picked `"lit-development"` over `"development"` so that it's less likely to collide with other packages that might also have a similar export condition, because export conditions are global.</strike>

A number of tools are on the verge of supporting export conditions:

### @web/dev-server

Confirmed working with local copy of https://github.com/rollup/plugins/pull/540. Will work once it gets merged and published.

```js
// web-dev-server.config.mjs

export default {
  nodeResolve: {
    exportConditions: [ "development" ]
  }
}
```

### es-dev-server

Uses an older version of `@rollup/node-plugin-resolve`, which is not compatible with https://github.com/rollup/plugins/pull/540, so an update to es-dev-server would be needed (probably really small). Maybe we just tell people to upgrade to `@web/dev-server` (which replaces `es-dev-server`).

```js
// es-dev-server.config.js

exports.default = {
  nodeResolve: {
    exportConditions: [ "development" ]
  }
}
```

### Rollup

Confirmed working with local copy of https://github.com/rollup/plugins/pull/540. Will work once it gets merged and published.

```js
// rollup.config.js

export default {
  plugins: [
    nodeResolve({
      exportConditions: [ "development" ]
    })
  ]
};
```

### Webpack

Confirmed working with webpack 5 (currently in beta). See https://gist.github.com/sokra/e032a0f17c1721c71cfced6f14516c62 for docs.

```bash
npm install --save-dev webpack@next
```

```js
// webpack.config.js

module.exports = {
  entry: './index.js',
  mode: 'development',
  resolve: {
    conditionNames: [ "development" ]
  }
};
```

cc @LarsDenBakker Awesome work on https://github.com/rollup/plugins/pull/540!

Fixes https://github.com/Polymer/lit-html/issues/1255