### PR TITLE
Add type assertion to JSON.parse().

### DIFF
--- a/packages/lit-element/src/lib/updating-element.ts
+++ b/packages/lit-element/src/lib/updating-element.ts
@@ -180,7 +180,8 @@ export const defaultConverter: ComplexAttributeConverter = {
         // don't normally complain on being mis-configured.
         // TODO(sorvell): Do generate exception in *dev mode*.
         try {
-          fromValue = JSON.parse(value!);
+          // Assert to adhere to Bazel's "must type assert JSON parse" rule.
+          fromValue = JSON.parse(value!) as unknown;
         } catch (e) {
           fromValue = null;
         }


### PR DESCRIPTION
This makes this repo compliant with Bazel's TypeScript rules: https://github.com/bazelbuild/rules_typescript/blob/master/internal/tsetse/rules/must_type_assert_json_parse_rule.ts

https://github.com/Polymer/lit-element/pull/1086#pullrequestreview-505141528