### PR TITLE
Fix incorrect Sauce regex parsing

### DIFF
--- a/packages/tests/web-test-runner.config.js
+++ b/packages/tests/web-test-runner.config.js
@@ -112,7 +112,7 @@ Valid examples:
 
 See https://wiki.saucelabs.com/display/DOCS/Platform+Configurator for all options.`);
     }
-    const [platformName, browserName, browserVersion] = match;
+    const [_, platformName, browserName, browserVersion] = match;
     return [
       makeSauceLauncherOnce()({
         browserName,


### PR DESCRIPTION
Small bug from https://github.com/Polymer/lit-html/pull/1362, didn't get caught because we can't run Sauce browsers on CI :sob: 