### PR TITLE
[lit-next] Add lint step to the CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,6 +3,20 @@ name: Tests
 on: [push, pull_request]
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 14
+
+      - run: npm ci
+
+      - run: npm run lint
+
   tests-local:
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
Now that everything works and is up to date, I think we can add a lint step to the GitHub Actions.

Just 24 seconds:

<img width="867" alt="Screenshot 2020-10-16 at 11 33 42" src="https://user-images.githubusercontent.com/1007051/96242206-7ca1da80-0fa3-11eb-88db-cd7b3237f549.png">
