### PR TITLE
[lit-next] Re-fires errors in update cycle asynchronously

### DIFF
--- a/packages/lit-element/CHANGELOG.md
+++ b/packages/lit-element/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
-- [Breaking] Errors that occur during the update cycle were previously squelched to allow subsequent updates to proceed normally. Now errors are re-fired asynchronously so they can be detected. Errors can be observed via an `unhandledexception` event handler on window.
+- [Breaking] Errors that occur during the update cycle were previously squelched to allow subsequent updates to proceed normally. Now errors are re-fired asynchronously so they can be detected. Errors can be observed via an `unhandledrejection` event handler on window.
 - [Breaking] `UpdatingElement` has been moved to its own package. The `updating-element`, `css-tag`, and all `decorators` have moved to the `updating-element` package. For convenience, all decorators are re-exported in `LitElement` at `lit-element/decorators` and `lit-element/decorators/*`.
 - [Breaking] The `lib` folder has been removed.
 - [Breaking] Rendering of `renderRoot`/`shadowRoot`) via `createRenderRoot` and support for `static styles` has moved from `LitElement` to `UpdatingElement`.

--- a/packages/lit-element/CHANGELOG.md
+++ b/packages/lit-element/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+- [Breaking] Errors that occur during the update cycle were previously squelched to allow subsequent updates to proceed normally. Now errors are re-fired asynchronously so they can be detected. Errors can be observed via an `unhandledexception` event handler on window.
 - [Breaking] `UpdatingElement` has been moved to its own package. The `updating-element`, `css-tag`, and all `decorators` have moved to the `updating-element` package. For convenience, all decorators are re-exported in `LitElement` at `lit-element/decorators` and `lit-element/decorators/*`.
 - [Breaking] The `lib` folder has been removed.
 - [Breaking] Rendering of `renderRoot`/`shadowRoot`) via `createRenderRoot` and support for `static styles` has moved from `LitElement` to `UpdatingElement`.

--- a/packages/lit-element/src/test/lit-element_test.ts
+++ b/packages/lit-element/src/test/lit-element_test.ts
@@ -275,7 +275,7 @@ import {assert} from '@esm-bundle/chai';
     shouldThrow = false;
     a.foo = 20;
     // TODO(sorvell): Make sure to wait beyond error timing or wtr is sad.
-    await new Promise((r) => setTimeout(r, 100));
+    await new Promise((r) => setTimeout(r));
     assert.equal(a.foo, 20);
     assert.equal(a.shadowRoot!.textContent, '20');
     console.error = consoleError;

--- a/packages/lit-element/src/test/lit-element_test.ts
+++ b/packages/lit-element/src/test/lit-element_test.ts
@@ -276,8 +276,7 @@ import {assert} from '@esm-bundle/chai';
     shouldThrow = false;
     a.foo = 20;
     // TODO(sorvell): Make sure to wait beyond error timing or wtr is sad.
-    await nextFrame();
-    await nextFrame();
+    await new Promise((r) => setTimeout(r, 100));
     assert.equal(a.foo, 20);
     assert.equal(a.shadowRoot!.textContent, '20');
     console.error = consoleError;

--- a/packages/lit-element/src/test/lit-element_test.ts
+++ b/packages/lit-element/src/test/lit-element_test.ts
@@ -16,7 +16,6 @@ import {html, LitElement} from '../lit-element.js';
 import {
   canTestLitElement,
   generateElementName,
-  nextFrame,
   stripExpressionComments,
 } from './test-helpers.js';
 import {assert} from '@esm-bundle/chai';

--- a/packages/lit-element/src/test/lit-element_test.ts
+++ b/packages/lit-element/src/test/lit-element_test.ts
@@ -16,6 +16,7 @@ import {html, LitElement} from '../lit-element.js';
 import {
   canTestLitElement,
   generateElementName,
+  nextFrame,
   stripExpressionComments,
 } from './test-helpers.js';
 import {assert} from '@esm-bundle/chai';
@@ -240,6 +241,9 @@ import {assert} from '@esm-bundle/chai';
   });
 
   test('exceptions in `render` throw but do not prevent further updates', async () => {
+    // TODO(sorvell): console errors produced by wtr and upset it.
+    const consoleError = console.error;
+    console.error = () => {};
     let shouldThrow = false;
     class A extends LitElement {
       static properties = {foo: {}};
@@ -271,9 +275,12 @@ import {assert} from '@esm-bundle/chai';
     assert.equal(a.shadowRoot!.textContent, '5');
     shouldThrow = false;
     a.foo = 20;
-    await a.updateComplete;
+    // TODO(sorvell): Make sure to wait beyond error timing or wtr is sad.
+    await nextFrame();
+    await nextFrame();
     assert.equal(a.foo, 20);
     assert.equal(a.shadowRoot!.textContent, '20');
+    console.error = consoleError;
   });
 
   test('if `render` is unimplemented, do not overwrite renderRoot', async () => {

--- a/packages/updating-element/CHANGELOG.md
+++ b/packages/updating-element/CHANGELOG.md
@@ -19,6 +19,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+### Changed
+
+- Errors that occur during the update cycle were previously squelched to allow subsequent updates to proceed normally. Now errors are re-fired asynchronously so they can be detected. Errors can be observed via an `unhandledexception` event handler on window.
+
 ### Added
 
 - UpdatingElement moved from `lit-element` package to `updating-element` package.

--- a/packages/updating-element/CHANGELOG.md
+++ b/packages/updating-element/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
-- Errors that occur during the update cycle were previously squelched to allow subsequent updates to proceed normally. Now errors are re-fired asynchronously so they can be detected. Errors can be observed via an `unhandledexception` event handler on window.
+- Errors that occur during the update cycle were previously squelched to allow subsequent updates to proceed normally. Now errors are re-fired asynchronously so they can be detected. Errors can be observed via an `unhandledrejection` event handler on window.
 
 ### Added
 

--- a/packages/updating-element/src/test/updating-element_test.ts
+++ b/packages/updating-element/src/test/updating-element_test.ts
@@ -20,7 +20,7 @@ import {
   PropertyValues,
   UpdatingElement,
 } from '../updating-element.js';
-import {generateElementName, nextFrame} from './test-helpers.js';
+import {generateElementName} from './test-helpers.js';
 import {assert} from '@esm-bundle/chai';
 
 suite('UpdatingElement', () => {
@@ -2424,7 +2424,8 @@ suite('UpdatingElement', () => {
         container.parentNode.removeChild(container);
       }
       // allow errors to resolve between tests.
-      await nextFrame();
+      // await nextFrame();
+      await new Promise((r) => setTimeout(r));
     });
 
     test('exceptions in `update` do not prevent further updates', async () => {
@@ -2687,9 +2688,8 @@ suite('UpdatingElement', () => {
       // next update only will throw
       shouldThrow = true;
       a.foo = 10;
-      // TODO(sorvell): runner appears to need more time for this.
-      await nextFrame();
-      await nextFrame();
+      // TODO(sorvell): runner appears to need more time than raf
+      await new Promise((r) => setTimeout(r));
       assert.isTrue(threwError);
       assert.equal(a.foo, 10);
       assert.equal(a.updateCount, 3);

--- a/packages/updating-element/src/test/updating-element_test.ts
+++ b/packages/updating-element/src/test/updating-element_test.ts
@@ -2424,6 +2424,10 @@ suite('UpdatingElement', () => {
         container.parentNode.removeChild(container);
       }
       // allow errors to resolve between tests.
+      // TODO(sorvell): test runner seems flaky without a long pause between
+      // tests.
+      await nextFrame();
+      await nextFrame();
       await nextFrame();
     });
 

--- a/packages/updating-element/src/test/updating-element_test.ts
+++ b/packages/updating-element/src/test/updating-element_test.ts
@@ -20,7 +20,7 @@ import {
   PropertyValues,
   UpdatingElement,
 } from '../updating-element.js';
-import {generateElementName} from './test-helpers.js';
+import {generateElementName, nextFrame} from './test-helpers.js';
 import {assert} from '@esm-bundle/chai';
 
 suite('UpdatingElement', () => {
@@ -2388,236 +2388,313 @@ suite('UpdatingElement', () => {
     assert.equal(a.getAttribute('bar'), 'yo');
   });
 
-  test('exceptions in `update` do not prevent further updates', async () => {
-    let shouldThrow = false;
-    class A extends UpdatingElement {
-      static properties = {foo: {}};
-      foo = 5;
-      updatedFoo = 0;
+  suite('exceptions', () => {
+    let threwError = false;
+    const promiseErrorListener = (e: Event) => {
+      threwError = true;
+      e.stopImmediatePropagation();
+      return true;
+    };
+    // squelch console errors as it seems to mess up the test runner.
+    const consoleError = console.error;
+    suiteSetup(() => {
+      console.error = () => {};
+      window.addEventListener('unhandledrejection', promiseErrorListener, true);
+    });
 
-      update(changedProperties: Map<PropertyKey, unknown>) {
-        if (shouldThrow) {
-          throw new Error('test error');
-        }
-        super.update(changedProperties);
+    suiteTeardown(() => {
+      console.error = consoleError;
+      window.removeEventListener(
+        'unhandledrejection',
+        promiseErrorListener,
+        true
+      );
+    });
+
+    let container: HTMLElement;
+
+    setup(() => {
+      threwError = false;
+      container = document.createElement('div');
+      document.body.appendChild(container);
+    });
+
+    teardown(async () => {
+      if (container && container.parentNode) {
+        container.parentNode.removeChild(container);
       }
+      // allow errors to resolve between tests.
+      await nextFrame();
+    });
 
-      updated(_changedProperties: Map<PropertyKey, unknown>) {
-        this.updatedFoo = this.foo;
-      }
-    }
-    customElements.define(generateElementName(), A);
-    const a = new A();
-    container.appendChild(a);
-    await a.updateComplete;
-    assert.equal(a.updatedFoo, 5);
-    shouldThrow = true;
-    a.foo = 10;
-    let threw = false;
-    try {
-      await a.updateComplete;
-    } catch (e) {
-      threw = true;
-    }
-    assert.isTrue(threw);
-    assert.equal(a.foo, 10);
-    assert.equal(a.updatedFoo, 5);
-    shouldThrow = false;
-    a.foo = 20;
-    await a.updateComplete;
-    assert.equal(a.foo, 20);
-    assert.equal(a.updatedFoo, 20);
-  });
+    test('exceptions in `update` do not prevent further updates', async () => {
+      let shouldThrow = false;
+      class A extends UpdatingElement {
+        static properties = {foo: {}};
+        foo = 5;
+        updatedFoo = 0;
 
-  test('exceptions in `update` prevent `firstUpdated` and `updated` from being called', async () => {
-    let shouldThrow = false;
-    class A extends UpdatingElement {
-      firstUpdatedCalled = false;
-      updatedCalled = false;
-
-      update(changedProperties: Map<PropertyKey, unknown>) {
-        if (shouldThrow) {
-          throw new Error('test error');
-        }
-        super.update(changedProperties);
-      }
-
-      firstUpdated() {
-        this.firstUpdatedCalled = true;
-      }
-
-      updated(_changedProperties: Map<PropertyKey, unknown>) {
-        this.updatedCalled = true;
-      }
-    }
-    customElements.define(generateElementName(), A);
-    shouldThrow = true;
-    const a = new A();
-    container.appendChild(a);
-    let threw = false;
-    try {
-      await a.updateComplete;
-    } catch (e) {
-      threw = true;
-    }
-    assert.isTrue(threw);
-    assert.isFalse(a.firstUpdatedCalled);
-    assert.isFalse(a.updatedCalled);
-    shouldThrow = false;
-    a.requestUpdate();
-    await a.updateComplete;
-    assert.isTrue(a.firstUpdatedCalled);
-    assert.isTrue(a.updatedCalled);
-  });
-
-  test('exceptions in `shouldUpdate` do not prevent further updates', async () => {
-    let shouldThrow = false;
-    class A extends UpdatingElement {
-      static properties = {foo: {}};
-      foo = 5;
-      updatedFoo = 0;
-
-      shouldUpdate(changedProperties: Map<PropertyKey, unknown>) {
-        if (shouldThrow) {
-          throw new Error('test error');
-        }
-        return super.shouldUpdate(changedProperties);
-      }
-
-      updated(_changedProperties: Map<PropertyKey, unknown>) {
-        this.updatedFoo = this.foo;
-      }
-    }
-    customElements.define(generateElementName(), A);
-    const a = new A();
-    container.appendChild(a);
-    await a.updateComplete;
-    assert.equal(a.updatedFoo, 5);
-    shouldThrow = true;
-    a.foo = 10;
-    let threw = false;
-    try {
-      await a.updateComplete;
-    } catch (e) {
-      threw = true;
-    }
-    assert.isTrue(threw);
-    assert.equal(a.foo, 10);
-    assert.equal(a.updatedFoo, 5);
-    shouldThrow = false;
-    a.foo = 20;
-    await a.updateComplete;
-    assert.equal(a.foo, 20);
-    assert.equal(a.updatedFoo, 20);
-  });
-
-  test('exceptions in `updated` do not prevent further or re-entrant updates', async () => {
-    let shouldThrow = false;
-    let enqueue = false;
-    class A extends UpdatingElement {
-      static properties = {foo: {}};
-      foo = 5;
-      updatedFoo = 0;
-
-      changedProps?: PropertyValues;
-
-      updated(_changedProperties: Map<PropertyKey, unknown>) {
-        if (enqueue) {
-          enqueue = false;
-          this.foo++;
-        }
-        if (shouldThrow) {
-          shouldThrow = false;
-          throw new Error('test error');
-        }
-        this.changedProps = _changedProperties;
-        this.updatedFoo = this.foo;
-      }
-
-      get updateComplete(): Promise<any> {
-        return super.updateComplete.then((v) => v || this.updateComplete);
-      }
-    }
-    customElements.define(generateElementName(), A);
-    const a = new A();
-    container.appendChild(a);
-    await a.updateComplete;
-    assert.equal(a.updatedFoo, 5);
-    shouldThrow = true;
-    a.changedProps = new Map();
-    a.foo = 10;
-    let threw = false;
-    try {
-      await a.updateComplete;
-    } catch (e) {
-      threw = true;
-    }
-    assert.isTrue(threw);
-    assert.isFalse(a.changedProps.has('foo'));
-    assert.equal(a.foo, 10);
-    assert.equal(a.updatedFoo, 5);
-    a.foo = 20;
-    await a.updateComplete;
-    assert.equal(a.changedProps.get('foo'), 10);
-    assert.equal(a.foo, 20);
-    assert.equal(a.updatedFoo, 20);
-    enqueue = true;
-    shouldThrow = true;
-    a.foo = 50;
-    threw = false;
-    try {
-      await a.updateComplete;
-    } catch (e) {
-      threw = true;
-    }
-    assert.isTrue(threw);
-    assert.equal(a.changedProps.get('foo'), 50);
-    assert.equal(a.foo, 51);
-    assert.equal(a.updatedFoo, 51);
-  });
-
-  test('exceptions in `performUpdate` do not prevent further updates', async () => {
-    let shouldThrow = false;
-    class A extends UpdatingElement {
-      static properties = {foo: {}};
-      foo = 5;
-      updatedFoo = 0;
-
-      updated(_changedProperties: Map<PropertyKey, unknown>) {
-        this.updatedFoo = this.foo;
-      }
-
-      performUpdate() {
-        return new Promise((resolve, reject) => {
-          super.performUpdate();
+        update(changedProperties: Map<PropertyKey, unknown>) {
           if (shouldThrow) {
-            reject();
-          } else {
-            resolve();
+            throw new Error('test error');
           }
-        });
+          super.update(changedProperties);
+        }
+
+        updated(_changedProperties: Map<PropertyKey, unknown>) {
+          this.updatedFoo = this.foo;
+        }
       }
-    }
-    customElements.define(generateElementName(), A);
-    const a = new A();
-    container.appendChild(a);
-    await a.updateComplete;
-    assert.equal(a.updatedFoo, 5);
-    shouldThrow = true;
-    a.foo = 10;
-    let threw = false;
-    try {
+      customElements.define(generateElementName(), A);
+      const a = new A();
+      container.appendChild(a);
       await a.updateComplete;
-    } catch (e) {
-      threw = true;
-    }
-    assert.isTrue(threw);
-    assert.equal(a.foo, 10);
-    assert.equal(a.updatedFoo, 10);
-    shouldThrow = false;
-    a.foo = 20;
-    await a.updateComplete;
-    assert.equal(a.foo, 20);
-    assert.equal(a.updatedFoo, 20);
+      assert.equal(a.updatedFoo, 5);
+      shouldThrow = true;
+      a.foo = 10;
+      let threw = false;
+      try {
+        await a.updateComplete;
+      } catch (e) {
+        threw = true;
+      }
+      assert.isTrue(threw);
+      assert.equal(a.foo, 10);
+      assert.equal(a.updatedFoo, 5);
+      shouldThrow = false;
+      a.foo = 20;
+      await a.updateComplete;
+      assert.equal(a.foo, 20);
+      assert.equal(a.updatedFoo, 20);
+    });
+
+    test('exceptions in `update` prevent `firstUpdated` and `updated` from being called', async () => {
+      let shouldThrow = false;
+      class A extends UpdatingElement {
+        firstUpdatedCalled = false;
+        updatedCalled = false;
+
+        update(changedProperties: Map<PropertyKey, unknown>) {
+          if (shouldThrow) {
+            throw new Error('test error');
+          }
+          super.update(changedProperties);
+        }
+
+        firstUpdated() {
+          this.firstUpdatedCalled = true;
+        }
+
+        updated(_changedProperties: Map<PropertyKey, unknown>) {
+          this.updatedCalled = true;
+        }
+      }
+      customElements.define(generateElementName(), A);
+      shouldThrow = true;
+      const a = new A();
+      container.appendChild(a);
+      let threw = false;
+      try {
+        await a.updateComplete;
+      } catch (e) {
+        threw = true;
+      }
+      assert.isTrue(threw);
+      assert.isFalse(a.firstUpdatedCalled);
+      assert.isFalse(a.updatedCalled);
+      shouldThrow = false;
+      a.requestUpdate();
+      await a.updateComplete;
+      assert.isTrue(a.firstUpdatedCalled);
+      assert.isTrue(a.updatedCalled);
+    });
+
+    test('exceptions in `shouldUpdate` do not prevent further updates', async () => {
+      let shouldThrow = false;
+      class A extends UpdatingElement {
+        static properties = {foo: {}};
+        foo = 5;
+        updatedFoo = 0;
+
+        shouldUpdate(changedProperties: Map<PropertyKey, unknown>) {
+          if (shouldThrow) {
+            throw new Error('test error');
+          }
+          return super.shouldUpdate(changedProperties);
+        }
+
+        updated(_changedProperties: Map<PropertyKey, unknown>) {
+          this.updatedFoo = this.foo;
+        }
+      }
+      customElements.define(generateElementName(), A);
+      const a = new A();
+      container.appendChild(a);
+      await a.updateComplete;
+      assert.equal(a.updatedFoo, 5);
+      shouldThrow = true;
+      a.foo = 10;
+      let threw = false;
+      try {
+        await a.updateComplete;
+      } catch (e) {
+        threw = true;
+      }
+      assert.isTrue(threw);
+      assert.equal(a.foo, 10);
+      assert.equal(a.updatedFoo, 5);
+      shouldThrow = false;
+      a.foo = 20;
+      await a.updateComplete;
+      assert.equal(a.foo, 20);
+      assert.equal(a.updatedFoo, 20);
+    });
+
+    test('exceptions in `updated` do not prevent further or re-entrant updates', async () => {
+      let shouldThrow = false;
+      let enqueue = false;
+      class A extends UpdatingElement {
+        static properties = {foo: {}};
+        foo = 5;
+        updatedFoo = 0;
+
+        changedProps?: PropertyValues;
+
+        updated(_changedProperties: Map<PropertyKey, unknown>) {
+          if (enqueue) {
+            enqueue = false;
+            this.foo++;
+          }
+          if (shouldThrow) {
+            shouldThrow = false;
+            throw new Error('test error');
+          }
+          this.changedProps = _changedProperties;
+          this.updatedFoo = this.foo;
+        }
+
+        get updateComplete(): Promise<any> {
+          return super.updateComplete.then((v) => v || this.updateComplete);
+        }
+      }
+      customElements.define(generateElementName(), A);
+      const a = new A();
+      container.appendChild(a);
+      await a.updateComplete;
+      assert.equal(a.updatedFoo, 5);
+      shouldThrow = true;
+      a.changedProps = new Map();
+      a.foo = 10;
+      let threw = false;
+      try {
+        await a.updateComplete;
+      } catch (e) {
+        threw = true;
+      }
+      assert.isTrue(threw);
+      assert.isFalse(a.changedProps.has('foo'));
+      assert.equal(a.foo, 10);
+      assert.equal(a.updatedFoo, 5);
+      a.foo = 20;
+      await a.updateComplete;
+      assert.equal(a.changedProps.get('foo'), 10);
+      assert.equal(a.foo, 20);
+      assert.equal(a.updatedFoo, 20);
+      enqueue = true;
+      shouldThrow = true;
+      a.foo = 50;
+      threw = false;
+      try {
+        await a.updateComplete;
+      } catch (e) {
+        threw = true;
+      }
+      assert.isTrue(threw);
+      assert.equal(a.changedProps.get('foo'), 50);
+      assert.equal(a.foo, 51);
+      assert.equal(a.updatedFoo, 51);
+    });
+
+    test('exceptions in `performUpdate` do not prevent further updates', async () => {
+      let shouldThrow = false;
+      class A extends UpdatingElement {
+        static properties = {foo: {}};
+        foo = 5;
+        updatedFoo = 0;
+
+        updated(_changedProperties: Map<PropertyKey, unknown>) {
+          this.updatedFoo = this.foo;
+        }
+
+        performUpdate() {
+          return new Promise((resolve, reject) => {
+            super.performUpdate();
+            if (shouldThrow) {
+              reject();
+            } else {
+              resolve();
+            }
+          });
+        }
+      }
+      customElements.define(generateElementName(), A);
+      const a = new A();
+      container.appendChild(a);
+      await a.updateComplete;
+      assert.equal(a.updatedFoo, 5);
+      shouldThrow = true;
+      a.foo = 10;
+      let threw = false;
+      try {
+        await a.updateComplete;
+      } catch (e) {
+        threw = true;
+      }
+      assert.isTrue(threw);
+      assert.equal(a.foo, 10);
+      assert.equal(a.updatedFoo, 10);
+      shouldThrow = false;
+      a.foo = 20;
+      await a.updateComplete;
+      assert.equal(a.foo, 20);
+      assert.equal(a.updatedFoo, 20);
+    });
+
+    test('exceptions in the update cycle are visible via `unhandledrejection` event', async () => {
+      let shouldThrow = false;
+      class A extends UpdatingElement {
+        static properties = {foo: {}};
+        foo = 5;
+        updateCount = 0;
+
+        updated(_changedProperties: Map<PropertyKey, unknown>) {
+          this.updateCount++;
+          if (shouldThrow) {
+            // This will queue another update that must await this update
+            // completing, and this update will error. That error will
+            // fire async and be observable via the `unhandledrejection` event.
+            this.requestUpdate();
+            shouldThrow = false;
+            throw new Error('Exception during update');
+          }
+        }
+      }
+      customElements.define(generateElementName(), A);
+      const a = new A();
+      container.appendChild(a);
+      await a.updateComplete;
+      assert.equal(a.updateCount, 1);
+      // next update only will throw
+      shouldThrow = true;
+      a.foo = 10;
+      await nextFrame();
+      assert.isTrue(threwError);
+      assert.equal(a.foo, 10);
+      assert.equal(a.updateCount, 3);
+      // subsequent update that does not error proceeds normally
+      a.foo = 15;
+      await a.updateComplete;
+      assert.equal(a.updateCount, 4);
+    });
   });
 });

--- a/packages/updating-element/src/test/updating-element_test.ts
+++ b/packages/updating-element/src/test/updating-element_test.ts
@@ -2424,10 +2424,6 @@ suite('UpdatingElement', () => {
         container.parentNode.removeChild(container);
       }
       // allow errors to resolve between tests.
-      // TODO(sorvell): test runner seems flaky without a long pause between
-      // tests.
-      await nextFrame();
-      await nextFrame();
       await nextFrame();
     });
 
@@ -2691,6 +2687,8 @@ suite('UpdatingElement', () => {
       // next update only will throw
       shouldThrow = true;
       a.foo = 10;
+      // TODO(sorvell): runner appears to need more time for this.
+      await nextFrame();
       await nextFrame();
       assert.isTrue(threwError);
       assert.equal(a.foo, 10);

--- a/packages/updating-element/src/updating-element.ts
+++ b/packages/updating-element/src/updating-element.ts
@@ -744,9 +744,7 @@ export abstract class UpdatingElement extends HTMLElement {
       // cycle. Errors are refired so developers have a chance to observe
       // them, and this can be done by implementing
       // `window.onunhandledrejection`.
-      Promise.resolve().then(() => {
-        throw e;
-      });
+      Promise.reject(e);
     }
     const result = this.performUpdate();
     // If `performUpdate` returns a Promise, we await it. This is done to

--- a/packages/updating-element/src/updating-element.ts
+++ b/packages/updating-element/src/updating-element.ts
@@ -740,8 +740,13 @@ export abstract class UpdatingElement extends HTMLElement {
       // This `await` also ensures that property changes are batched.
       await this._updatePromise;
     } catch (e) {
-      // Ignore any previous errors. We only care that the previous cycle is
-      // done. Any error should have been handled in the previous update.
+      // Refire any previous errors async so they do not disrupt the update
+      // cycle. Errors are refired so developers have a chance to observe
+      // them, and this can be done by implementing
+      // `window.onunhandledrejection`.
+      Promise.resolve().then(() => {
+        throw e;
+      });
     }
     const result = this.performUpdate();
     // If `performUpdate` returns a Promise, we await it. This is done to


### PR DESCRIPTION
Errors that occur during the update cycle are squelched to allow subsequent updates to proceed normally. However, they are now refired so developers have a chance to observe them. This can be done by implementing `window.onunhandledrejection`. Fixes https://github.com/Polymer/lit-element/issues/1081