### PR TITLE
[lit-next] Fixes queryAssignedNodes when querying for nodes on browsers that do …

### DIFF
--- a/packages/updating-element/CHANGELOG.md
+++ b/packages/updating-element/CHANGELOG.md
@@ -22,3 +22,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 - UpdatingElement moved from `lit-element` package to `updating-element` package.
+
+### Fixed
+
+- Fixes an issue with `queryAssignedNodes` when applying a selector on a slot that included text nodes on older browsers not supporting Element.matches [#1088](https://github.com/Polymer/lit-element/issues/1088).

--- a/packages/updating-element/src/decorators/queryAssignedNodes.ts
+++ b/packages/updating-element/src/decorators/queryAssignedNodes.ts
@@ -80,6 +80,7 @@ export function queryAssignedNodes(
           nodes = nodes.filter(
             (node) =>
               node.nodeType === Node.ELEMENT_NODE &&
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
               ((node as any).matches
                 ? (node as Element).matches(selector)
                 : legacyMatches.call(node as Element, selector))

--- a/packages/updating-element/src/decorators/queryAssignedNodes.ts
+++ b/packages/updating-element/src/decorators/queryAssignedNodes.ts
@@ -26,6 +26,7 @@ import {
   standardPrototypeMethod,
 } from './base.js';
 
+// TODO(sorvell): Remove when https://github.com/webcomponents/polyfills/issues/397 is addressed.
 // x-browser support for matches
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const ElementProto = Element.prototype as any;

--- a/packages/updating-element/src/decorators/queryAssignedNodes.ts
+++ b/packages/updating-element/src/decorators/queryAssignedNodes.ts
@@ -77,10 +77,12 @@ export function queryAssignedNodes(
         const slot = this.renderRoot?.querySelector(slotSelector);
         let nodes = (slot as HTMLSlotElement)?.assignedNodes({flatten});
         if (nodes && selector) {
-          nodes = nodes.filter((node) =>
-            node.nodeType === Node.ELEMENT_NODE && (node as Element).matches
-              ? (node as Element).matches(selector)
-              : legacyMatches.call(node as Element, selector)
+          nodes = nodes.filter(
+            (node) =>
+              node.nodeType === Node.ELEMENT_NODE &&
+              ((node as any).matches
+                ? (node as Element).matches(selector)
+                : legacyMatches.call(node as Element, selector))
           );
         }
         return nodes;

--- a/packages/updating-element/src/test/decorators/queryAssignedNodes_test.ts
+++ b/packages/updating-element/src/test/decorators/queryAssignedNodes_test.ts
@@ -116,18 +116,26 @@ const flush =
       el.div.nextSibling!,
     ]);
     const child = document.createElement('div');
+    const text1 = document.createTextNode('');
+    el.assignedNodesEl.appendChild(text1);
     el.assignedNodesEl.appendChild(child);
+    const text2 = document.createTextNode('');
+    el.assignedNodesEl.appendChild(text2);
     flush();
     assert.deepEqual(el.assignedNodesEl.defaultAssigned, [
       el.div,
       el.div.nextSibling!,
+      text1,
       child,
+      text2,
     ]);
     el.assignedNodesEl.removeChild(child);
     flush();
     assert.deepEqual(el.assignedNodesEl.defaultAssigned, [
       el.div,
       el.div.nextSibling!,
+      text1,
+      text2,
     ]);
   });
 
@@ -166,5 +174,34 @@ const flush =
     el.removeChild(child2);
     flush();
     assert.deepEqual(el.assignedNodesEl.footerAssignedItems, []);
+  });
+
+  test('returns assignedNodes for slot that contains text nodes filtered by selector when Element.matches does not exist', () => {
+    const descriptor = Object.getOwnPropertyDescriptor(
+      Element.prototype,
+      'matches'
+    );
+    Object.defineProperty(Element.prototype, 'matches', {
+      value: undefined,
+      configurable: true,
+    });
+    assert.deepEqual(el.assignedNodesEl.footerAssignedItems, []);
+    const child1 = document.createElement('div');
+    const child2 = document.createElement('div');
+    const text1 = document.createTextNode('');
+    const text2 = document.createTextNode('');
+    child2.classList.add('item');
+    el.appendChild(child1);
+    el.appendChild(text1);
+    el.appendChild(child2);
+    el.appendChild(text2);
+    flush();
+    assert.deepEqual(el.assignedNodesEl.footerAssignedItems, [child2]);
+    el.removeChild(child2);
+    flush();
+    assert.deepEqual(el.assignedNodesEl.footerAssignedItems, []);
+    if (descriptor !== undefined) {
+      Object.defineProperty(Element.prototype, 'matches', descriptor);
+    }
   });
 });


### PR DESCRIPTION
…not support Element.matches

Fixes https://github.com/Polymer/lit-element/issues/1088