### PR TITLE
Update the deprecated `::set-env` in GitHub workflows.

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -22,9 +22,9 @@ jobs:
 
       # Note this is the way to set an environment variable that lives across
       # all steps
-      # (https://docs.github.com/en/actions/reference/environment-variables#about-environment-variables).
+      # (https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable).
       - name: Set environment variables
-        run: echo "::set-env name=PLAYWRIGHT_BROWSERS_PATH::$HOME/.playwright"
+        run: echo "PLAYWRIGHT_BROWSERS_PATH=$HOME/.playwright" >> $GITHUB_ENV
 
       # Cache all of our node_modules/ directories and playwright browser
       # binaries to save ~30 seconds of install time.

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,9 +29,9 @@ jobs:
 
       # Note this is the way to set an environment variable that lives across
       # all steps
-      # (https://docs.github.com/en/actions/reference/environment-variables#about-environment-variables).
+      # (https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable).
       - name: Set environment variables
-        run: echo "::set-env name=PLAYWRIGHT_BROWSERS_PATH::$HOME/.playwright"
+        run: echo "PLAYWRIGHT_BROWSERS_PATH=$HOME/.playwright" >> $GITHUB_ENV
 
       # Cache all of our node_modules/ directories and playwright browser
       # binaries to save ~30 seconds of install time.
@@ -86,9 +86,9 @@ jobs:
 
       # Note this is the way to set an environment variable that lives across
       # all steps
-      # (https://docs.github.com/en/actions/reference/environment-variables#about-environment-variables).
+      # (https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable).
       - name: Set environment variables
-        run: echo "::set-env name=PLAYWRIGHT_BROWSERS_PATH::$HOME/.playwright"
+        run: echo "PLAYWRIGHT_BROWSERS_PATH=$HOME/.playwright" >> $GITHUB_ENV
 
       # Cache all of our node_modules/ directories and playwright browser
       # binaries to save ~30 seconds of install time.


### PR DESCRIPTION
A deprecation warning is being printed in the "Set environment variables" step during test runs that points to this link: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/