### PR TITLE
Capitalize browser names in Sauce browser identifers.

### DIFF
--- a/packages/tests/web-test-runner.config.js
+++ b/packages/tests/web-test-runner.config.js
@@ -32,11 +32,11 @@ const browserPresets = {
   // Many browser configurations don't yet work with @web/test-runner-saucelabs.
   // See https://github.com/modernweb-dev/web/issues/472.
   sauce: [
-    'sauce:Windows 10/firefox@68', // Current ESR
-    'sauce:Windows 10/chrome@latest-3',
-    'sauce:macOS 10.15/safari@latest',
+    'sauce:Windows 10/Firefox@68', // Current ESR
+    'sauce:Windows 10/Chrome@latest-3',
+    'sauce:macOS 10.15/Safari@latest',
     // "sauce:Windows 10/MicrosoftEdge@18", // Browser start timeout
-    'sauce:Windows 7/internet explorer@11', // Browser start timeout
+    'sauce:Windows 7/Internet Explorer@11', // Browser start timeout
   ],
 };
 

--- a/packages/tests/web-test-runner.config.js
+++ b/packages/tests/web-test-runner.config.js
@@ -113,7 +113,7 @@ Valid examples:
 
 See https://wiki.saucelabs.com/display/DOCS/Platform+Configurator for all options.`);
     }
-    const [_, platformName, browserName, browserVersion] = match;
+    const [, platformName, browserName, browserVersion] = match;
     return [
       makeSauceLauncherOnce()({
         browserName,


### PR DESCRIPTION
Recently, tests that were running on Chrome on Sauce with versions of the form `latest-N` started failing with this error being thrown on every test page: `WebDriverError: Unexpected server error.` Capitalizing `Chrome` in the browser identifier strings seems to fix them. I have no idea why. I also capitalized the others because it felt right, I guess.