### PR TITLE
Remove a `test.only` in the lit-html tests.

### DIFF
--- a/packages/lit-html/src/lit-html.ts
+++ b/packages/lit-html/src/lit-html.ts
@@ -1181,7 +1181,7 @@ export class AttributePart {
           (this._value as Array<unknown>)[i] = v;
         }
         attributeValue +=
-          (typeof v === 'string' ? v : String(v)) + strings[i + 1];
+          (typeof v === 'string' ? v : String(v ?? '')) + strings[i + 1];
       }
       if (change && !noCommit) {
         this._commitValue(remove ? nothing : attributeValue);

--- a/packages/lit-html/src/test/lit-html_test.ts
+++ b/packages/lit-html/src/test/lit-html_test.ts
@@ -1731,7 +1731,7 @@ suite('lit-html', () => {
       assert.strictEqual((container.firstElementChild as any).foo, 'A:1');
     });
 
-    test.only('renders directives on EventParts', () => {
+    test('renders directives on EventParts', () => {
       const handle = directive(
         class extends Directive {
           count = 0;


### PR DESCRIPTION
I haven't looked into the cause for the failures this exposes, but I believe they're all legitimately failing tests so we shouldn't (necessarily) wait to make them pass in this PR before merging.