### PR TITLE
Remove the inline append / remove polyfills from the platform-support module.

### DIFF
--- a/packages/lit-html/src/platform-support.ts
+++ b/packages/lit-html/src/platform-support.ts
@@ -32,52 +32,6 @@
  * @packageDocumentation
  */
 
-// TODO(sorvell): Remove these once ShadyDOM/webcomponentsjs supports them.
-// Source: https://developer.mozilla.org/en-US/docs/Web/API/ParentNode/append
-(function (arr) {
-  arr.forEach(function (item) {
-    if (item.hasOwnProperty('append') && !window.ShadyDOM?.inUse) {
-      return;
-    }
-    Object.defineProperty(item, 'append', {
-      configurable: true,
-      enumerable: true,
-      writable: true,
-      value: function append() {
-        // eslint-disable-next-line prefer-rest-params
-        const argArr = Array.prototype.slice.call(arguments),
-          docFrag = document.createDocumentFragment();
-
-        argArr.forEach(function (argItem) {
-          const isNode = argItem instanceof Node;
-          docFrag.appendChild(
-            isNode ? argItem : document.createTextNode(String(argItem))
-          );
-        });
-
-        this.appendChild(docFrag);
-      },
-    });
-  });
-})([Element.prototype, Document.prototype, DocumentFragment.prototype]);
-
-// from: https://developer.mozilla.org/en-US/docs/Web/API/ChildNode/remove
-(function (arr) {
-  arr.forEach(function (item) {
-    if (item.hasOwnProperty('remove') && !window.ShadyDOM?.inUse) {
-      return;
-    }
-    Object.defineProperty(item, 'remove', {
-      configurable: true,
-      enumerable: true,
-      writable: true,
-      value: function remove() {
-        this.parentNode.removeChild(this);
-      },
-    });
-  });
-})([Element.prototype, CharacterData.prototype, DocumentType.prototype]);
-
 const needsPlatformSupport = !!(
   window.ShadyCSS !== undefined &&
   (!window.ShadyCSS.nativeShadow || window.ShadyCSS.ApplyShim)


### PR DESCRIPTION
webcomponentsjs includes these as of 2.5.0, which the lit-next branch is now using.