### PR TITLE
Fix styleMap example

### DIFF
--- a/docs/guide/03-styling-templates.md
+++ b/docs/guide/03-styling-templates.md
@@ -47,7 +47,7 @@ const myTemplate = () => {
     backgroundColor: highlight ? myHighlightColor : myBackgroundColor,
   };
 
-  html`
+  return html`
     <div style=${styleMap(styles)}>
       Hi there!
     </div>


### PR DESCRIPTION
Example function has a body, hence it doesn't have an implicit return value. An explicit return value is needed for the example to make sense.