### PR TITLE
[localize] New msg signature with options object

### DIFF
--- a/packages/localize/CHANGELOG.md
+++ b/packages/localize/CHANGELOG.md
@@ -5,7 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Changed
+
+- **[BREAKING]** The signature for the `msg` function has changed:
+
+  Before:
+
+  ```ts
+  msg(id: string, template: string|TemplateResult|Function, ...args: any[])
+  ```
+
+  After:
+
+  ```ts
+  msg(template: string|TemplateResult|Function, options: {id: string: args?: any[]})
+  ```
 
 ## [0.5.1] - 2020-11-09
 

--- a/packages/localize/README.md
+++ b/packages/localize/README.md
@@ -33,7 +33,7 @@ Wrap your template with the `msg` function to make it localizable:
 ```typescript
 import {html} from 'lit-html';
 import {msg} from '@lit/localize';
-render(msg('greeting', html`Hello <b>World</b>!`), document.body);
+render(msg(html`Hello <b>World</b>!`, {id: 'greeting'}), document.body);
 ```
 
 Run `lit-localize` to extract all localizable templates and generate an XLIFF
@@ -130,7 +130,7 @@ lit-localize supports two output modes: _transform_ and _runtime_.
    import {msg} from '@lit/localize';
 
    render(
-     html`<p>${msg('greeting', html`Hello <b>World</b>!`)}</p>`,
+     html`<p>${msg(html`Hello <b>World</b>!`, {id: 'greeting'})}</p>`,
      document.body
    );
    ```
@@ -216,8 +216,7 @@ The `@lit/localize` module exports the following functions:
 > signatures to identify calls to `msg` and other APIs during analysis of your
 > code. Casting a lit-localize function to a type that does not include its
 > annotation will prevent lit-localize from being able to extract and transform
-> templates from your application. For example, a cast like
-> `(msg as any)("greeting", "Hello")` will not be identified. It is safe to
+> templates from your application. For example, a cast like `(msg as any)("Hello", {id: "greeting"})` will not be identified. It is safe to
 > re-assign lit-localize functions or pass them as parameters, as long as the
 > distinctive type signature is preserved. If needed, you can reference each
 > function's distinctive type with e.g. `typeof msg`.
@@ -324,18 +323,18 @@ promise resolves.
 Throws if the given locale is not contained by the configured `sourceLocale` or
 `targetLocales`.
 
-### `msg(id: string, template, ...args) => string|TemplateResult`
+### `msg(template: string|TemplateResult|Function, options: {id: string, args?: any[]}) => string|TemplateResult`
 
 Make a string or lit-html template localizable.
 
-The `id` parameter is a project-wide unique identifier for this template.
+The `options.id` parameter is a project-wide unique identifier for this template.
 
 The `template` parameter can have any of these types:
 
 - A plain string with no placeholders:
 
   ```typescript
-  msg('greeting', 'Hello World!');
+  msg('Hello World!', {id: 'greeting'});
   ```
 
 - A lit-html
@@ -343,27 +342,30 @@ The `template` parameter can have any of these types:
   that may contain embedded HTML:
 
   ```typescript
-  msg('greeting', html`Hello <b>World</b>!`);
+  msg(html`Hello <b>World</b>!`, {id: 'greeting'});
   ```
 
 - A function that returns a [template
   literal](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals)
   string that may contain placeholders. Placeholders may only reference
-  parameters of the function, which will be called with the 3rd and onwards
-  parameters to `msg`.
+  parameters of the function. The function will be invoked with the
+  `options.args` array as its parameters:
 
   ```typescript
-  msg('greeting', (name) => `Hello ${name}!`, getUsername());
+  msg((name) => `Hello ${name}!`, {id: 'greeting', args: [getUsername()]});
   ```
 
 - A function that returns a lit-html
   [`TemplateResult`](https://lit-html.polymer-project.org/api/classes/_lit_html_.templateresult.html)
   that may contain embedded HTML, and may contain placeholders. Placeholders may
-  only reference parameters of the function, which will be called with the 3rd
-  and onwards parameters to `msg`:
+  only reference parameters of the function. The function will be invoked with
+  the `options.args` array as its parameters:
 
   ```typescript
-  msg('greeting', (name) => html`Hello <b>${name}</b>!`, getUsername());
+  msg((name) => html`Hello <b>${name}</b>!`, {
+    id: 'greeting',
+    args: [getUsername()],
+  });
   ```
 
 In transform mode, calls to this function are replaced with the static localized
@@ -465,7 +467,7 @@ class MyElement extends Localized(LitElement) {
   render() {
     // Whenever setLocale() is called, and templates for that locale have
     // finished loading, this render() function will be re-invoked.
-    return html`<p>${msg('greeting', html`Hello <b>World!</b>`)}</p>`;
+    return html`<p>${msg(html`Hello <b>World!</b>`, {id: 'greeting'})}</p>`;
   }
 }
 ```

--- a/packages/localize/examples/runtime/package.json
+++ b/packages/localize/examples/runtime/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "scripts": {
     "build": "rm -rf lib/* && lit-localize && tsc",
-    "serve": "es-dev-server --node-resolve"
+    "serve": "es-dev-server --node-resolve --preserve-symlinks"
   },
   "dependencies": {
     "@lit/localize": "^0.5.1",

--- a/packages/localize/examples/runtime/src/locale-codes.ts
+++ b/packages/localize/examples/runtime/src/locale-codes.ts
@@ -8,7 +8,7 @@ export const sourceLocale = `en`;
 
 /**
  * The other locale codes that this application is localized into. Sorted
- * longest first, then lexicographically.
+ * lexicographically.
  */
 export const targetLocales = [
   `es-419`,
@@ -16,11 +16,10 @@ export const targetLocales = [
 ] as const;
 
 /**
- * All valid project locale codes. Sorted longest first, then
- * lexicographically.
+ * All valid project locale codes. Sorted lexicographically.
  */
 export const allLocales = [
+  `en`,
   `es-419`,
   `zh_CN`,
-  `en`,
 ] as const;

--- a/packages/localize/examples/runtime/src/locales/es-419.ts
+++ b/packages/localize/examples/runtime/src/locales/es-419.ts
@@ -8,6 +8,6 @@
     /* eslint-disable @typescript-eslint/no-explicit-any */
 
     export const templates = {
-      greeting: html`Hola <b>Mundo</b>!`,
+      'greeting': html`Hola <b>Mundo</b>!`,
     };
   

--- a/packages/localize/examples/runtime/src/locales/zh_CN.ts
+++ b/packages/localize/examples/runtime/src/locales/zh_CN.ts
@@ -8,6 +8,6 @@
     /* eslint-disable @typescript-eslint/no-explicit-any */
 
     export const templates = {
-      greeting: html`你好, <b>世界!</b>`,
+      'greeting': html`你好, <b>世界!</b>`,
     };
   

--- a/packages/localize/examples/runtime/src/x-greeter.ts
+++ b/packages/localize/examples/runtime/src/x-greeter.ts
@@ -4,7 +4,7 @@ import {Localized} from '@lit/localize/localized-element.js';
 
 export class XGreeter extends Localized(LitElement) {
   render() {
-    return html`<p>${msg('greeting', html`Hello <b>World</b>!`)}</p>`;
+    return html`<p>${msg(html`Hello <b>World</b>!`, {id: 'greeting'})}</p>`;
   }
 }
 customElements.define('x-greeter', XGreeter);

--- a/packages/localize/examples/transform/package-lock.json
+++ b/packages/localize/examples/transform/package-lock.json
@@ -1047,6 +1047,23 @@
         "vary": "^1.1.2"
       }
     },
+    "@lit/localize": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@lit/localize/-/localize-0.5.1.tgz",
+      "integrity": "sha512-5GNMQMQmscKp16EQOcBvHtSaV4w1cmkI5x/CkJUX/fwIYErD4a9uGqOqjrn6zgThjas/MuHBjTX6o8aV0a0CxA==",
+      "requires": {
+        "fs-extra": "^9.0.0",
+        "glob": "^7.1.6",
+        "jsonschema": "^1.2.6",
+        "lit-element": "^2.3.1",
+        "lit-html": "^1.2.1",
+        "minimist": "^1.2.5",
+        "parse5": "^6.0.0",
+        "source-map-support": "^0.5.19",
+        "typescript": "^4.0.2",
+        "xmldom": "^0.3.0"
+      }
+    },
     "@open-wc/building-utils": {
       "version": "2.18.0",
       "resolved": "https://registry.npmjs.org/@open-wc/building-utils/-/building-utils-2.18.0.tgz",
@@ -2543,30 +2560,6 @@
       "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-1.3.0.tgz",
       "integrity": "sha512-0Q1bwmaFH9O14vycPHw8C/IeHMk/uSDldVLIefu/kfbTBGIc44KGH6A8p1bDfxUfHdc8q6Ct7kQklWoHgr4t1Q=="
     },
-    "lit-localize": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/lit-localize/-/lit-localize-0.3.0.tgz",
-      "integrity": "sha512-WK8IvJdmkGkodSb/L0FNLGU4IGyLTCJk5193djImUfObED97CYZTZnCrlkOiY4SawEc9VF30i8dL9VsqttPoDQ==",
-      "requires": {
-        "fs-extra": "^9.0.0",
-        "glob": "^7.1.6",
-        "jsonschema": "^1.2.6",
-        "lit-element": "^2.3.1",
-        "lit-html": "^1.2.1",
-        "minimist": "^1.2.5",
-        "parse5": "^6.0.0",
-        "source-map-support": "^0.5.19",
-        "typescript": "^3.8.3",
-        "xmldom": "^0.3.0"
-      },
-      "dependencies": {
-        "typescript": {
-          "version": "3.9.7",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
-          "integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw=="
-        }
-      }
-    },
     "lodash": {
       "version": "4.17.20",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
@@ -3234,8 +3227,7 @@
     "typescript": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.2.tgz",
-      "integrity": "sha512-e4ERvRV2wb+rRZ/IQeb3jm2VxBsirQLpQhdxplZ2MEzGvDkkMmPglecnNDfSUBivMjP93vRbngYYDQqQ/78bcQ==",
-      "dev": true
+      "integrity": "sha512-e4ERvRV2wb+rRZ/IQeb3jm2VxBsirQLpQhdxplZ2MEzGvDkkMmPglecnNDfSUBivMjP93vRbngYYDQqQ/78bcQ=="
     },
     "typical": {
       "version": "4.0.0",

--- a/packages/localize/examples/transform/package.json
+++ b/packages/localize/examples/transform/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "scripts": {
     "build": "rm -rf lib/* && lit-localize",
-    "serve": "es-dev-server --node-resolve"
+    "serve": "es-dev-server --node-resolve --preserve-symlinks"
   },
   "dependencies": {
     "@lit/localize": "^0.5.1",

--- a/packages/localize/examples/transform/src/locale-codes.ts
+++ b/packages/localize/examples/transform/src/locale-codes.ts
@@ -8,7 +8,7 @@ export const sourceLocale = `en`;
 
 /**
  * The other locale codes that this application is localized into. Sorted
- * longest first, then lexicographically.
+ * lexicographically.
  */
 export const targetLocales = [
   `es-419`,
@@ -16,11 +16,10 @@ export const targetLocales = [
 ] as const;
 
 /**
- * All valid project locale codes. Sorted longest first, then
- * lexicographically.
+ * All valid project locale codes. Sorted lexicographically.
  */
 export const allLocales = [
+  `en`,
   `es-419`,
   `zh_CN`,
-  `en`,
 ] as const;

--- a/packages/localize/examples/transform/src/x-greeter.ts
+++ b/packages/localize/examples/transform/src/x-greeter.ts
@@ -3,7 +3,7 @@ import {msg} from '@lit/localize';
 
 export class XGreeter extends LitElement {
   render() {
-    return html`<p>${msg('greeting', html`Hello <b>World</b>!`)}</p>`;
+    return html`<p>${msg(html`Hello <b>World</b>!`, {id: 'greeting'})}</p>`;
   }
 }
 customElements.define('x-greeter', XGreeter);

--- a/packages/localize/package-lock.json
+++ b/packages/localize/package-lock.json
@@ -277,15 +277,6 @@
       "integrity": "sha512-3c+yGKvVP5Y9TYBEibGNR+kLtijnj7mYrXRg+WpFb2X9xm04g/DXYkfg4hmzJQosc9snFNUPkbYIhu+KAm6jJw==",
       "dev": true
     },
-    "@types/jsonschema": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@types/jsonschema/-/jsonschema-1.1.1.tgz",
-      "integrity": "sha1-CHA9/gdAEOjoKRIxEVlK9zH1exo=",
-      "dev": true,
-      "requires": {
-        "jsonschema": "*"
-      }
-    },
     "@types/keygrip": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@types/keygrip/-/keygrip-1.0.2.tgz",
@@ -4165,9 +4156,9 @@
       "dev": true
     },
     "jsonschema": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.2.6.tgz",
-      "integrity": "sha512-SqhURKZG07JyKKeo/ir24QnS4/BV7a6gQy93bUSe4lUdNp0QNpIz2c9elWJQ9dpc5cQYY6cvCzgRwy0MQCLyqA=="
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.4.0.tgz",
+      "integrity": "sha512-/YgW6pRMr6M7C+4o8kS+B/2myEpHCrxO4PEWnqJNBFMjn7EWXqlQ4tGwL6xTHeRplwuZmcAncdvfOad1nT2yMw=="
     },
     "jszip": {
       "version": "3.5.0",

--- a/packages/localize/package.json
+++ b/packages/localize/package.json
@@ -47,7 +47,7 @@
   "dependencies": {
     "fs-extra": "^9.0.0",
     "glob": "^7.1.6",
-    "jsonschema": "^1.2.6",
+    "jsonschema": "^1.4.0",
     "lit-element": "^2.3.1",
     "lit-html": "^1.2.1",
     "minimist": "^1.2.5",
@@ -62,7 +62,6 @@
     "@types/diff": "^4.0.2",
     "@types/fs-extra": "^9.0.1",
     "@types/glob": "^7.1.1",
-    "@types/jsonschema": "^1.1.1",
     "@types/minimist": "^1.2.0",
     "@types/mocha": "^8.0.2",
     "@types/node": "^14.0.1",

--- a/packages/localize/src/config.ts
+++ b/packages/localize/src/config.ts
@@ -127,7 +127,7 @@ export function readConfigFileAndWriteSchema(configPath: string): Config {
 
   // eslint-disable-next-line @typescript-eslint/no-var-requires
   const schema = require('../config.schema.json');
-  const result = jsonSchema.validate(parsed, schema, {propertyName: 'config'});
+  const result = jsonSchema.validate(parsed, schema);
   if (result.errors.length > 0) {
     throw new KnownError(
       `Error validating config file ${configPath}:\n\n` +

--- a/packages/localize/src/tests/analysis.unit.test.ts
+++ b/packages/localize/src/tests/analysis.unit.test.ts
@@ -76,7 +76,7 @@ test('irrelevant code', (t) => {
 test('string message', (t) => {
   const src = `
     import {msg} from './lit-localize.js';
-    msg('greeting', 'Hello World');
+    msg('Hello World', {id: 'greeting'});
   `;
   checkAnalysis(t, src, [
     {
@@ -89,7 +89,7 @@ test('string message', (t) => {
 test('HTML message', (t) => {
   const src = `
     import {msg} from './lit-localize.js';
-    msg('greeting', html\`<b>Hello World</b>\`);
+    msg(html\`<b>Hello World</b>\`, {id: 'greeting'});
   `;
   checkAnalysis(t, src, [
     {
@@ -106,7 +106,7 @@ test('HTML message', (t) => {
 test('HTML message with comment', (t) => {
   const src = `
     import {msg} from './lit-localize.js';
-    msg('greeting', html\`<b><!-- greeting -->Hello World</b>\`);
+    msg(html\`<b><!-- greeting -->Hello World</b>\`, {id: 'greeting'});
   `;
   checkAnalysis(t, src, [
     {
@@ -123,7 +123,7 @@ test('HTML message with comment', (t) => {
 test('parameterized string message', (t) => {
   const src = `
     import {msg} from './lit-localize.js';
-    msg('greeting', (name: string) => \`Hello \${name}\`, "friend");
+    msg((name: string) => \`Hello \${name}\`, {id: 'greeting', args: ["friend"]});
   `;
   checkAnalysis(t, src, [
     {
@@ -137,7 +137,7 @@ test('parameterized string message', (t) => {
 test('parameterized HTML message', (t) => {
   const src = `
     import {msg} from './lit-localize.js';
-    msg('greeting', (name: string) => html\`<b>Hello \${name}</b>\`, "friend");
+    msg((name: string) => html\`<b>Hello \${name}</b>\`, {id: 'greeting', args: ["friend"]);
   `;
   checkAnalysis(t, src, [
     {
@@ -156,7 +156,7 @@ test('immediate description', (t) => {
   const src = `
     import {msg} from './lit-localize.js';
     // msgdesc: Greeting
-    msg('greeting', 'Hello World');
+    msg('Hello World', {id: 'greeting'});
   `;
   checkAnalysis(t, src, [
     {
@@ -174,7 +174,7 @@ test('inherited description', (t) => {
     class XGreeter extends HTMLElement {
       render() {
         // msgdesc: Greeting
-        return msg('greeting', 'Hello World');
+        return msg('Hello World', {id: 'greeting'});
       }
     }
   `;
@@ -192,7 +192,7 @@ test('different msg function', (t) => {
     function msg(id: string, template: string) {
       return template;
     }
-    msg('greeting', 'Greeting');
+    msg('Greeting', {id: 'greeting'});
   `;
   checkAnalysis(t, src, []);
 });
@@ -200,14 +200,46 @@ test('different msg function', (t) => {
 test('error: message id cannot be empty', (t) => {
   const src = `
     import {msg} from './lit-localize.js';
-    msg('', 'Hello World');
+    msg('Hello World', {id: ''});
   `;
   checkAnalysis(
     t,
     src,
     [],
     [
-      '__DUMMY__.ts(3,9): error TS2324: Expected first argument to msg() to be a static and non-empty string',
+      '__DUMMY__.ts(3,29): error TS2324: Options id property must be a non-empty string literal',
+    ]
+  );
+});
+
+test('error: options must be object literal', (t) => {
+  const src = `
+    import {msg} from './lit-localize.js';
+    const options = {id: 'greeting'};
+    msg('Hello World', options);
+  `;
+  checkAnalysis(
+    t,
+    src,
+    [],
+    [
+      '__DUMMY__.ts(4,24): error TS2324: Expected second argument to msg() to be an object',
+    ]
+  );
+});
+
+test('error: options must be long-form', (t) => {
+  const src = `
+    import {msg} from './lit-localize.js';
+    const id = 'greeting';
+    msg('Hello World', {id});
+  `;
+  checkAnalysis(
+    t,
+    src,
+    [],
+    [
+      '__DUMMY__.ts(4,25): error TS2324: Options shorthand object assignment is not supported',
     ]
   );
 });
@@ -216,16 +248,16 @@ test('error: message id must be static', (t) => {
   const src = `
     import {msg} from './lit-localize.js';
     const id = 'greeting';
-    msg(id, 'Hello World');
-    msg(\`\${id}\`, 'Hello World');
+    msg('Hello World', {id: id});
+    msg('Hello World', {id: \`\${id}\`});
   `;
   checkAnalysis(
     t,
     src,
     [],
     [
-      '__DUMMY__.ts(4,9): error TS2324: Expected first argument to msg() to be a static and non-empty string',
-      '__DUMMY__.ts(5,9): error TS2324: Expected first argument to msg() to be a static and non-empty string',
+      '__DUMMY__.ts(4,29): error TS2324: Options id property must be a non-empty string literal',
+      '__DUMMY__.ts(5,29): error TS2324: Options id property must be a non-empty string literal',
     ]
   );
 });
@@ -234,16 +266,16 @@ test('error: placeholders must use function', (t) => {
   const src = `
     import {msg} from './lit-localize.js';
     const foo = 'foo';
-    msg('greeting', \`Hello \${name}\`);
-    msg('greeting', html\`<b>Hello \${name}</b>\`);
+    msg(\`Hello \${name}\`, {id: 'greeting'});
+    msg(html\`<b>Hello \${name}</b>\`, {id: 'greeting'});
   `;
   checkAnalysis(
     t,
     src,
     [],
     [
-      '__DUMMY__.ts(4,21): error TS2324: To use a variable, pass an arrow function.',
-      '__DUMMY__.ts(5,21): error TS2324: To use a variable, pass an arrow function.',
+      '__DUMMY__.ts(4,9): error TS2324: To use a variable, pass an arrow function.',
+      '__DUMMY__.ts(5,9): error TS2324: To use a variable, pass an arrow function.',
     ]
   );
 });
@@ -252,14 +284,14 @@ test('error: placeholders must only reference function parameters', (t) => {
   const src = `
     import {msg} from './lit-localize.js';
     const foo = 'foo';
-    msg('greeting', (name) => \`Hello \${name} \${foo}\`, 'Friend');
+    msg((name) => \`Hello \${name} \${foo}\`, {id: 'greeting', args: ['Friend']);
   `;
   checkAnalysis(
     t,
     src,
     [],
     [
-      '__DUMMY__.ts(4,48): error TS2324: Placeholder must be one of the following identifiers: name',
+      '__DUMMY__.ts(4,36): error TS2324: Placeholder must be one of the following identifiers: name',
     ]
   );
 });
@@ -267,8 +299,8 @@ test('error: placeholders must only reference function parameters', (t) => {
 test('error: different message contents', (t) => {
   const src = `
     import {msg} from './lit-localize.js';
-    msg('greeting', 'Hello World');
-    msg('greeting', 'Hello Friend');
+    msg('Hello World', {id: 'greeting'});
+    msg('Hello Friend', {id: 'greeting'});
   `;
   checkAnalysis(
     t,

--- a/packages/localize/src/tests/analysis.unit.test.ts
+++ b/packages/localize/src/tests/analysis.unit.test.ts
@@ -223,7 +223,7 @@ test('error: options must be object literal', (t) => {
     src,
     [],
     [
-      '__DUMMY__.ts(4,24): error TS2324: Expected second argument to msg() to be an object',
+      '__DUMMY__.ts(4,24): error TS2324: Expected second argument to msg() to be an object literal',
     ]
   );
 });
@@ -239,7 +239,7 @@ test('error: options must be long-form', (t) => {
     src,
     [],
     [
-      '__DUMMY__.ts(4,25): error TS2324: Options shorthand object assignment is not supported',
+      '__DUMMY__.ts(4,25): error TS2324: Options object must use identifier or string literal property assignments. Shorthand and spread assignments are not supported.',
     ]
   );
 });

--- a/packages/localize/src/tests/e2e-goldens-test.ts
+++ b/packages/localize/src/tests/e2e-goldens-test.ts
@@ -83,6 +83,10 @@ export function e2eGoldensTest(
       process.stderr.write = realStderrWrite;
     }
 
+    if (expectedExitCode === 0 && exitCode !== 0) {
+      console.log(stdOutErr);
+    }
+
     t.is(exitCode, expectedExitCode);
     t.assert(
       stdOutErr.includes(expectedStdOutErr),

--- a/packages/localize/src/tests/transform.unit.test.ts
+++ b/packages/localize/src/tests/transform.unit.test.ts
@@ -97,11 +97,11 @@ test('unchanged html', (t) => {
 });
 
 test('msg(string)', (t) => {
-  checkTransform(t, 'msg("foo", "Hello World");', '"Hello World";');
+  checkTransform(t, 'msg("Hello World", {id: "foo"});', '"Hello World";');
 });
 
 test('msg(string) translated', (t) => {
-  checkTransform(t, 'msg("foo", "Hello World");', '`Hola Mundo`;', {
+  checkTransform(t, 'msg("Hello World", {id: "foo"});', '`Hola Mundo`;', {
     messages: [{name: 'foo', contents: ['Hola Mundo']}],
   });
 });
@@ -109,7 +109,7 @@ test('msg(string) translated', (t) => {
 test('html(msg(string))', (t) => {
   checkTransform(
     t,
-    'html`<b>${msg("foo", "Hello World")}</b>`;',
+    'html`<b>${msg("Hello World", {id: "foo"})}</b>`;',
     'html`<b>Hello World</b>`;'
   );
 });
@@ -117,7 +117,7 @@ test('html(msg(string))', (t) => {
 test('html(msg(string)) translated', (t) => {
   checkTransform(
     t,
-    'html`<b>${msg("foo", "Hello World")}</b>`;',
+    'html`<b>${msg("Hello World", {id: "foo"})}</b>`;',
     'html`<b>Hola Mundo</b>`;',
     {messages: [{name: 'foo', contents: ['Hola Mundo']}]}
   );
@@ -126,7 +126,7 @@ test('html(msg(string)) translated', (t) => {
 test('html(msg(html))', (t) => {
   checkTransform(
     t,
-    'html`<b>${msg("foo", html`Hello <i>World</i>`)}</b>`;',
+    'html`<b>${msg(html`Hello <i>World</i>`, {id: "foo"})}</b>`;',
     'html`<b>Hello <i>World</i></b>`;'
   );
 });
@@ -134,7 +134,7 @@ test('html(msg(html))', (t) => {
 test('html(msg(html)) translated', (t) => {
   checkTransform(
     t,
-    'html`<b>${msg("foo", html`Hello <i>World</i>`)}</b>`;',
+    'html`<b>${msg(html`Hello <i>World</i>`, {id: "foo"})}</b>`;',
     'html`<b>Hola <i>Mundo</i></b>`;',
     {
       messages: [
@@ -155,7 +155,8 @@ test('html(msg(html)) translated', (t) => {
 test('msg(fn(string), expr)', (t) => {
   checkTransform(
     t,
-    'const name = "World";' + 'msg("foo", (name) => `Hello ${name}!`, name);',
+    'const name = "World";' +
+      'msg((name) => `Hello ${name}!`, {id: "foo", args: [name]});',
     'const name = "World";' + '`Hello ${name}!`;'
   );
 });
@@ -163,7 +164,8 @@ test('msg(fn(string), expr)', (t) => {
 test('msg(fn(string), expr) translated', (t) => {
   checkTransform(
     t,
-    'const name = "World";' + 'msg("foo", (name) => `Hello ${name}!`, name);',
+    'const name = "World";' +
+      'msg((name) => `Hello ${name}!`, {id: "foo", args: [name]});',
     'const name = "World";' + '`Hola ${name}!`;',
     {
       messages: [
@@ -179,7 +181,7 @@ test('msg(fn(string), expr) translated', (t) => {
 test('msg(fn(string), string)', (t) => {
   checkTransform(
     t,
-    'msg("foo", (name) => `Hello ${name}!`, "World");',
+    'msg((name) => `Hello ${name}!`, {id: "foo", args: ["World"]});',
     '`Hello World!`;'
   );
 });
@@ -187,7 +189,7 @@ test('msg(fn(string), string)', (t) => {
 test('msg(fn(string), string) translated', (t) => {
   checkTransform(
     t,
-    'msg("foo", (name) => `Hello ${name}!`, "World");',
+    'msg((name) => `Hello ${name}!`, {id: "foo", args: ["World"]});',
     '`Hola World!`;',
     {
       messages: [
@@ -204,7 +206,7 @@ test('msg(fn(html), expr)', (t) => {
   checkTransform(
     t,
     'const name = "World";' +
-      'msg("foo", (name) => html`Hello <b>${name}</b>!`, name);',
+      'msg((name) => html`Hello <b>${name}</b>!`, {id: "foo", args: [name]});',
     'const name = "World";' + 'html`Hello <b>${name}</b>!`;'
   );
 });
@@ -213,7 +215,7 @@ test('msg(fn(html), expr) translated', (t) => {
   checkTransform(
     t,
     'const name = "World";' +
-      'msg("foo", (name) => html`Hello <b>${name}</b>!`, name);',
+      'msg((name) => html`Hello <b>${name}</b>!`, {id: "foo", args: [name]});',
     'const name = "World";' + 'html`Hola <b>${name}</b>!`;',
     {
       messages: [
@@ -229,7 +231,7 @@ test('msg(fn(html), expr) translated', (t) => {
 test('msg(fn(html), string)', (t) => {
   checkTransform(
     t,
-    'msg("foo", (name) => html`Hello <b>${name}</b>!`, "World");',
+    'msg((name) => html`Hello <b>${name}</b>!`, {id: "foo", args: ["World"]});',
     'html`Hello <b>World</b>!`;'
   );
 });
@@ -237,7 +239,7 @@ test('msg(fn(html), string)', (t) => {
 test('msg(fn(html), string) translated', (t) => {
   checkTransform(
     t,
-    'msg("foo", (name) => html`Hello <b>${name}</b>!`, "World");',
+    'msg((name) => html`Hello <b>${name}</b>!`, {id: "foo", args: ["World"]});',
     'html`Hola <b>World</b>!`;',
     {
       messages: [
@@ -253,7 +255,7 @@ test('msg(fn(html), string) translated', (t) => {
 test('msg(fn(html), html)', (t) => {
   checkTransform(
     t,
-    'msg("foo", (name) => html`Hello <b>${name}</b>!`, html`<i>World</i>`);',
+    'msg((name) => html`Hello <b>${name}</b>!`, {id: "foo", args: [html`<i>World</i>`]});',
     'html`Hello <b><i>World</i></b>!`;'
   );
 });
@@ -261,7 +263,7 @@ test('msg(fn(html), html)', (t) => {
 test('msg(fn(html), html) translated', (t) => {
   checkTransform(
     t,
-    'msg("foo", (name) => html`Hello <b>${name}</b>!`, html`<i>World</i>`);',
+    'msg((name) => html`Hello <b>${name}</b>!`, {id: "foo", args: [html`<i>World</i>`]});',
     'html`Hola <b><i>World</i></b>!`;',
     {
       messages: [
@@ -277,7 +279,7 @@ test('msg(fn(html), html) translated', (t) => {
 test('msg(fn(string), msg(string))', (t) => {
   checkTransform(
     t,
-    'msg("foo", (name) => `Hello ${name}!`, msg("bar", "World"));',
+    'msg((name) => `Hello ${name}!`, {id: "foo", args: [msg("World", {id: "bar"})]});',
     '`Hello World!`;'
   );
 });
@@ -285,7 +287,7 @@ test('msg(fn(string), msg(string))', (t) => {
 test('msg(fn(string), msg(string)) translated', (t) => {
   checkTransform(
     t,
-    'msg("foo", (name) => `Hello ${name}!`, msg("bar", "World"));',
+    'msg((name) => `Hello ${name}!`, {id: "foo", args: [msg("World", {id: "bar"})]});',
     '`Hola Mundo!`;',
     {
       messages: [
@@ -307,7 +309,7 @@ test('import * as litLocalize', (t) => {
     t,
     `
     import * as litLocalize from './lit-localize.js';
-    litLocalize.msg("foo", "Hello World");
+    litLocalize.msg("Hello World", {id: "foo"});
   `,
     '"Hello World";',
     {autoImport: false}
@@ -319,7 +321,7 @@ test('import {msg as foo}', (t) => {
     t,
     `
     import {msg as foo} from './lit-localize.js';
-    foo("foo", "Hello World");
+    foo("Hello World", {id: "foo"});
   `,
     '"Hello World";',
     {autoImport: false}
@@ -329,10 +331,10 @@ test('import {msg as foo}', (t) => {
 test('exclude different msg function', (t) => {
   checkTransform(
     t,
-    `function msg(id: string, template: string) { return template; }
-    msg("foo", "Hello World");`,
-    `function msg(id, template) { return template; }
-    msg("foo", "Hello World");`,
+    `function msg(template: string, options?: {id?: string}) { return template; }
+    msg("Hello World", {id: "foo"});`,
+    `function msg(template, options) { return template; }
+    msg("Hello World", {id: "foo"});`,
     {autoImport: false}
   );
 });
@@ -422,7 +424,7 @@ test('Localized(LitElement) -> LitElement', (t) => {
      import {msg} from './lit-localize.js';
      class MyElement extends Localized(LitElement) {
        render() {
-         return html\`<b>\${msg('greeting', 'Hello World!')}</b>\`;
+         return html\`<b>\${msg('Hello World!', {id: 'greeting'})}</b>\`;
        }
      }`,
     `import {LitElement, html} from 'lit-element';

--- a/packages/localize/src_client/lit-localize.ts
+++ b/packages/localize/src_client/lit-localize.ts
@@ -305,41 +305,43 @@ const setLocale: ((newLocale: string) => Promise<void>) & {
 /**
  * Make a string or lit-html template localizable.
  *
- * @param id A project-wide unique identifier for this template.
  * @param template A string, a lit-html template, or a function that returns
  * either a string or lit-html template.
- * @param args In the case that `template` is a function, it is invoked with
- * the 3rd and onwards arguments to `msg`.
+ * @param options Configuration object with the following properties:
+ *   - id: Project-wide unique identifier for this template.
+ *   - args: In the case that `template` is a function, it will be invoked with
+ *     these arguments.
  */
-export function _msg(id: string, template: string): string;
+export function _msg(template: string, options: {id: string}): string;
 
-export function _msg(id: string, template: TemplateResult): TemplateResult;
+export function _msg(
+  template: TemplateResult,
+  options: {id: string}
+): TemplateResult;
 
 export function _msg<F extends (...args: any[]) => string>(
-  id: string,
   fn: F,
-  ...params: Parameters<F>
+  options: {id: string; args: Parameters<F>}
 ): string;
 
 export function _msg<F extends (...args: any[]) => TemplateResult>(
-  id: string,
   fn: F,
-  ...params: Parameters<F>
+  options: {id: string; args: Parameters<F>}
 ): TemplateResult;
 
 export function _msg(
-  id: string,
   template: TemplateLike,
-  ...params: any[]
+  options: {id: string; args?: any[]}
 ): string | TemplateResult {
   if (templates) {
+    const id = options.id;
     const localized = templates[id];
     if (localized) {
       template = localized;
     }
   }
   if (typeof template === 'function') {
-    return template(...params);
+    return template(...(options?.args ?? []));
   }
   return template;
 }

--- a/packages/localize/src_client/tests/lit-localize.test.ts
+++ b/packages/localize/src_client/tests/lit-localize.test.ts
@@ -84,7 +84,7 @@ suite('lit-localize', () => {
     });
 
     test('renders regular template in English', () => {
-      render(msg('greeting', html`<b>Hello World</b>`), container);
+      render(msg(html`<b>Hello World</b>`, {id: 'greeting'}), container);
       assert.equal(container.textContent, 'Hello World');
     });
 
@@ -92,13 +92,16 @@ suite('lit-localize', () => {
       const loaded = setLocale('es-419');
       lastLoadLocaleResponse.resolve(spanishModule);
       await loaded;
-      render(msg('greeting', html`<b>Hello World</b>`), container);
+      render(msg(html`<b>Hello World</b>`, {id: 'greeting'}), container);
       assert.equal(container.textContent, 'Hola Mundo');
     });
 
     test('renders parameterized template in English', () => {
       render(
-        msg('parameterized', (name: string) => html`Hello ${name}`, 'friend'),
+        msg((name: string) => html`Hello ${name}`, {
+          id: 'parameterized',
+          args: ['friend'],
+        }),
         container
       );
       assert.equal(container.textContent, 'Hello friend');
@@ -109,7 +112,10 @@ suite('lit-localize', () => {
       lastLoadLocaleResponse.resolve(spanishModule);
       await loaded;
       render(
-        msg('parameterized', (name: string) => html`Hello ${name}`, 'friend'),
+        msg((name: string) => html`Hello ${name}`, {
+          id: 'parameterized',
+          args: ['friend'],
+        }),
         container
       );
       assert.equal(container.textContent, 'Hola friend');
@@ -119,7 +125,7 @@ suite('lit-localize', () => {
   suite('Localized mixin', () => {
     class XGreeter extends Localized(LitElement) {
       render() {
-        return msg('greeting', html`<b>Hello World</b>`);
+        return msg(html`<b>Hello World</b>`, {id: 'greeting'});
       }
     }
     customElements.define('x-greeter', XGreeter);
@@ -177,13 +183,13 @@ suite('lit-localize', () => {
 
     function assertEnglish() {
       assert.equal(getLocale(), 'en');
-      render(msg('greeting', html`<b>Hello World</b>`), container);
+      render(msg(html`<b>Hello World</b>`, {id: 'greeting'}), container);
       assert.equal(container.textContent, 'Hello World');
     }
 
     function assertSpanish() {
       assert.equal(getLocale(), 'es-419');
-      render(msg('greeting', html`<b>Hello World</b>`), container);
+      render(msg(html`<b>Hello World</b>`, {id: 'greeting'}), container);
       assert.equal(container.textContent, 'Hola Mundo');
     }
 

--- a/packages/localize/testdata/placeholder-errors/goldens/foo.ts
+++ b/packages/localize/testdata/placeholder-errors/goldens/foo.ts
@@ -1,8 +1,14 @@
 import {html} from 'lit-html';
 import {msg} from '../../../lit-localize.js';
 
-msg('extra-expression', `Hello World`);
-msg('missing-expression', (name: string) => `Hello ${name}`, 'Friend');
-msg('changed-expression', (name: string) => `Hello ${name}`, 'Friend');
-msg('missing-html', html`<b>Hello World</b>`);
-msg('changed-html', html`<b>Hello World</b>`);
+msg(`Hello World`, {id: 'extra-expression'});
+msg((name: string) => `Hello ${name}`, {
+  id: 'missing-expression',
+  args: ['Friend'],
+});
+msg((name: string) => `Hello ${name}`, {
+  id: 'changed-expression',
+  args: ['Friend'],
+});
+msg(html`<b>Hello World</b>`, {id: 'missing-html'});
+msg(html`<b>Hello World</b>`, {id: 'changed-html'});

--- a/packages/localize/testdata/placeholder-errors/input/foo.ts
+++ b/packages/localize/testdata/placeholder-errors/input/foo.ts
@@ -1,8 +1,14 @@
 import {html} from 'lit-html';
 import {msg} from '../../../lit-localize.js';
 
-msg('extra-expression', `Hello World`);
-msg('missing-expression', (name: string) => `Hello ${name}`, 'Friend');
-msg('changed-expression', (name: string) => `Hello ${name}`, 'Friend');
-msg('missing-html', html`<b>Hello World</b>`);
-msg('changed-html', html`<b>Hello World</b>`);
+msg(`Hello World`, {id: 'extra-expression'});
+msg((name: string) => `Hello ${name}`, {
+  id: 'missing-expression',
+  args: ['Friend'],
+});
+msg((name: string) => `Hello ${name}`, {
+  id: 'changed-expression',
+  args: ['Friend'],
+});
+msg(html`<b>Hello World</b>`, {id: 'missing-html'});
+msg(html`<b>Hello World</b>`, {id: 'changed-html'});

--- a/packages/localize/testdata/transform/goldens/foo.ts
+++ b/packages/localize/testdata/transform/goldens/foo.ts
@@ -13,24 +13,22 @@ window.addEventListener(LOCALE_STATUS_EVENT, (event) => {
   console.log(event.detail.status);
 });
 
-msg('string', 'Hello World!');
+msg('Hello World!', {id: 'string'});
 
-msg('lit', html`Hello <b><i>World!</i></b>`);
+msg(html`Hello <b><i>World!</i></b>`, {id: 'lit'});
 
-msg('variables_1', (name: string) => `Hello ${name}!`, 'World');
+msg((name: string) => `Hello ${name}!`, {id: 'variables_1', args: ['World']});
 
 msg(
-  'lit_variables_1',
   (url: string, name: string) =>
     html`Hello ${name}, click <a href="${url}">here</a>!`,
-  'https://www.example.com/',
-  'World'
+  {id: 'lit_variables_1', args: ['https://www.example.com/', 'World']}
 );
 
 export class MyElement extends Localized(LitElement) {
   render() {
     return html`<p>
-      ${msg('lit', html`Hello <b><i>World!</i></b>`)} (${getLocale()})
+      ${msg(html`Hello <b><i>World!</i></b>`, {id: 'lit'})} (${getLocale()})
     </p>`;
   }
 }

--- a/packages/localize/testdata/transform/input/foo.ts
+++ b/packages/localize/testdata/transform/input/foo.ts
@@ -13,24 +13,22 @@ window.addEventListener(LOCALE_STATUS_EVENT, (event) => {
   console.log(event.detail.status);
 });
 
-msg('string', 'Hello World!');
+msg('Hello World!', {id: 'string'});
 
-msg('lit', html`Hello <b><i>World!</i></b>`);
+msg(html`Hello <b><i>World!</i></b>`, {id: 'lit'});
 
-msg('variables_1', (name: string) => `Hello ${name}!`, 'World');
+msg((name: string) => `Hello ${name}!`, {id: 'variables_1', args: ['World']});
 
 msg(
-  'lit_variables_1',
   (url: string, name: string) =>
     html`Hello ${name}, click <a href="${url}">here</a>!`,
-  'https://www.example.com/',
-  'World'
+  {id: 'lit_variables_1', args: ['https://www.example.com/', 'World']}
 );
 
 export class MyElement extends Localized(LitElement) {
   render() {
     return html`<p>
-      ${msg('lit', html`Hello <b><i>World!</i></b>`)} (${getLocale()})
+      ${msg(html`Hello <b><i>World!</i></b>`, {id: 'lit'})} (${getLocale()})
     </p>`;
   }
 }

--- a/packages/localize/testdata/xlb/goldens/foo.ts
+++ b/packages/localize/testdata/xlb/goldens/foo.ts
@@ -1,28 +1,34 @@
 import {html} from 'lit-html';
 import * as litLocalize from '../../../lit-localize.js';
 
-litLocalize.msg('string', 'Hello World!');
+litLocalize.msg('Hello World!', {id: 'string'});
 
-litLocalize.msg('lit', html`Hello <b><i>World!</i></b>`);
+litLocalize.msg(html`Hello <b><i>World!</i></b>`, {id: 'lit'});
 
-litLocalize.msg('variables_1', (name: string) => `Hello ${name}!`, 'World');
+litLocalize.msg((name: string) => `Hello ${name}!`, {
+  id: 'variables_1',
+  args: ['World'],
+});
 
 litLocalize.msg(
-  'lit_variables_1',
   (url: string, name: string) =>
     html`Hello ${name}, click <a href="${url}">here</a>!`,
-  'World',
-  'https://www.example.com/'
+  {
+    id: 'lit_variables_1',
+    args: ['World', 'https://www.example.com/'],
+  }
 );
 
-litLocalize.msg('lit_variables_2', (x: string) => html`${x}y${x}y${x}`, 'x');
+litLocalize.msg((x: string) => html`${x}y${x}y${x}`, {
+  id: 'lit_variables_2',
+  args: ['x'],
+});
 
 litLocalize.msg(
-  'lit_variables_3',
-  (x: string) => html`<b> ${x} </b>
-    <i> y </i>
-    <b> ${x} </b>
-    <i> y </i>
-    <b> ${x} </b>`,
-  'x'
+  (x: string) => html`<b>${x}</b>
+    <i>y</i>
+    <b>${x}</b>
+    <i>y</i>
+    <b>${x}</b>`,
+  {id: 'lit_variables_3', args: ['x']}
 );

--- a/packages/localize/testdata/xlb/goldens/tsout/es-419.ts
+++ b/packages/localize/testdata/xlb/goldens/tsout/es-419.ts
@@ -13,9 +13,9 @@ export const templates = {
   string: `Hola Mundo!`,
   variables_1: (name: any) => `Hola ${name}!`,
   lit_variables_2: (x: any) => html`${x}y${x}y${x}`,
-  lit_variables_3: (x: any) => html`<b> ${x} </b>
-    <i> y </i>
-    <b> ${x} </b>
-    <i> y </i>
-    <b> ${x} </b>`,
+  lit_variables_3: (x: any) => html`<b>${x}</b>
+    <i>y</i>
+    <b>${x}</b>
+    <i>y</i>
+    <b>${x}</b>`,
 };

--- a/packages/localize/testdata/xlb/goldens/xlb/en.xlb
+++ b/packages/localize/testdata/xlb/goldens/xlb/en.xlb
@@ -6,20 +6,10 @@
     <msg name="variables_1">Hello <ph>${name}</ph>!</msg>
     <msg name="lit_variables_1">Hello <ph>${name}</ph>, click <ph>&lt;a href="${url}"></ph>here<ph>&lt;/a></ph>!</msg>
     <msg name="lit_variables_2"><ph>${x}</ph>y<ph>${x}</ph>y<ph>${x}</ph></msg>
-    <msg name="lit_variables_3"><ph>&lt;b>
-      ${x}
-    &lt;/b>
-    &lt;i></ph>
-      y
-    <ph>&lt;/i>
-    &lt;b>
-      ${x}
-    &lt;/b>
-    &lt;i></ph>
-      y
-    <ph>&lt;/i>
-    &lt;b>
-      ${x}
-    &lt;/b></ph></msg>
+    <msg name="lit_variables_3"><ph>&lt;b>${x}&lt;/b>
+    &lt;i></ph>y<ph>&lt;/i>
+    &lt;b>${x}&lt;/b>
+    &lt;i></ph>y<ph>&lt;/i>
+    &lt;b>${x}&lt;/b></ph></msg>
   </messages>
 </localizationbundle>

--- a/packages/localize/testdata/xlb/input/foo.ts
+++ b/packages/localize/testdata/xlb/input/foo.ts
@@ -1,38 +1,34 @@
 import {html} from 'lit-html';
 import * as litLocalize from '../../../lit-localize.js';
 
-litLocalize.msg('string', 'Hello World!');
+litLocalize.msg('Hello World!', {id: 'string'});
 
-litLocalize.msg('lit', html`Hello <b><i>World!</i></b>`);
+litLocalize.msg(html`Hello <b><i>World!</i></b>`, {id: 'lit'});
 
-litLocalize.msg('variables_1', (name: string) => `Hello ${name}!`, 'World');
+litLocalize.msg((name: string) => `Hello ${name}!`, {
+  id: 'variables_1',
+  args: ['World'],
+});
 
 litLocalize.msg(
-  'lit_variables_1',
   (url: string, name: string) =>
     html`Hello ${name}, click <a href="${url}">here</a>!`,
-  'World',
-  'https://www.example.com/'
+  {
+    id: 'lit_variables_1',
+    args: ['World', 'https://www.example.com/'],
+  }
 );
 
-litLocalize.msg('lit_variables_2', (x: string) => html`${x}y${x}y${x}`, 'x');
+litLocalize.msg((x: string) => html`${x}y${x}y${x}`, {
+  id: 'lit_variables_2',
+  args: ['x'],
+});
 
 litLocalize.msg(
-  'lit_variables_3',
-  (x: string) => html`<b>
-      ${x}
-    </b>
-    <i>
-      y
-    </i>
-    <b>
-      ${x}
-    </b>
-    <i>
-      y
-    </i>
-    <b>
-      ${x}
-    </b>`,
-  'x'
+  (x: string) => html`<b>${x}</b>
+    <i>y</i>
+    <b>${x}</b>
+    <i>y</i>
+    <b>${x}</b>`,
+  {id: 'lit_variables_3', args: ['x']}
 );

--- a/packages/localize/testdata/xliff-init/goldens/foo.ts
+++ b/packages/localize/testdata/xliff-init/goldens/foo.ts
@@ -1,3 +1,3 @@
 import {msg} from '../../../lit-localize.js';
 
-msg('string', 'Hello World!');
+msg('Hello World!', {id: 'string'});

--- a/packages/localize/testdata/xliff-init/input/foo.ts
+++ b/packages/localize/testdata/xliff-init/input/foo.ts
@@ -1,3 +1,3 @@
 import {msg} from '../../../lit-localize.js';
 
-msg('string', 'Hello World!');
+msg('Hello World!', {id: 'string'});

--- a/packages/localize/testdata/xliff/goldens/foo.ts
+++ b/packages/localize/testdata/xliff/goldens/foo.ts
@@ -1,30 +1,27 @@
 import {html} from 'lit-html';
 import {msg} from '../../../lit-localize.js';
 
-msg('string', 'Hello World!');
+msg('Hello World!', {id: 'string'});
 
-msg('lit', html`Hello <b><i>World!</i></b>`);
+msg(html`Hello <b><i>World!</i></b>`, {id: 'lit'});
 
-msg('variables_1', (name: string) => `Hello ${name}!`, 'World');
+msg((name: string) => `Hello ${name}!`, {id: 'variables_1', args: ['World']});
 
 msg(
-  'lit_variables_1',
   (url: string, name: string) =>
     html`Hello ${name}, click <a href="${url}">here</a>!`,
-  'World',
-  'https://www.example.com/'
+  {id: 'lit_variables_1', args: ['World', 'https://www.example.com/']}
 );
 
-msg('lit_variables_2', (x: string) => html`${x}y${x}y${x}`, 'x');
+msg((x: string) => html`${x}y${x}y${x}`, {id: 'lit_variables_2', args: ['x']});
 
 msg(
-  'lit_variables_3',
-  (x: string) => html`<b> ${x} </b>
-    <i> y </i>
-    <b> ${x} </b>
-    <i> y </i>
-    <b> ${x} </b>`,
-  'x'
+  (x: string) => html`<b>${x}</b>
+    <i>y</i>
+    <b>${x}</b>
+    <i>y</i>
+    <b>${x}</b>`,
+  {id: 'lit_variables_3', args: ['x']}
 );
 
-msg('comment', html`Hello <b><!-- comment -->World!</b>`);
+msg(html`Hello <b><!-- comment -->World!</b>`, {id: 'comment'});

--- a/packages/localize/testdata/xliff/goldens/tsout/es-419.ts
+++ b/packages/localize/testdata/xliff/goldens/tsout/es-419.ts
@@ -14,9 +14,9 @@ export const templates = {
   string: `Hola Mundo!`,
   variables_1: (name: any) => `Hola ${name}!`,
   lit_variables_2: (x: any) => html`${x}y${x}y${x}`,
-  lit_variables_3: (x: any) => html`<b> ${x} </b>
-    <i> y </i>
-    <b> ${x} </b>
-    <i> y </i>
-    <b> ${x} </b>`,
+  lit_variables_3: (x: any) => html`<b>${x}</b>
+    <i>y</i>
+    <b>${x}</b>
+    <i>y</i>
+    <b>${x}</b>`,
 };

--- a/packages/localize/testdata/xliff/goldens/tsout/zh_CN.ts
+++ b/packages/localize/testdata/xliff/goldens/tsout/zh_CN.ts
@@ -13,10 +13,10 @@ export const templates = {
   lit_variables_1: (url: any, name: any) =>
     html`Hello ${name}, click <a href="${url}">here</a>!`,
   lit_variables_2: (x: any) => html`${x}y${x}y${x}`,
-  lit_variables_3: (x: any) => html`<b> ${x} </b>
-    <i> y </i>
-    <b> ${x} </b>
-    <i> y </i>
-    <b> ${x} </b>`,
+  lit_variables_3: (x: any) => html`<b>${x}</b>
+    <i>y</i>
+    <b>${x}</b>
+    <i>y</i>
+    <b>${x}</b>`,
   comment: html`Hello <b><!-- comment -->World!</b>`,
 };

--- a/packages/localize/testdata/xliff/goldens/xliff/es-419.xlf
+++ b/packages/localize/testdata/xliff/goldens/xliff/es-419.xlf
@@ -22,21 +22,11 @@
   <source><ph id="0">${x}</ph>y<ph id="1">${x}</ph>y<ph id="2">${x}</ph></source>
 </trans-unit>
 <trans-unit id="lit_variables_3">
-  <source><ph id="0">&lt;b>
-      ${x}
-    &lt;/b>
-    &lt;i></ph>
-      y
-    <ph id="1">&lt;/i>
-    &lt;b>
-      ${x}
-    &lt;/b>
-    &lt;i></ph>
-      y
-    <ph id="2">&lt;/i>
-    &lt;b>
-      ${x}
-    &lt;/b></ph></source>
+  <source><ph id="0">&lt;b>${x}&lt;/b>
+    &lt;i></ph>y<ph id="1">&lt;/i>
+    &lt;b>${x}&lt;/b>
+    &lt;i></ph>y<ph id="2">&lt;/i>
+    &lt;b>${x}&lt;/b></ph></source>
 </trans-unit>
 <trans-unit id="comment">
   <source>Hello <ph id="0">&lt;b>&lt;!-- comment --></ph>World!<ph id="1">&lt;/b></ph></source>

--- a/packages/localize/testdata/xliff/goldens/xliff/zh_CN.xlf
+++ b/packages/localize/testdata/xliff/goldens/xliff/zh_CN.xlf
@@ -18,21 +18,11 @@
   <source><ph id="0">${x}</ph>y<ph id="1">${x}</ph>y<ph id="2">${x}</ph></source>
 </trans-unit>
 <trans-unit id="lit_variables_3">
-  <source><ph id="0">&lt;b>
-      ${x}
-    &lt;/b>
-    &lt;i></ph>
-      y
-    <ph id="1">&lt;/i>
-    &lt;b>
-      ${x}
-    &lt;/b>
-    &lt;i></ph>
-      y
-    <ph id="2">&lt;/i>
-    &lt;b>
-      ${x}
-    &lt;/b></ph></source>
+  <source><ph id="0">&lt;b>${x}&lt;/b>
+    &lt;i></ph>y<ph id="1">&lt;/i>
+    &lt;b>${x}&lt;/b>
+    &lt;i></ph>y<ph id="2">&lt;/i>
+    &lt;b>${x}&lt;/b></ph></source>
 </trans-unit>
 <trans-unit id="comment">
   <source>Hello <ph id="0">&lt;b>&lt;!-- comment --></ph>World!<ph id="1">&lt;/b></ph></source>

--- a/packages/localize/testdata/xliff/input/foo.ts
+++ b/packages/localize/testdata/xliff/input/foo.ts
@@ -1,40 +1,27 @@
 import {html} from 'lit-html';
 import {msg} from '../../../lit-localize.js';
 
-msg('string', 'Hello World!');
+msg('Hello World!', {id: 'string'});
 
-msg('lit', html`Hello <b><i>World!</i></b>`);
+msg(html`Hello <b><i>World!</i></b>`, {id: 'lit'});
 
-msg('variables_1', (name: string) => `Hello ${name}!`, 'World');
+msg((name: string) => `Hello ${name}!`, {id: 'variables_1', args: ['World']});
 
 msg(
-  'lit_variables_1',
   (url: string, name: string) =>
     html`Hello ${name}, click <a href="${url}">here</a>!`,
-  'World',
-  'https://www.example.com/'
+  {id: 'lit_variables_1', args: ['World', 'https://www.example.com/']}
 );
 
-msg('lit_variables_2', (x: string) => html`${x}y${x}y${x}`, 'x');
+msg((x: string) => html`${x}y${x}y${x}`, {id: 'lit_variables_2', args: ['x']});
 
 msg(
-  'lit_variables_3',
-  (x: string) => html`<b>
-      ${x}
-    </b>
-    <i>
-      y
-    </i>
-    <b>
-      ${x}
-    </b>
-    <i>
-      y
-    </i>
-    <b>
-      ${x}
-    </b>`,
-  'x'
+  (x: string) => html`<b>${x}</b>
+    <i>y</i>
+    <b>${x}</b>
+    <i>y</i>
+    <b>${x}</b>`,
+  {id: 'lit_variables_3', args: ['x']}
 );
 
-msg('comment', html`Hello <b><!-- comment -->World!</b>`);
+msg(html`Hello <b><!-- comment -->World!</b>`, {id: 'comment'});


### PR DESCRIPTION
Changes the lit-localize `msg` signature, the first step in adding support for automatic localize message IDs (https://github.com/Polymer/lit-html/issues/1437).


 Before:

  ```ts
  msg(id: string, template: string|TemplateResult|Function, ...args: any[])
  ```

  After:

  ```ts
  msg(template: string|TemplateResult|Function, options: {id: string: args?: any[]})
  ```

In the next PR, `id` will become optional.

Also fixes the json-schema build issue.