### PR TITLE
[localize] Switch to UTF-16 version of FNV-1A hash

### DIFF
--- a/packages/localize/README.md
+++ b/packages/localize/README.md
@@ -40,7 +40,7 @@ Run `lit-localize` to extract all localizable templates and generate an XLIFF
 file, a format which is supported by many localization tools and services:
 
 ```xml
-<trans-unit id="ah3c44aff2d5f5ef6b">
+<trans-unit id="h3c44aff2d5f5ef6b">
   <source>Hello <ph id="0">&lt;b></ph>World<ph id="1">&lt;/b></ph>!</source>
   <!-- target tag added by your localization process -->
   <target>Hola <ph id="0">&lt;b></ph>Mundo<ph id="1">&lt;/b></ph>!</target>
@@ -165,7 +165,7 @@ lit-localize supports two output modes: _transform_ and _runtime_.
    into `<ph>` tags.
 
    ```xml
-   <trans-unit id="ah3c44aff2d5f5ef6b">
+   <trans-unit id="h3c44aff2d5f5ef6b">
      <source>Hello <ph id="0">&lt;b></ph>World<ph id="1">&lt;/b></ph>!</source>
    </trans-unit>
    ```
@@ -175,7 +175,7 @@ lit-localize supports two output modes: _transform_ and _runtime_.
    this tag by feeding it this XLIFF file.
 
    ```xml
-   <trans-unit id="ah3c44aff2d5f5ef6b">
+   <trans-unit id="h3c44aff2d5f5ef6b">
      <source>Hello <ph id="0">&lt;b></ph>World<ph id="1">&lt;/b></ph>!</source>
      <target>Hola <ph id="0">&lt;b></ph>Mundo<ph id="1">&lt;/b></ph>!</target>
    </trans-unit>

--- a/packages/localize/examples/runtime/src/locales/es-419.ts
+++ b/packages/localize/examples/runtime/src/locales/es-419.ts
@@ -8,5 +8,5 @@
     /* eslint-disable @typescript-eslint/no-explicit-any */
 
     export const templates = {
-      'ah3c44aff2d5f5ef6b': html`Hola <b>Mundo</b>!`,
+      'h3c44aff2d5f5ef6b': html`Hola <b>Mundo</b>!`,
     };

--- a/packages/localize/examples/runtime/src/locales/zh_CN.ts
+++ b/packages/localize/examples/runtime/src/locales/zh_CN.ts
@@ -8,5 +8,5 @@
     /* eslint-disable @typescript-eslint/no-explicit-any */
 
     export const templates = {
-      'ah3c44aff2d5f5ef6b': html`你好, <b>世界!</b>`,
+      'h3c44aff2d5f5ef6b': html`你好, <b>世界!</b>`,
     };

--- a/packages/localize/examples/runtime/xliff/es-419.xlf
+++ b/packages/localize/examples/runtime/xliff/es-419.xlf
@@ -2,7 +2,7 @@
 <xliff version="1.2" xmlns="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-strict.xsd">
 <file target-language="es-419" source-language="en" original="lit-localize-inputs" datatype="plaintext">
 <body>
-<trans-unit id="ah3c44aff2d5f5ef6b">
+<trans-unit id="h3c44aff2d5f5ef6b">
   <source>Hello <ph id="0">&lt;b></ph>World<ph id="1">&lt;/b></ph>!</source>
   <target>Hola <ph id="0">&lt;b></ph>Mundo<ph id="1">&lt;/b></ph>!</target>
 </trans-unit>

--- a/packages/localize/examples/runtime/xliff/zh_CN.xlf
+++ b/packages/localize/examples/runtime/xliff/zh_CN.xlf
@@ -2,7 +2,7 @@
 <xliff version="1.2" xmlns="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-strict.xsd">
 <file target-language="zh_CN" source-language="en" original="lit-localize-inputs" datatype="plaintext">
 <body>
-<trans-unit id="ah3c44aff2d5f5ef6b">
+<trans-unit id="h3c44aff2d5f5ef6b">
   <source>Hello <ph id="0">&lt;b></ph>World<ph id="1">&lt;/b></ph>!</source>
   <target>你好, <ph id="0">&lt;b></ph>世界!<ph id="1">&lt;/b></ph></target>
 </trans-unit>

--- a/packages/localize/examples/transform/xliff/es-419.xlf
+++ b/packages/localize/examples/transform/xliff/es-419.xlf
@@ -2,7 +2,7 @@
 <xliff version="1.2" xmlns="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-strict.xsd">
 <file target-language="es-419" source-language="en" original="lit-localize-inputs" datatype="plaintext">
 <body>
-<trans-unit id="ah3c44aff2d5f5ef6b">
+<trans-unit id="h3c44aff2d5f5ef6b">
   <source>Hello <ph id="0">&lt;b></ph>World<ph id="1">&lt;/b></ph>!</source>
   <target>Hola <ph id="0">&lt;b></ph>Mundo<ph id="1">&lt;/b></ph>!</target>
 </trans-unit>

--- a/packages/localize/examples/transform/xliff/zh_CN.xlf
+++ b/packages/localize/examples/transform/xliff/zh_CN.xlf
@@ -2,7 +2,7 @@
 <xliff version="1.2" xmlns="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-strict.xsd">
 <file target-language="zh_CN" source-language="en" original="lit-localize-inputs" datatype="plaintext">
 <body>
-<trans-unit id="ah3c44aff2d5f5ef6b">
+<trans-unit id="h3c44aff2d5f5ef6b">
   <source>Hello <ph id="0">&lt;b></ph>World<ph id="1">&lt;/b></ph>!</source>
   <target>你好, <ph id="0">&lt;b></ph>世界!<ph id="1">&lt;/b></ph></target>
 </trans-unit>

--- a/packages/localize/src/tests/analysis.unit.test.ts
+++ b/packages/localize/src/tests/analysis.unit.test.ts
@@ -93,7 +93,7 @@ test('string message (auto ID)', (t) => {
   `;
   checkAnalysis(t, src, [
     {
-      name: 'as3d58dee72d4e0c27',
+      name: 's3d58dee72d4e0c27',
       contents: ['Hello World'],
     },
   ]);
@@ -123,7 +123,7 @@ test('HTML message (auto ID)', (t) => {
   `;
   checkAnalysis(t, src, [
     {
-      name: 'ahc468c061c2d171f4',
+      name: 'hc468c061c2d171f4',
       contents: [
         {untranslatable: '<b>'},
         'Hello World',
@@ -171,7 +171,7 @@ test('parameterized string message (auto ID)', (t) => {
   `;
   checkAnalysis(t, src, [
     {
-      name: 'asaed7d3734ce7f09d',
+      name: 'saed7d3734ce7f09d',
       contents: ['Hello ', {untranslatable: '${name}'}],
       params: ['name'],
     },

--- a/packages/localize/src_client/fnv1a64.ts
+++ b/packages/localize/src_client/fnv1a64.ts
@@ -3,10 +3,11 @@ Copyright 2014 Travis Webb
 SPDX-License-Identifier: MIT */
 
 // This module is derived from the file:
-// https://github.com/tjwebb/fnv-plus/blob/1e2ce68a07cb7dd4c3c85364f3d8d96c95919474/index.js#L530
+// https://github.com/tjwebb/fnv-plus/blob/1e2ce68a07cb7dd4c3c85364f3d8d96c95919474/index.js#L309
 //
 // Changes:
-// - Only the _hash64_1a_fast_utf function is included.
+// - Only the _hash64_1a_fast function is included.
+// - Removed loop unrolling.
 // - Converted to TypeScript ES module.
 // - var -> let/const
 //
@@ -18,16 +19,13 @@ for (let i = 0; i < 256; i++) {
 }
 
 /**
- * Perform a FNV-1A 64-bit hash of the given string (encoded to UTF-8), and
+ * Perform a FNV-1A 64-bit hash of the given string (as UTF-16 code units), and
  * return a hexadecimal digest (left zero padded to 16 characters).
  *
  * @see {@link http://tools.ietf.org/html/draft-eastlake-fnv-06}
  */
-export function fnv1a64(str: string): string {
-  const l = str.length;
-  let c: number,
-    i: number,
-    t0 = 0,
+export function fnv1a64(str: string) {
+  let t0 = 0,
     v0 = 0x2325,
     t1 = 0,
     v1 = 0x8422,
@@ -36,100 +34,8 @@ export function fnv1a64(str: string): string {
     t3 = 0,
     v3 = 0xcbf2;
 
-  for (i = 0; i < l; i++) {
-    c = str.charCodeAt(i);
-    if (c < 128) {
-      v0 ^= c;
-    } else if (c < 2048) {
-      v0 ^= (c >> 6) | 192;
-      t0 = v0 * 435;
-      t1 = v1 * 435;
-      t2 = v2 * 435;
-      t3 = v3 * 435;
-      t2 += v0 << 8;
-      t3 += v1 << 8;
-      t1 += t0 >>> 16;
-      v0 = t0 & 65535;
-      t2 += t1 >>> 16;
-      v1 = t1 & 65535;
-      v3 = (t3 + (t2 >>> 16)) & 65535;
-      v2 = t2 & 65535;
-      v0 ^= (c & 63) | 128;
-    } else if (
-      (c & 64512) == 55296 &&
-      i + 1 < l &&
-      (str.charCodeAt(i + 1) & 64512) == 56320
-    ) {
-      c = 65536 + ((c & 1023) << 10) + (str.charCodeAt(++i) & 1023);
-      v0 ^= (c >> 18) | 240;
-      t0 = v0 * 435;
-      t1 = v1 * 435;
-      t2 = v2 * 435;
-      t3 = v3 * 435;
-      t2 += v0 << 8;
-      t3 += v1 << 8;
-      t1 += t0 >>> 16;
-      v0 = t0 & 65535;
-      t2 += t1 >>> 16;
-      v1 = t1 & 65535;
-      v3 = (t3 + (t2 >>> 16)) & 65535;
-      v2 = t2 & 65535;
-      v0 ^= ((c >> 12) & 63) | 128;
-      t0 = v0 * 435;
-      t1 = v1 * 435;
-      t2 = v2 * 435;
-      t3 = v3 * 435;
-      t2 += v0 << 8;
-      t3 += v1 << 8;
-      t1 += t0 >>> 16;
-      v0 = t0 & 65535;
-      t2 += t1 >>> 16;
-      v1 = t1 & 65535;
-      v3 = (t3 + (t2 >>> 16)) & 65535;
-      v2 = t2 & 65535;
-      v0 ^= ((c >> 6) & 63) | 128;
-      t0 = v0 * 435;
-      t1 = v1 * 435;
-      t2 = v2 * 435;
-      t3 = v3 * 435;
-      t2 += v0 << 8;
-      t3 += v1 << 8;
-      t1 += t0 >>> 16;
-      v0 = t0 & 65535;
-      t2 += t1 >>> 16;
-      v1 = t1 & 65535;
-      v3 = (t3 + (t2 >>> 16)) & 65535;
-      v2 = t2 & 65535;
-      v0 ^= (c & 63) | 128;
-    } else {
-      v0 ^= (c >> 12) | 224;
-      t0 = v0 * 435;
-      t1 = v1 * 435;
-      t2 = v2 * 435;
-      t3 = v3 * 435;
-      t2 += v0 << 8;
-      t3 += v1 << 8;
-      t1 += t0 >>> 16;
-      v0 = t0 & 65535;
-      t2 += t1 >>> 16;
-      v1 = t1 & 65535;
-      v3 = (t3 + (t2 >>> 16)) & 65535;
-      v2 = t2 & 65535;
-      v0 ^= ((c >> 6) & 63) | 128;
-      t0 = v0 * 435;
-      t1 = v1 * 435;
-      t2 = v2 * 435;
-      t3 = v3 * 435;
-      t2 += v0 << 8;
-      t3 += v1 << 8;
-      t1 += t0 >>> 16;
-      v0 = t0 & 65535;
-      t2 += t1 >>> 16;
-      v1 = t1 & 65535;
-      v3 = (t3 + (t2 >>> 16)) & 65535;
-      v2 = t2 & 65535;
-      v0 ^= (c & 63) | 128;
-    }
+  for (let i = 0; i < str.length; i++) {
+    v0 ^= str.charCodeAt(i);
     t0 = v0 * 435;
     t1 = v1 * 435;
     t2 = v2 * 435;

--- a/packages/localize/src_client/id-generation.ts
+++ b/packages/localize/src_client/id-generation.ts
@@ -49,14 +49,13 @@ const STRING_PREFIX = 's';
  *
  *   [0]    Version indicator for this ID generation scheme ("a").
  *   [1]    Kind of template: [h]tml or [s]tring.
- *   [2,17] 64-bit FNV-1a hash hex digest of the template strings, where each
- *          string is UTF-8 encoded and delineated by an ASCII "record separator"
- *          character.
+ *   [2,17] 64-bit FNV-1a hash hex digest of the template strings, as UTF-16
+ *          code points, delineated by an ASCII "record separator" character.
  *
  * We choose FNV-1a because:
  *
  *   1. It's pretty fast (e.g. much faster than SHA-1).
- *   2. It's pretty small (0.41 KiB minified + brotli).
+ *   2. It's pretty small (0.25 KiB minified + brotli).
  *   3. We don't require cryptographic security, and 64 bits should give
  *      sufficient collision resistance for any one application. Worst
  *      case, we will always detect collisions during analysis.

--- a/packages/localize/src_client/id-generation.ts
+++ b/packages/localize/src_client/id-generation.ts
@@ -17,7 +17,7 @@ import {fnv1a64} from './fnv1a64.js';
  *
  * This is the "record separator" ASCII character.
  */
-export const HASH_DELIMITER = String.fromCharCode(30);
+export const HASH_DELIMITER = '\x1e';
 
 /**
  * Id scheme version prefix to distinguish this implementation from potential

--- a/packages/localize/src_client/id-generation.ts
+++ b/packages/localize/src_client/id-generation.ts
@@ -20,12 +20,6 @@ import {fnv1a64} from './fnv1a64.js';
 export const HASH_DELIMITER = '\x1e';
 
 /**
- * Id scheme version prefix to distinguish this implementation from potential
- * changes in the future.
- */
-const VERSION_PREFIX = 'a';
-
-/**
  * Id prefix on html-tagged templates to distinguish e.g. `<b>x</b>` from
  * html`<b>x</b>`.
  */
@@ -43,13 +37,12 @@ const STRING_PREFIX = 's';
  * Example:
  *   Template: html`Hello <b>${who}</b>!`
  *     Params: ["Hello <b>", "</b>!"], true
- *     Output: ah82ccc38d4d46eaa9
+ *     Output: h82ccc38d4d46eaa9
  *
  * The ID is constructed as:
  *
- *   [0]    Version indicator for this ID generation scheme ("a").
- *   [1]    Kind of template: [h]tml or [s]tring.
- *   [2,17] 64-bit FNV-1a hash hex digest of the template strings, as UTF-16
+ *   [0]    Kind of template: [h]tml or [s]tring.
+ *   [1,16] 64-bit FNV-1a hash hex digest of the template strings, as UTF-16
  *          code points, delineated by an ASCII "record separator" character.
  *
  * We choose FNV-1a because:
@@ -70,7 +63,6 @@ export function generateMsgId(
   isHtmlTagged: boolean
 ): string {
   return (
-    VERSION_PREFIX +
     (isHtmlTagged ? HTML_PREFIX : STRING_PREFIX) +
     fnv1a64(
       typeof strings === 'string' ? strings : strings.join(HASH_DELIMITER)

--- a/packages/localize/src_client/tests/lit-localize.test.ts
+++ b/packages/localize/src_client/tests/lit-localize.test.ts
@@ -125,10 +125,10 @@ suite('lit-localize', () => {
   suite('auto ID', () => {
     const autoSpanishModule = {
       templates: {
-        as8c0ec8d1fb9e6e32: 'Hola Mundo!',
-        as00ad08ebae1e0f74: (name: string) => `Hola ${name}!`,
-        ah3c44aff2d5f5ef6b: html`Hola <b>Mundo</b>!`,
-        ah82ccc38d4d46eaa9: (name: string) => html`Hola <b>${name}</b>!`,
+        s8c0ec8d1fb9e6e32: 'Hola Mundo!',
+        s00ad08ebae1e0f74: (name: string) => `Hola ${name}!`,
+        h3c44aff2d5f5ef6b: html`Hola <b>Mundo</b>!`,
+        h82ccc38d4d46eaa9: (name: string) => html`Hola <b>${name}</b>!`,
       },
     };
 

--- a/packages/localize/testdata/xliff/goldens/tsout/es-419.ts
+++ b/packages/localize/testdata/xliff/goldens/tsout/es-419.ts
@@ -7,14 +7,14 @@ import {html} from 'lit-html';
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 export const templates = {
-  ah3c44aff2d5f5ef6b: html`Hola <b>Mundo</b>!`,
-  ah82ccc38d4d46eaa9: (name: any) => html`Hola <b>${name}</b>!`,
-  as00ad08ebae1e0f74: (name: any) => `Hola ${name}!`,
-  as8c0ec8d1fb9e6e32: `Hola Mundo!`,
   comment: html`Hola <b><!-- comment -->Mundo!</b>`,
+  h3c44aff2d5f5ef6b: html`Hola <b>Mundo</b>!`,
+  h82ccc38d4d46eaa9: (name: any) => html`Hola <b>${name}</b>!`,
   lit: html`Hola <b><i>Galaxia!</i></b>`,
   lit_variables_1: (url: any, name: any) =>
     html`Hola ${name}, clic <a href="${url}">aquí</a>!`,
+  s00ad08ebae1e0f74: (name: any) => `Hola ${name}!`,
+  s8c0ec8d1fb9e6e32: `Hola Mundo!`,
   string: `Hola Mundo!`,
   variables_1: (name: any) => `Hola ${name}!`,
   lit_variables_2: (x: any) => html`${x}y${x}y${x}`,
@@ -23,7 +23,7 @@ export const templates = {
     <b>${x}</b>
     <i>y</i>
     <b>${x}</b>`,
-  as03c68d79ad36e8d4: `described 0`,
-  as03c68e79ad36ea87: `described 1`,
-  as03c68f79ad36ec3a: `described 2`,
+  s03c68d79ad36e8d4: `described 0`,
+  s03c68e79ad36ea87: `described 1`,
+  s03c68f79ad36ec3a: `described 2`,
 };

--- a/packages/localize/testdata/xliff/goldens/tsout/zh_CN.ts
+++ b/packages/localize/testdata/xliff/goldens/tsout/zh_CN.ts
@@ -19,11 +19,11 @@ export const templates = {
     <i>y</i>
     <b>${x}</b>`,
   comment: html`Hello <b><!-- comment -->World!</b>`,
-  as8c0ec8d1fb9e6e32: `Hello World!`,
-  as00ad08ebae1e0f74: (name: any) => `Hello ${name}!`,
-  ah3c44aff2d5f5ef6b: html`Hello <b>World</b>!`,
-  ah82ccc38d4d46eaa9: (name: any) => html`Hello <b>${name}</b>!`,
-  as03c68d79ad36e8d4: `described 0`,
-  as03c68e79ad36ea87: `described 1`,
-  as03c68f79ad36ec3a: `described 2`,
+  s8c0ec8d1fb9e6e32: `Hello World!`,
+  s00ad08ebae1e0f74: (name: any) => `Hello ${name}!`,
+  h3c44aff2d5f5ef6b: html`Hello <b>World</b>!`,
+  h82ccc38d4d46eaa9: (name: any) => html`Hello <b>${name}</b>!`,
+  s03c68d79ad36e8d4: `described 0`,
+  s03c68e79ad36ea87: `described 1`,
+  s03c68f79ad36ec3a: `described 2`,
 };

--- a/packages/localize/testdata/xliff/goldens/xliff/es-419.xlf
+++ b/packages/localize/testdata/xliff/goldens/xliff/es-419.xlf
@@ -32,31 +32,31 @@
   <source>Hello <ph id="0">&lt;b>&lt;!-- comment --></ph>World!<ph id="1">&lt;/b></ph></source>
   <target>Hola <ph id="0">&lt;b>&lt;!-- comment --></ph>Mundo!<ph id="1">&lt;/b></ph></target>
 </trans-unit>
-<trans-unit id="as8c0ec8d1fb9e6e32">
+<trans-unit id="s8c0ec8d1fb9e6e32">
   <source>Hello World!</source>
   <target>Hola Mundo!</target>
 </trans-unit>
-<trans-unit id="as00ad08ebae1e0f74">
+<trans-unit id="s00ad08ebae1e0f74">
   <source>Hello <ph id="0">${name}</ph>!</source>
   <target>Hola <ph id="0">${name}</ph>!</target>
 </trans-unit>
-<trans-unit id="ah3c44aff2d5f5ef6b">
+<trans-unit id="h3c44aff2d5f5ef6b">
   <source>Hello <ph id="0">&lt;b></ph>World<ph id="1">&lt;/b></ph>!</source>
   <target>Hola <ph id="0">&lt;b></ph>Mundo<ph id="1">&lt;/b></ph>!</target>
 </trans-unit>
-<trans-unit id="ah82ccc38d4d46eaa9">
+<trans-unit id="h82ccc38d4d46eaa9">
   <source>Hello <ph id="0">&lt;b>${name}&lt;/b></ph>!</source>
   <target>Hola <ph id="0">&lt;b>${name}&lt;/b></ph>!</target>
 </trans-unit>
-<trans-unit id="as03c68d79ad36e8d4">
+<trans-unit id="s03c68d79ad36e8d4">
   <note>Description of 0</note>
   <source>described 0</source>
 </trans-unit>
-<trans-unit id="as03c68e79ad36ea87">
+<trans-unit id="s03c68e79ad36ea87">
   <note>Parent description / Description of 1</note>
   <source>described 1</source>
 </trans-unit>
-<trans-unit id="as03c68f79ad36ec3a">
+<trans-unit id="s03c68f79ad36ec3a">
   <note>Parent description / Description of 2</note>
   <source>described 2</source>
 </trans-unit>

--- a/packages/localize/testdata/xliff/goldens/xliff/zh_CN.xlf
+++ b/packages/localize/testdata/xliff/goldens/xliff/zh_CN.xlf
@@ -27,27 +27,27 @@
 <trans-unit id="comment">
   <source>Hello <ph id="0">&lt;b>&lt;!-- comment --></ph>World!<ph id="1">&lt;/b></ph></source>
 </trans-unit>
-<trans-unit id="as8c0ec8d1fb9e6e32">
+<trans-unit id="s8c0ec8d1fb9e6e32">
   <source>Hello World!</source>
 </trans-unit>
-<trans-unit id="as00ad08ebae1e0f74">
+<trans-unit id="s00ad08ebae1e0f74">
   <source>Hello <ph id="0">${name}</ph>!</source>
 </trans-unit>
-<trans-unit id="ah3c44aff2d5f5ef6b">
+<trans-unit id="h3c44aff2d5f5ef6b">
   <source>Hello <ph id="0">&lt;b></ph>World<ph id="1">&lt;/b></ph>!</source>
 </trans-unit>
-<trans-unit id="ah82ccc38d4d46eaa9">
+<trans-unit id="h82ccc38d4d46eaa9">
   <source>Hello <ph id="0">&lt;b>${name}&lt;/b></ph>!</source>
 </trans-unit>
-<trans-unit id="as03c68d79ad36e8d4">
+<trans-unit id="s03c68d79ad36e8d4">
   <note>Description of 0</note>
   <source>described 0</source>
 </trans-unit>
-<trans-unit id="as03c68e79ad36ea87">
+<trans-unit id="s03c68e79ad36ea87">
   <note>Parent description / Description of 1</note>
   <source>described 1</source>
 </trans-unit>
-<trans-unit id="as03c68f79ad36ec3a">
+<trans-unit id="s03c68f79ad36ec3a">
   <note>Parent description / Description of 2</note>
   <source>described 2</source>
 </trans-unit>

--- a/packages/localize/testdata/xliff/input/xliff/es-419.xlf
+++ b/packages/localize/testdata/xliff/input/xliff/es-419.xlf
@@ -34,19 +34,19 @@
       <source>Hello <ph id="0">&lt;b>&lt;!-- comment --></ph>World!<ph id="1">&lt;/b></ph></source>
       <target>Hola <ph id="0">&lt;b>&lt;!-- comment --></ph>Mundo!<ph id="1">&lt;/b></ph></target>
     </trans-unit>
-    <trans-unit id="as8c0ec8d1fb9e6e32">
+    <trans-unit id="s8c0ec8d1fb9e6e32">
       <source>Hello World!</source>
       <target>Hola Mundo!</target>
     </trans-unit>
-    <trans-unit id="as00ad08ebae1e0f74">
+    <trans-unit id="s00ad08ebae1e0f74">
       <source>Hello <ph id="0">${name}</ph>!</source>
       <target>Hola <ph id="0">${name}</ph>!</target>
     </trans-unit>
-    <trans-unit id="ah3c44aff2d5f5ef6b">
+    <trans-unit id="h3c44aff2d5f5ef6b">
       <source>Hello <ph id="0">&lt;b></ph>World<ph id="1">&lt;/b></ph>!</source>
       <target>Hola <ph id="0">&lt;b></ph>Mundo<ph id="1">&lt;/b></ph>!</target>
     </trans-unit>
-    <trans-unit id="ah82ccc38d4d46eaa9">
+    <trans-unit id="h82ccc38d4d46eaa9">
       <source>Hello <ph id="0">&lt;b>${name}&lt;/b></ph>!</source>
       <target>Hola <ph id="0">&lt;b>${name}&lt;/b></ph>!</target>
     </trans-unit>


### PR DESCRIPTION
This drops total `lit-localize.js` minified + brotli size from 1.09 KiB to 0.95 KiB (13.94 -> 11.25 uncompressed). The hash module by itself drops from 0.38 KiB to 0.25 KiB (4.15 -> 1.46 uncompressed).

Previously we were using a version that converted each charcode to UTF-8, but there's no reason to do that other than compatibility with other more-common UTF-8 based implementations, which isn't a requirement.

First render of 100 templates:

![image](https://user-images.githubusercontent.com/48894/101659649-28dbcc80-39fb-11eb-95c1-629d80ea02d4.png)

Also two additional changes that further drop `lit-localize.js` to 0.94 KiB (10.98 uncompressed):

- Omit the `a` version prefix from IDs. The `h` and `s` can effectively already serve as a version indicator, because if we did a V2, we could just switch to different characters, or add a prefix. This also removes a byte from each generated ID.
- Use `\x1e` instead of `String.fromCharCode(30)` to generate the record delimiter code.