### PR TITLE
Change nothing and noChange to global Symbols

### DIFF
--- a/packages/lit-html/src/directives/live.ts
+++ b/packages/lit-html/src/directives/live.ts
@@ -45,7 +45,7 @@ class LiveDirective extends Directive {
   }
 
   update(part: AttributePart, [value]: Parameters<this['render']>) {
-    if (value === noChange) {
+    if (value === noChange || value === nothing) {
       return value;
     }
     const element = part.element;
@@ -60,9 +60,7 @@ class LiveDirective extends Directive {
         return noChange;
       }
     } else if (part.type === BOOLEAN_ATTRIBUTE_PART) {
-      if (
-        (value === nothing ? false : !!value) === element.hasAttribute(name)
-      ) {
+      if (!!value === element.hasAttribute(name)) {
         return noChange;
       }
     } else if (part.type === ATTRIBUTE_PART) {

--- a/packages/lit-html/src/directives/unsafe-html.ts
+++ b/packages/lit-html/src/directives/unsafe-html.ts
@@ -42,7 +42,7 @@ export class UnsafeHTML extends Directive {
     }
   }
 
-  render(value: string) {
+  render(value: string | typeof nothing | typeof noChange) {
     // TODO: add tests for nothing and noChange
     if (value === nothing) {
       this.templateResult = undefined;

--- a/packages/lit-html/src/lit-html.ts
+++ b/packages/lit-html/src/lit-html.ts
@@ -1232,28 +1232,30 @@ export class AttributePart {
    * @param value The part value, or an array of values for multi-valued parts
    * @param valueIndex the index to start reading values from. `undefined` for
    *   single-valued parts
-   * @param commitValue An optional method to override the _commitValue call;
-   *   is used in hydration to no-op re-setting serialized attributes, and in
-   *   to no-op the DOM operation and capture the value for serialization
+   * @param noCommit causes the part to not commit its value to the DOM. Used
+   *   in hydration to prime attribute parts with their first-rendered value,
+   *   but not set the attribute, and in SSR to no-op the DOM operation and
+   *   capture the value for serialization.
+   *
    * @internal
    */
   _$setValue(
     value: unknown | Array<unknown>,
     directiveParent: DirectiveParent = this,
-    valueIndex?: number) {
+    valueIndex?: number,
+    noCommit?: boolean
+  ) {
     const strings = this.strings;
 
     // Whether any of the values has changed, for dirty-checking
     let change = false;
 
-    // Whether any of the values is the `nothing` sentinel. If any are, we
-    // remove the entire attribute.
-    // let remove = false;
-
     if (strings === undefined) {
       // Single-value binding case
       value = resolveDirective(this, value, directiveParent, 0);
-      if (change = ((!isPrimitive(value) || value !== this._$value) && value !== noChange)) {
+      change =
+        !isPrimitive(value) || (value !== this._$value && value !== noChange);
+      if (change) {
         this._$value = value;
       }
     } else {
@@ -1263,30 +1265,24 @@ export class AttributePart {
 
       let i, v;
       for (i = 0; i < strings.length - 1; i++) {
-        v = resolveDirective(
-          this,
-          values[valueIndex! + i],
-          directiveParent,
-          i
-        );
+        v = resolveDirective(this, values[valueIndex! + i], directiveParent, i);
 
         if (v === noChange) {
           // If the user-provided value is `noChange`, use the previous value
           v = (this._$value as Array<unknown>)[i];
         }
-        if (v === nothing || value === nothing) {
-          change = true;
+        change ||= !isPrimitive(v) || v !== (this._$value as Array<unknown>)[i];
+        if (v === nothing) {
           value = nothing;
-        } else {
-          change ||= !isPrimitive(v) || v !== (this._$value as Array<unknown>)[i];
+        } else if (value !== nothing) {
           value += (v ?? '') + strings[i + 1];
         }
         // We always record each value, even if one is `nothing`, for future
-        // change detection
+        // change detection.
         (this._$value as Array<unknown>)[i] = v;
       }
     }
-    if (change) {
+    if (change && !noCommit) {
       this._commitValue(value);
     }
   }

--- a/packages/lit-html/src/platform-support.ts
+++ b/packages/lit-html/src/platform-support.ts
@@ -152,9 +152,9 @@ const scopeCssStore: Map<string, string[]> = new Map();
         }
         const scopeCss = cssForScope(scope);
         // Remove styles and store textContent.
-        const styles = template.content.querySelectorAll('style') as NodeListOf<
-          HTMLStyleElement
-        >;
+        const styles = template.content.querySelectorAll(
+          'style'
+        ) as NodeListOf<HTMLStyleElement>;
         // Store the css in this template in the scope css and remove the <style>
         // from the template _before_ the node-walk captures part indices
         scopeCss.push(

--- a/packages/lit-html/src/test/lit-html_test.ts
+++ b/packages/lit-html/src/test/lit-html_test.ts
@@ -773,16 +773,16 @@ suite('lit-html', () => {
     test.skip('renders a Symbol to an attribute', () => {
       render(html`<div foo=${Symbol('A')}></div>`, container);
       assert.include(
-        container.querySelector('div')!.getAttribute('foo')!.toLowerCase(),
-        'symbol'
+        container.querySelector('div')!.getAttribute('foo'),
+        ''
       );
     });
 
     test.skip('renders a Symbol in an array to an attribute', () => {
       render(html`<div foo=${[Symbol('A')] as any}></div>`, container);
       assert.include(
-        container.querySelector('div')!.getAttribute('foo')!.toLowerCase(),
-        'symbol'
+        container.querySelector('div')!.getAttribute('foo')!,
+        ''
       );
     });
 

--- a/packages/lit-ssr/src/test/lit/render-lit_test.ts
+++ b/packages/lit-ssr/src/test/lit/render-lit_test.ts
@@ -259,8 +259,8 @@ test('repeat directive with a string', async (t: Test) => {
       'qux' +
       '<!--/lit-part-->' +
       '<!--/lit-part-->' +
-      '<?>' +             // endNode for template instance since it had no
-                          // static end node
+      '<?>' + // endNode for template instance since it had no
+      // static end node
       '<!--/lit-part-->'
   );
 });


### PR DESCRIPTION
This makes the `nothing` and `noChange` sentinels work across multiple instances of the core library.