### PR TITLE
Small documentation cleanups

### DIFF
--- a/packages/benchmarks/lit-html/kitchen-sink/index.ts
+++ b/packages/benchmarks/lit-html/kitchen-sink/index.ts
@@ -76,7 +76,7 @@ interface Data {
  * models for the given width & depth.
  *
  * @param updateId Increment to ensure new data models for the given id
- *   create unique (non-dirty checking) values
+ *     create unique (non-dirty checking) values
  * @param id Id for item, unique amongst its peers
  * @param parent Parent moniker (to create unique text for each item)
  * @param currentDepth Current depth, used to stop recursion at REPEAT_DEPTH.

--- a/packages/lit-html/src/directives/class-map.ts
+++ b/packages/lit-html/src/directives/class-map.ts
@@ -110,6 +110,6 @@ class ClassMap extends Directive {
  * For example `{foo: bar}` applies the class `foo` if the value of `bar` is
  * truthy.
  *
- * @param classInfo {ClassInfo}
+ * @param classInfo
  */
 export const classMap = directive(ClassMap);

--- a/packages/lit-html/src/directives/style-map.ts
+++ b/packages/lit-html/src/directives/style-map.ts
@@ -124,6 +124,6 @@ class StyleMap extends Directive {
  * For example `styleMap({backgroundColor: 'red', 'border-top': '5px', '--size':
  * '0'})` sets the `background-color`, `border-top` and `--size` properties.
  *
- * @param styleInfo {StyleInfo}
+ * @param styleInfo
  */
 export const styleMap = directive(StyleMap);

--- a/packages/lit-html/src/disconnectable-directive.ts
+++ b/packages/lit-html/src/disconnectable-directive.ts
@@ -141,7 +141,7 @@ export {directive} from './lit-html.js';
  * the connected state of directives and run `disconnectedCallback`/
  * `reconnectedCallback`s.
  *
- * @returns True if there were children to disconnect; false otherwise
+ * @return True if there were children to disconnect; false otherwise
  */
 const setChildrenConnected = (
   parent: Disconnectable,
@@ -296,7 +296,7 @@ export abstract class DisconnectableDirective extends Directive {
    *
    * @param isConnected
    * @param isClearingDirective - True when the directive itself is being
-   *   removed; false when the tree is being disconnected
+   *     removed; false when the tree is being disconnected
    * @internal
    */
   _$setDirectiveConnected(isConnected: boolean, isClearingDirective = true) {

--- a/packages/lit-html/src/lit-html.ts
+++ b/packages/lit-html/src/lit-html.ts
@@ -33,12 +33,12 @@ if (DEV_MODE) {
  * for this technique (https://github.com/WICG/trusted-types).
  *
  * @param node The HTML node (usually either a #text node or an Element) that
- *   is being written to. Note that this is just an exemplar node, the write
- *   may take place against another instance of the same class of node.
+ *     is being written to. Note that this is just an exemplar node, the write
+ *     may take place against another instance of the same class of node.
  * @param name The name of an attribute or property (for example, 'href').
  * @param type Indicates whether the write that's about to be performed will
- *   be to a property or a node.
- * @returns A function that will sanitize this class of writes.
+ *     be to a property or a node.
+ * @return A function that will sanitize this class of writes.
  */
 export type SanitizerFactory = (
   node: Node,
@@ -53,9 +53,9 @@ export type SanitizerFactory = (
  * See SanitizerFactory.
  *
  * @param value The value to sanitize. Will be the actual value passed into
- *   the lit-html template literal, so this could be of any type.
- * @returns The value to write to the DOM. Usually the same as the input value,
- *   unless sanitization is needed.
+ *     the lit-html template literal, so this could be of any type.
+ * @return The value to write to the DOM. Usually the same as the input value,
+ *     unless sanitization is needed.
  */
 export type ValueSanitizer = (value: unknown) => unknown;
 
@@ -461,8 +461,8 @@ export abstract class Directive {
  * @param strings template strings array
  * @param type HTML or SVG
  * @return Array containing `[html, attrNames]` (array returned for terseness,
- *   to avoid object fields since this code is shared with non-minified SSR
- *   code)
+ *     to avoid object fields since this code is shared with non-minified SSR
+ *     code)
  */
 const getTemplateHtml = (
   strings: TemplateStringsArray,
@@ -1141,10 +1141,10 @@ export class NodePart {
    * Removes the nodes contained within this Part from the DOM.
    *
    * @param start Start node to clear from, for clearing a subset of the part's
-   *  DOM (used when truncating iterables)
+   *     DOM (used when truncating iterables)
    * @param from  When `start` is specified, the index within the iterable from
-   *  which NodeParts are being removed, used for disconnecting directives in
-   *  those Parts.
+   *     which NodeParts are being removed, used for disconnecting directives in
+   *     those Parts.
    */
   private _clear(
     start: ChildNode | null = this._$startNode.nextSibling,
@@ -1231,10 +1231,10 @@ export class AttributePart {
    *
    * @param value The part value, or an array of values for multi-valued parts
    * @param valueIndex the index to start reading values from. `undefined` for
-   *   single-valued parts
+   *     single-valued parts
    * @param commitValue An optional method to override the _commitValue call;
-   *   is used in hydration to no-op re-setting serialized attributes, and in
-   *   to no-op the DOM operation and capture the value for serialization
+   *     is used in hydration to no-op re-setting serialized attributes, and in
+   *     to no-op the DOM operation and capture the value for serialization
    * @internal
    */
   _$setValue(

--- a/packages/lit-html/src/parts.ts
+++ b/packages/lit-html/src/parts.ts
@@ -73,7 +73,8 @@ export const detachNodePart = (part: NodePart): NodePartState => {
  * previously committed value.
  *
  * @param part The NodePart to restore
- * @param state The state restore, returned from a prior call to `detachNodePart`
+ * @param state The state restore, returned from a prior call to
+ *     `detachNodePart`
  */
 export const restoreNodePart = (part: NodePart, state: NodePartState) => {
   ((part as unknown) as NodePartInternal)._commitNode(
@@ -92,7 +93,7 @@ const createMarker = () => document.createComment('');
  *
  * @param containerPart Part within which to add the new NodePart
  * @param refPart Part before which to add the new NodePart; when omitted the
- *  part added to the end of the `containerPart`
+ *     part added to the end of the `containerPart`
  */
 export const createAndInsertPart = (
   containerPart: NodePart,
@@ -187,7 +188,7 @@ export const getPartValue = (part: NodePart) => part._$value;
  * @param containerPart Part within which to insert the NodePart
  * @param part Part to insert
  * @param refPart Part before which to add the new NodePart; when omitted the
- *  part added to the end of the `containerPart`
+ *     part added to the end of the `containerPart`
  */
 export const insertPartBefore = (
   containerPart: NodePart,

--- a/packages/localize/src/tests/e2e-goldens-test.ts
+++ b/packages/localize/src/tests/e2e-goldens-test.ts
@@ -35,12 +35,13 @@ import {formatDirDiff} from './format-dir-diff';
  * update the goldens/ directory to match output/, and fail the test to prevent
  * accidentally having this setting on.
  *
- * @param {name} Name of a sub-directory in "<repo root>/testdata/". Must
- * contain input/ and goldens/ sub-directories.
- * @param {args} Command line arguments to lit-localize (not including the node
- * binary and script name). Note that we chdir to the output/ directory before
- * running the command, so relative paths in arguments can be used here.
- * @param {expectedExitCode} The expected process exit code.
+ * @param name Name of a sub-directory in "<repo root>/testdata/". Must
+ *     contain input/ and goldens/ sub-directories.
+ * @param args Command line arguments to lit-localize (not including the node
+ *     binary and script name). Note that we chdir to the output/ directory
+ *     before running the command, so relative paths in arguments can be used
+ *     here.
+ * @param expectedExitCode The expected process exit code.
  */
 export function e2eGoldensTest(
   name: string,

--- a/packages/updating-element/src/css-tag.ts
+++ b/packages/updating-element/src/css-tag.ts
@@ -110,7 +110,7 @@ export const css = (
 
 /**
  * Applies the given styles to a `shadowRoot`. When Shadow DOM is
- * available but `adoptedStyleSheets` is not, styles are appended to the the
+ * available but `adoptedStyleSheets` is not, styles are appended to the
  * `shadowRoot` to [mimic spec behavior](https://wicg.github.io/construct-stylesheets/#using-constructed-stylesheets).
  * Note, when shimming is used, any styles that are subsequently placed into
  * the shadowRoot should be placed *before* any shimmed adopted styles. This

--- a/packages/updating-element/src/decorators/query.ts
+++ b/packages/updating-element/src/decorators/query.ts
@@ -32,7 +32,7 @@ import {
  *
  * @param selector A DOMString containing one or more selectors to match.
  * @param cache An optional boolean which when true performs the DOM query only
- * once and caches the result.
+ *     once and caches the result.
  *
  * See: https://developer.mozilla.org/en-US/docs/Web/API/Document/querySelector
  *

--- a/packages/updating-element/src/decorators/queryAssignedNodes.ts
+++ b/packages/updating-element/src/decorators/queryAssignedNodes.ts
@@ -40,10 +40,10 @@ const legacyMatches =
  *
  * @param slotName A string name of the slot.
  * @param flatten A boolean which when true flattens the assigned nodes,
- * meaning any assigned nodes that are slot elements are replaced with their
- * assigned nodes.
+ *     meaning any assigned nodes that are slot elements are replaced with their
+ *     assigned nodes.
  * @param selector A string which filters the results to elements that match
- * the given css selector.
+ *     the given css selector.
  *
  * * @example
  * ```ts

--- a/packages/updating-element/src/updating-element.ts
+++ b/packages/updating-element/src/updating-element.ts
@@ -661,7 +661,8 @@ export abstract class UpdatingElement extends HTMLElement {
    * creates and returns an open shadowRoot. Implement to customize where the
    * element's DOM is rendered. For example, to render into the element's
    * childNodes, return `this`.
-   * @returns {Element|DocumentFragment} Returns a node into which to render.
+   *
+   * @return Returns a node into which to render.
    */
   protected createRenderRoot(): Element | ShadowRoot {
     const renderRoot =
@@ -809,10 +810,10 @@ export abstract class UpdatingElement extends HTMLElement {
    * property `name` and `oldValue` to ensure that any configured property
    * options are honored.
    *
-   * @param name {PropertyKey} (optional) name of requesting property
-   * @param oldValue {any} (optional) old value of requesting property
-   * @param options {PropertyDeclaration} (optional) property options to use
-   * instead of the previously configured options
+   * @param name name of requesting property
+   * @param oldValue old value of requesting property
+   * @param options property options to use instead of the previously
+   *     configured options
    */
   requestUpdate(
     name?: PropertyKey,
@@ -1011,8 +1012,8 @@ export abstract class UpdatingElement extends HTMLElement {
    * before fulfilling this Promise. To do this, first await
    * `super.getUpdateComplete()`, then any subsequent state.
    *
-   * @returns {Promise} The Promise returns a boolean that indicates if the
-   * update resolved without triggering another update.
+   * @return A promise of a boolean that indicates if the update resolved
+   *     without triggering another update.
    */
   get updateComplete() {
     return this.getUpdateComplete();


### PR DESCRIPTION
Fixed a few typos, like
the the -> the
@returns -> @return

Dropped types from jsdoc, as they're now in TypeScript.

Reflowed a few comments in @param and @return for consistency.