### PR TITLE
Bump template-shadowroot package

### DIFF
--- a/packages/lit-ssr/package-lock.json
+++ b/packages/lit-ssr/package-lock.json
@@ -6278,7 +6278,7 @@
       }
     },
     "template-shadowroot": {
-      "version": "github:webcomponents/template-shadowroot#8086dd2c87ce0ed57ffd77504a06788de43e2f41",
+      "version": "github:webcomponents/template-shadowroot#b2598238404cbe42022ec6151283ae13efdd09bb",
       "from": "github:webcomponents/template-shadowroot#npm-support"
     },
     "terser": {


### PR DESCRIPTION
This package-lock update comes up on `npm run bootstrap`