### PR TITLE
[lit-next] Use __ for class properties and add mangling prefix

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,15 +67,15 @@ shared between different versions of the libraries on the same page.
 
 When submitting code, please take care to follow the conventions below:
 
-1. _`_`prefix for private properties_ - Most`private`-annotated fields should
+1. **`_` prefix for private properties** - Most`private`-annotated fields should
    be prefixed prefixed with a single underscore, and will be minified
    ("mangled" by Terser) to a randomly-assigned short property name. See the
    following two cases for exceptions.
-2. _`_$` prefix for private properties on objects shared between versions_ - Any
+2. **`_$` prefix for private properties on objects shared between versions** - Any
    private property that is considered "private" to the library but could be
    accessed by a different version of the library running on the same page
    should be prefixed with `_$`**and** added to the list of`stableProperties` in [`rollup-common.js`](./rollup-common.js). These properties are assigned a stable minified symbol that will not change between releases. These properties are often marked with the `// @internal`annotation when it is not possible to mark them as`private` for type reasons.
-3. \_`__` prefix for fields on exported classes - Any private fields on a class
+3. **`__` prefix for private fields on exported classes** - Any private fields on a class
    intended to be subclassed outside of the package it is defined in should be
    prefixed with a double-underscore. We use the double-underscore convention to
    automatically assign a unicode character prefix to the randomly-assigned

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,7 +56,31 @@ We stick to subset of TypeScript that is more strict and closer to standard Java
        1. `namespace`
        2. `enum`
        3. Parameter properties (initialize class fields in the constructor parameter list)
-7.  Prefix private members with `_`. (don't assume clients are using TypeScript)
+
+## Private Property Prefixing
+
+This codebase follows some specific conventions regarding prefixing for private
+properties/fields, which serve several purposes: hiding and/or communicating
+"private" status to non-TypeScript users, allowing code-size optimization via
+object/class property minification, and ensuring compatibility between objects
+shared between different versions of the libraries on the same page.
+
+When submitting code, please take care to follow the conventions below:
+
+1. _`_`prefix for private properties_ - Most`private`-annotated fields should
+   be prefixed prefixed with a single underscore, and will be minified
+   ("mangled" by Terser) to a randomly-assigned short property name. See the
+   following two cases for exceptions.
+2. _`_$` prefix for private properties on objects shared between versions_ - Any
+   private property that is considered "private" to the library but could be
+   accessed by a different version of the library running on the same page
+   should be prefixed with `_$`**and** added to the list of`stableProperties` in [`rollup-common.js`](./rollup-common.js). These properties are assigned a stable minified symbol that will not change between releases. These properties are often marked with the `// @internal`annotation when it is not possible to mark them as`private` for type reasons.
+3. \_`__` prefix for fields on exported classes - Any private fields on a class
+   intended to be subclassed outside of the package it is defined in should be
+   prefixed with a double-underscore. We use the double-underscore convention to
+   automatically assign a unicode character prefix to the randomly-assigned
+   short property name chosen by Terser to namespace private class fields by
+   package, to avoid collisions.
 
 ## Contributor License Agreement
 

--- a/packages/labs/rollup.config.js
+++ b/packages/labs/rollup.config.js
@@ -15,6 +15,7 @@
 import {litProdConfig} from '../../rollup-common.js';
 
 export default litProdConfig({
+  classPropertyPrefix: 'Ω',
   entryPoints: ['index', 'frameworks/react/create-component'],
   external: ['reactive-element', 'lit-html', 'lit-element'],
 });

--- a/packages/lit-element/rollup.config.js
+++ b/packages/lit-element/rollup.config.js
@@ -15,6 +15,7 @@
 import {litProdConfig} from '../../rollup-common.js';
 
 export default litProdConfig({
+  classPropertyPrefix: 'Φ',
   entryPoints: [
     'lit-element',
     'hydrate-support',

--- a/packages/lit-element/src/lit-element.ts
+++ b/packages/lit-element/src/lit-element.ts
@@ -98,7 +98,7 @@ export class LitElement extends ReactiveElement {
 
   readonly _$renderOptions: RenderOptions = {host: this};
 
-  private _$childPart: ChildPart | undefined = undefined;
+  private __childPart: ChildPart | undefined = undefined;
 
   protected createRenderRoot() {
     const renderRoot = super.createRenderRoot();
@@ -123,7 +123,7 @@ export class LitElement extends ReactiveElement {
     // before that.
     const value = this.render();
     super.update(changedProperties);
-    this._$childPart = render(value, this.renderRoot, this._$renderOptions);
+    this.__childPart = render(value, this.renderRoot, this._$renderOptions);
   }
 
   // TODO(kschaaf): Consider debouncing directive disconnection so element moves
@@ -131,12 +131,12 @@ export class LitElement extends ReactiveElement {
   // https://github.com/Polymer/lit-html/issues/1457
   connectedCallback() {
     super.connectedCallback();
-    this._$childPart?.setConnected(true);
+    this.__childPart?.setConnected(true);
   }
 
   disconnectedCallback() {
     super.disconnectedCallback();
-    this._$childPart?.setConnected(false);
+    this.__childPart?.setConnected(false);
   }
 
   /**

--- a/packages/lit-html/rollup.config.js
+++ b/packages/lit-html/rollup.config.js
@@ -15,6 +15,7 @@
 import {litProdConfig} from '../../rollup-common.js';
 
 export default litProdConfig({
+  classPropertyPrefix: 'Σ',
   entryPoints: [
     'directives/cache',
     'directives/class-map',

--- a/packages/lit-html/src/directive.ts
+++ b/packages/lit-html/src/directive.ts
@@ -108,11 +108,11 @@ export const directive = <C extends DirectiveClass>(c: C) => (
  */
 export abstract class Directive {
   //@internal
-  _part: ChildPart | AttributePart | ElementPart;
+  __part: ChildPart | AttributePart | ElementPart;
   //@internal
-  _attributeIndex: number | undefined;
+  __attributeIndex: number | undefined;
   //@internal
-  _directive?: Directive;
+  __directive?: Directive;
 
   //@internal
   _$parent: Disconnectable;
@@ -125,17 +125,17 @@ export abstract class Directive {
 
   constructor(partInfo: PartInfo) {
     this._$parent = partInfo._$parent;
-    this._part = partInfo._$part;
-    this._attributeIndex = partInfo._$attributeIndex;
+    this.__part = partInfo._$part;
+    this.__attributeIndex = partInfo._$attributeIndex;
   }
   /** @internal */
   _resolve(props: Array<unknown>): unknown {
-    const {_part, _attributeIndex} = this;
+    const {__part, __attributeIndex} = this;
     return resolveDirective(
-      _part,
-      this.update(_part, props),
+      __part,
+      this.update(__part, props),
       this,
-      _attributeIndex
+      __attributeIndex
     );
   }
   abstract render(...props: Array<unknown>): unknown;

--- a/packages/lit-html/src/disconnectable-directive.ts
+++ b/packages/lit-html/src/disconnectable-directive.ts
@@ -359,7 +359,7 @@ export abstract class DisconnectableDirective extends Directive {
    */
   setValue(value: unknown) {
     if (this.isConnected) {
-      setPartValue(this._part, value, this._attributeIndex, this);
+      setPartValue(this.__part, value, this.__attributeIndex, this);
     } else {
       this._pendingValue = value;
     }

--- a/packages/lit-html/src/lit-html.ts
+++ b/packages/lit-html/src/lit-html.ts
@@ -346,8 +346,8 @@ let sanitizerFactoryInternal: SanitizerFactory = noopSanitizer;
 // `resolveDirective`
 export interface DirectiveParent {
   _$parent?: DirectiveParent;
-  _directive?: Directive;
-  _directives?: Array<Directive | undefined>;
+  __directive?: Directive;
+  __directives?: Array<Directive | undefined>;
 }
 
 /**
@@ -659,8 +659,8 @@ function resolveDirective(
 ): unknown {
   let currentDirective =
     _$attributeIndex !== undefined
-      ? (_$parent as AttributePart)._directives?.[_$attributeIndex]
-      : (_$parent as ChildPart | ElementPart | Directive)._directive;
+      ? (_$parent as AttributePart).__directives?.[_$attributeIndex]
+      : (_$parent as ChildPart | ElementPart | Directive).__directive;
   const nextDirectiveConstructor = isPrimitive(value)
     ? undefined
     : (value as DirectiveResult)._$litDirective$;
@@ -676,11 +676,11 @@ function resolveDirective(
             _$attributeIndex,
           } as PartInfo);
     if (_$attributeIndex !== undefined) {
-      ((_$parent as AttributePart)._directives ??= [])[
+      ((_$parent as AttributePart).__directives ??= [])[
         _$attributeIndex
       ] = currentDirective;
     } else {
-      (_$parent as ChildPart | Directive)._directive = currentDirective;
+      (_$parent as ChildPart | Directive).__directive = currentDirective;
     }
   }
   if (currentDirective !== undefined) {
@@ -824,7 +824,7 @@ export class ChildPart {
   readonly options: RenderOptions | undefined;
   _$committedValue: unknown;
   /** @internal */
-  _directive?: Directive;
+  __directive?: Directive;
   /** @internal */
   _$startNode: ChildNode;
   /** @internal */
@@ -1082,7 +1082,7 @@ export class AttributePart {
   /** @internal */
   _$committedValue: unknown | Array<unknown> = nothing;
   /** @internal */
-  _directives?: Array<Directive | undefined>;
+  __directives?: Array<Directive | undefined>;
   /** @internal */
   _$parent: Disconnectable | undefined;
   /** @internal */
@@ -1327,7 +1327,7 @@ export class ElementPart {
   readonly type = ELEMENT_PART;
 
   /** @internal */
-  _directive?: Directive;
+  __directive?: Directive;
 
   // This is to ensure that every Part has a _$committedValue
   _$committedValue: undefined;

--- a/packages/lit-ssr/src/lib/render-lit-html.ts
+++ b/packages/lit-ssr/src/lib/render-lit-html.ts
@@ -71,12 +71,12 @@ declare module 'parse5' {
 patchDirectiveResolve(
   Directive.prototype,
   function (this: Directive, values: unknown[]) {
-    const {_part, _attributeIndex} = this;
+    const {__part, __attributeIndex} = this;
     return resolveDirective(
-      _part,
+      __part,
       this.render(...values),
       this,
-      _attributeIndex
+      __attributeIndex
     );
   }
 );

--- a/packages/reactive-element/rollup.config.js
+++ b/packages/reactive-element/rollup.config.js
@@ -15,6 +15,7 @@
 import {litProdConfig} from '../../rollup-common.js';
 
 export default litProdConfig({
+  classPropertyPrefix: 'Π',
   entryPoints: [
     'reactive-element',
     'css-tag',

--- a/rollup-common.js
+++ b/rollup-common.js
@@ -145,6 +145,10 @@ const prefixClassProperties = (context, nameCache, prefix) => {
       props: {props},
     } = nameCache;
     for (const p in props) {
+      // Note all properties in the terser name cache are prefixed with '$'
+      // (presumably to avoid collisions with built-ins). Checking for the
+      // prefix is just to ensure we don't double-prefix properties if
+      // `prefixClassProperties` is called twice on the same `nameCache`.
       if (p.startsWith('$__') && !props[p].startsWith(prefix)) {
         props[p] = prefix + props[p];
       }


### PR DESCRIPTION
We determined that our exported classes intended for user subclassing are susceptible to mangling collision if the user subclass is subsequently mangled using similar settings. This occurred in practice between our `LitElement` and `ReactiveElement` classes, but could theoretically occur with in-the-wild subclasses.

As such, this PR introduces a new convention where fields on user-subclassable base classes use a double-underscore `__` prefix. We then modify the seeded nameCache to prefix the chosen mangled name for these with a unique unicode prefix per package, which should ensure we get the benefit of minifying private class fields while minimizing the risk of collision.