### PR TITLE
[lit-html] Fix cache() directive

### DIFF
--- a/packages/lit-html/src/directives/cache.ts
+++ b/packages/lit-html/src/directives/cache.ts
@@ -57,12 +57,12 @@ export const cache = directive(
     }
 
     update(containerPart: ChildPart, [v]: DirectiveParameters<this>) {
-      // If the new value is not a TemplateResult from the same Template as the
-      // previous value, move the nodes from the DOM into the cache.
+      // If the previous value is a TemplateResult and the new value is not,
+      // or is a different Template as the previous value, move the child part
+      // from into the cache.
       if (
-        this.value !== undefined &&
-        this.value.strings !== (v as TemplateResult).strings
-      ) {
+        isTemplateResult(this.value) && 
+        (!isTemplateResult(v) || this.value.strings !== v.strings)) {
         // This is always an array because we return [v] in render()
         const partValue = getComittedValue(containerPart) as Array<ChildPart>;
         const childPart = partValue.pop()!;
@@ -70,15 +70,18 @@ export const cache = directive(
         if (cachedContainerPart === undefined) {
           const fragment = new DocumentFragment();
           cachedContainerPart = render(nothing, fragment);
-          setComittedValue(cachedContainerPart, [childPart]);
           this.templateCache.set(this.value.strings, cachedContainerPart);
         }
         // Move into cache
-        insertPart(containerPart, undefined, childPart);
+        setComittedValue(cachedContainerPart, [childPart]);
+        insertPart(cachedContainerPart, undefined, childPart);
         clearPart(containerPart);
       }
-      // If the new value is a TemplateResult, try to restore it from cache
-      if (isTemplateResult(v)) {
+      // If the new value is a TemplateResult and the previous value is not,
+      // or is a different Template as the previous value, restore the child
+      // part from the cache.
+      if (isTemplateResult(v) && 
+          (!isTemplateResult(this.value) || this.value.strings !== v.strings)) {
         const cachedContainerPart = this.templateCache.get(v.strings);
         if (cachedContainerPart !== undefined) {
           // Move the cached part back into the container part value
@@ -86,9 +89,10 @@ export const cache = directive(
             cachedContainerPart
           ) as Array<ChildPart>;
           const cachedPart = partValue.pop()!;
-          setComittedValue(containerPart, cachedPart);
           // Move cached part back into DOM
+          clearPart(containerPart);
           insertPart(containerPart, undefined, cachedPart);
+          setComittedValue(containerPart, [cachedPart]);
         }
         this.value = v;
       } else {

--- a/packages/lit-html/src/directives/cache.ts
+++ b/packages/lit-html/src/directives/cache.ts
@@ -59,7 +59,7 @@ export const cache = directive(
     update(containerPart: ChildPart, [v]: DirectiveParameters<this>) {
       // If the previous value is a TemplateResult and the new value is not,
       // or is a different Template as the previous value, move the child part
-      // from into the cache.
+      // into the cache.
       if (
         isTemplateResult(this.value) && 
         (!isTemplateResult(v) || this.value.strings !== v.strings)) {
@@ -75,7 +75,6 @@ export const cache = directive(
         // Move into cache
         setComittedValue(cachedContainerPart, [childPart]);
         insertPart(cachedContainerPart, undefined, childPart);
-        clearPart(containerPart);
       }
       // If the new value is a TemplateResult and the previous value is not,
       // or is a different Template as the previous value, restore the child

--- a/packages/lit-html/src/test/directives/cache_test.ts
+++ b/packages/lit-html/src/test/directives/cache_test.ts
@@ -97,7 +97,7 @@ suite('cache directive', () => {
     assert.equal(stripExpressionComments(container.innerHTML), 'D');
   });
 
-  test.only('cache can be dynamic', () => {
+  test('cache can be dynamic', () => {
     const renderMaybeCached = (condition: any, v: string) =>
       render(
         html`${condition ? cache(html`<div v=${v}></div>`) : v}`,


### PR DESCRIPTION
The cache tests has a wayward `test.only` in them, hiding some failures. The directive wasn't clearing the container part at the right times, and was setting the container part's value wrong when restoring from cache. The fix should read a bit better now.