### PR TITLE
[lit-next] Use setTimeout(..., 0) to get past microtasks in tests

### DIFF
--- a/packages/reactive-element/src/test/reactive-element_test.ts
+++ b/packages/reactive-element/src/test/reactive-element_test.ts
@@ -2204,7 +2204,7 @@ suite('ReactiveElement', () => {
               setTimeout(() => {
                 this.promiseFulfilled = true;
                 resolve(true);
-              }, 1);
+              }, 0);
             }))
           );
         })();
@@ -2234,7 +2234,7 @@ suite('ReactiveElement', () => {
               setTimeout(() => {
                 this.promiseFulfilled = true;
                 resolve(true);
-              }, 1)
+              }, 0)
             )
         );
       }
@@ -2324,7 +2324,7 @@ suite('ReactiveElement', () => {
     assert.isFalse(a.updateCalled);
 
     // update is not called after a small amount of time
-    await new Promise((r) => setTimeout(r, 10));
+    await new Promise((r) => setTimeout(r, 0));
     assert.isFalse(a.updateCalled);
 
     // update is called after performUpdate allowed to complete
@@ -2384,7 +2384,7 @@ suite('ReactiveElement', () => {
     }
     customElements.define(generateElementName(), A);
     const a = new A();
-    await new Promise((r) => setTimeout(r, 20));
+    await new Promise((r) => setTimeout(r, 0));
     assert.equal(a.updatedCalledCount, 0);
     container.appendChild(a);
     await a.updateComplete;
@@ -2406,7 +2406,7 @@ suite('ReactiveElement', () => {
       updated = true;
       assert.isTrue(a.didUpdate);
     });
-    await new Promise((r) => setTimeout(r, 20));
+    await new Promise((r) => setTimeout(r, 0));
     assert.isFalse(updated);
     container.appendChild(a);
     await a.updateComplete;


### PR DESCRIPTION
Use `setTimeout(..., 0)` (rather than larger timeout values) to get past microtasks, in attempt to avoid throttling-based test timeouts

Hoping to avoid failures like this
```
../reactive-element/development/test/platform-support/reactive-element-sd-ce_test.html:

 ❌ ReactiveElement > update does not occur before element is connected (failed on Windows 10 Chrome latest-3)
      at: ../http:/10.1.0.4:9689/tests/node_modules/@web/test-runner-mocha/dist/standalone.js:1:225756
      Error: Timeout of 2000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves.
        at Hg.pd._timeoutError (../http:/10.1.0.4:9689/tests/node_modules/@web/test-runner-mocha/dist/standalone.js:1:225756)
        at a (../http:/10.1.0.4:9689/tests/node_modules/@web/test-runner-mocha/dist/standalone.js:1:224260)
        at ../http:/10.1.0.4:9689/tests/node_modules/@web/test-runner-mocha/dist/standalone.js:1:225218
```

Under the theory that code like this is being throttled beyond the wall-clock test timeout, leading to failures:
```js
    await new Promise((r) => setTimeout(r, 20));
```