### PR TITLE
Controller and DisconnectableDirective API changes

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -79,5 +79,6 @@ packages/reactive-element/css-tag.*
 packages/reactive-element/decorators.*
 packages/reactive-element/platform-support.*
 packages/reactive-element/reactive-element.*
+packages/reactive-element/controller.*
 
 packages/localize/testdata/

--- a/.eslintignore
+++ b/.eslintignore
@@ -79,6 +79,6 @@ packages/reactive-element/css-tag.*
 packages/reactive-element/decorators.*
 packages/reactive-element/platform-support.*
 packages/reactive-element/reactive-element.*
-packages/reactive-element/controller.*
+packages/reactive-element/reactive-controller.*
 
 packages/localize/testdata/

--- a/.prettierignore
+++ b/.prettierignore
@@ -79,6 +79,7 @@ packages/reactive-element/css-tag.*
 packages/reactive-element/decorators.*
 packages/reactive-element/platform-support.*
 packages/reactive-element/reactive-element.*
+packages/reactive-element/controller.*
 
 packages/localize/examples/
 packages/localize/testdata/

--- a/.prettierignore
+++ b/.prettierignore
@@ -79,7 +79,7 @@ packages/reactive-element/css-tag.*
 packages/reactive-element/decorators.*
 packages/reactive-element/platform-support.*
 packages/reactive-element/reactive-element.*
-packages/reactive-element/controller.*
+packages/reactive-element/reactive-controller.*
 
 packages/localize/examples/
 packages/localize/testdata/

--- a/packages/benchmarks/reactive-element/list/index.ts
+++ b/packages/benchmarks/reactive-element/list/index.ts
@@ -16,7 +16,7 @@ import {
   PropertyDeclaration,
   PropertyValues,
   css,
-  Controller,
+  ReactiveController,
 } from '@lit/reactive-element';
 import {property} from '@lit/reactive-element/decorators.js';
 import {queryParams} from '../../utils/query-params.js';
@@ -65,7 +65,7 @@ import {queryParams} from '../../utils/query-params.js';
 
   const useController = queryParams.controller;
 
-  class MyController implements Controller {
+  class MyController implements ReactiveController {
     host: ReactiveElement;
     isConnected = false;
     value = '';

--- a/packages/lit-element/src/test/lit-element_test.ts
+++ b/packages/lit-element/src/test/lit-element_test.ts
@@ -356,10 +356,10 @@ import {createRef, ref} from 'lit-html/directives/ref.js';
           log.push(`render-${id}`);
           return (this.id = id);
         }
-        disconnectedCallback() {
+        disconnected() {
           log.push(`disconnect-${this.id}`);
         }
-        reconnectedCallback() {
+        reconnected() {
           log.push(`reconnect-${this.id}`);
         }
       }

--- a/packages/lit-html/CHANGELOG.md
+++ b/packages/lit-html/CHANGELOG.md
@@ -19,6 +19,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 <!-- ## [X.Y.Z] - YYYY-MM-DD -->
 
+## Unreleased
+
+#### Changed
+
+- (Since 2.0.0-pre.4) `DisconnectableDirective`'s `disconnectedCallback` and `reconnectedCallback` were renamed to `disconnected` and `reconnected`.
+
 ## [2.0.0-pre.4] - 2020-12-16
 
 ### Added

--- a/packages/lit-html/src/directives/ref.ts
+++ b/packages/lit-html/src/directives/ref.ts
@@ -95,7 +95,7 @@ class RefDirective extends DisconnectableDirective {
       : this._ref?.value;
   }
 
-  disconnectedCallback() {
+  disconnected() {
     // Only clear the box if our element is still the one in it (i.e. another
     // directive instance hasn't rendered its element to it before us); that
     // only happens in the event of the directive being cleared (not via manual
@@ -105,7 +105,7 @@ class RefDirective extends DisconnectableDirective {
     }
   }
 
-  reconnectedCallback() {
+  reconnected() {
     // If we were manually disconnected, we can safely put our element back in
     // the box, since no rendering could have occurred to change its state
     this._updateRefValue(this._element);

--- a/packages/lit-html/src/disconnectable-directive.ts
+++ b/packages/lit-html/src/disconnectable-directive.ts
@@ -15,15 +15,15 @@
 /**
  * Overview:
  *
- * This module is designed to add `disconnectedCallback` support to directives
- * with the least impact on the core runtime or payload when that feature is not
- * used.
+ * This module is designed to add support for a `disconnected` callback to
+ * directives with the least impact on the core runtime or payload when that
+ * feature is not used.
  *
  * The strategy is to introduce a `DisconnectableDirective` subclass of
  * `Directive` that climbs the "parent" tree in its constructor to note which
  * branches of lit-html's "logical tree" of data structures contain such
  * directives and thus need to be crawled when a subtree is being cleared (or
- * manually disconnected) in order to run the `disconnectedCallback`.
+ * manually disconnected) in order to run the `disconnected` callback.
  *
  * The "nodes" of the logical tree include Parts, TemplateInstances (for when a
  * TemplateResult is committed to a value of a ChildPart), and Directives; these
@@ -139,8 +139,8 @@ const DEV_MODE = true;
 
 /**
  * Recursively walks down the tree of Parts/TemplateInstances/Directives to set
- * the connected state of directives and run `disconnectedCallback`/
- * `reconnectedCallback`s.
+ * the connected state of directives and run `disconnected`/ `reconnected`
+ * callbacks.
  *
  * @return True if there were children to disconnect; false otherwise
  */
@@ -190,9 +190,9 @@ const removeDisconnectableFromParent = (obj: Disconnectable) => {
 
 /**
  * Sets the connected state on any directives contained within the committed
- * value of this part (i.e. within a TemplateInstance or iterable of ChildParts)
- * and runs their `disconnectedCallback`/`reconnectedCallback`s, as well as
- * within any directives stored on the ChildPart (when `valueOnly` is false).
+ * value of this part (i.e. within a TemplateInstance or iterable of
+ * ChildParts) and runs their `disconnected`/`reconnected`s, as well as within
+ * any directives stored on the ChildPart (when `valueOnly` is false).
  *
  * `isClearingValue` should be passed as `true` on a top-level part that is
  * clearing itself, and not as a result of recursively disconnecting directives
@@ -251,16 +251,15 @@ const installDisconnectAPI = (obj: Disconnectable) => {
 };
 
 /**
- * An abstract `Directive` base class whose `disconnectedCallback` will be
+ * An abstract `Directive` base class whose `disconnected` method will be
  * called when the part containing the directive is cleared as a result of
  * re-rendering, or when the user calls `part.setDirectiveConnection(false)` on
  * a part that was previously rendered containing the directive.
  *
- * If `part.setDirectiveConnection(true)` is subsequently called on a containing
- * part, the directive's `reconnectedCallback` will be called prior to its next
- * `update`/`render` callbacks. When implementing `disconnectedCallback`,
- * `reconnectedCallback` should also be implemented to be compatible with
- * reconnection.
+ * If `part.setDirectiveConnection(true)` is subsequently called on a
+ * containing part, the directive's `reconnected` method will be called prior
+ * to its next `update`/`render` callbacks. When implementing `disconnected`,
+ * `reconnected` should also be implemented to be compatible with reconnection.
  */
 export abstract class DisconnectableDirective extends Directive {
   isConnected = true;
@@ -308,10 +307,10 @@ export abstract class DisconnectableDirective extends Directive {
     }
   }
   /**
-   * Private method used to set the connection state of the directive and
-   * call the respective `disconnectedCallback` or `reconnectedCallback`
-   * callback. Note that since `isConnected` defaults to true, we do not run
-   * `reconnectedCallback` on first render.
+   * Private method used to set the connection state of the directive and call
+   * the respective `disconnected` or `reconnected` callback. Note thatsince
+   * `isConnected` defaults to true, we do not run `reconnected` on first
+   * render.
    *
    * If a call to `setValue` was made while disconnected, flush it to the part
    * before reconnecting.
@@ -327,16 +326,17 @@ export abstract class DisconnectableDirective extends Directive {
           this.setValue(this._pendingValue);
           this._pendingValue = noChange;
         }
-        this.reconnectedCallback?.();
+        this.reconnected?.();
       } else {
         this.isConnected = false;
-        this.disconnectedCallback?.();
+        this.disconnected?.();
       }
     }
   }
+
   /**
-   * Override of the base `_resolve` method to ensure `reconnectedCallback` is
-   * run prior to the next render.
+   * Override of the base `_resolve` method to ensure `reconnected` is run
+   * prior to the next render.
    *
    * @override
    * @internal
@@ -386,9 +386,9 @@ export abstract class DisconnectableDirective extends Directive {
   /**
    * User callbacks for implementing logic to release any resources/subscriptions
    * that may have been retained by this directive. Since directives may also be
-   * re-connected, `reconnectedCallback` should also be implemented to restore
+   * re-connected, `reconnected` should also be implemented to restore the
    * working state of the directive prior to the next render.
    */
-  protected disconnectedCallback() {}
-  protected reconnectedCallback() {}
+  protected disconnected() {}
+  protected reconnected() {}
 }

--- a/packages/lit-html/src/lit-html.ts
+++ b/packages/lit-html/src/lit-html.ts
@@ -875,9 +875,8 @@ class ChildPartImpl {
 
   /**
    * Sets the connection state for any `DisconnectableDirectives` contained
-   * within this part and runs their `disconnectedCallback` or
-   * `reconnectedCallback`, according to the `isConnected` argument.
-   * @param isConnected
+   * within this part and runs their `disconnected` or `reconnected`, according
+   * to the `isConnected` argument.
    */
   setConnected(isConnected: boolean) {
     this._$setChildPartConnected?.(isConnected);

--- a/packages/lit-html/src/test/lit-html_test.ts
+++ b/packages/lit-html/src/test/lit-html_test.ts
@@ -1778,10 +1778,10 @@ suite('lit-html', () => {
         return bool ? value : nothing;
       }
 
-      disconnectedCallback() {
+      disconnected() {
         this.log.push('disconnected' + (this.id ? `-${this.id}` : ''));
       }
-      reconnectedCallback() {
+      reconnected() {
         this.log.push('reconnected' + (this.id ? `-${this.id}` : ''));
       }
     }

--- a/packages/reactive-element/.gitignore
+++ b/packages/reactive-element/.gitignore
@@ -5,3 +5,4 @@
 /decorators.*
 /platform-support.*
 /reactive-element.*
+/controller.*

--- a/packages/reactive-element/.gitignore
+++ b/packages/reactive-element/.gitignore
@@ -5,4 +5,4 @@
 /decorators.*
 /platform-support.*
 /reactive-element.*
-/controller.*
+/reactive-controller.*

--- a/packages/reactive-element/CHANGELOG.md
+++ b/packages/reactive-element/CHANGELOG.md
@@ -17,6 +17,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 <!-- ### Removed -->
 <!-- ### Fixed -->
 
+## Unreleased
+
+### Changed
+
+- (Since 1.0.0-pre.1) Renamed `Controller`'s `dis/connectedCallback` methods.
+
 ## [1.0.0-pre.1] - 2020-12-16
 
 ### Changed

--- a/packages/reactive-element/CHANGELOG.md
+++ b/packages/reactive-element/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 
 - (Since 1.0.0-pre.1) Renamed `Controller`'s `dis/connectedCallback` methods.
+- (Since 1.0.0-pre.1) Renamed `Controller` to `ReactiveController`.
 
 ## [1.0.0-pre.1] - 2020-12-16
 

--- a/packages/reactive-element/rollup.config.js
+++ b/packages/reactive-element/rollup.config.js
@@ -18,7 +18,7 @@ export default litProdConfig({
   classPropertyPrefix: 'Π',
   entryPoints: [
     'reactive-element',
-    'controller',
+    'reactive-controller',
     'css-tag',
     'decorators',
     'decorators/base',

--- a/packages/reactive-element/rollup.config.js
+++ b/packages/reactive-element/rollup.config.js
@@ -18,6 +18,7 @@ export default litProdConfig({
   classPropertyPrefix: 'Π',
   entryPoints: [
     'reactive-element',
+    'controller',
     'css-tag',
     'decorators',
     'decorators/base',

--- a/packages/reactive-element/src/controller.ts
+++ b/packages/reactive-element/src/controller.ts
@@ -1,0 +1,81 @@
+/**
+ * An object that can host Reactive Controllers and call their lifecycle
+ * callbacks.
+ */
+export interface ControllerHost {
+  /**
+   * Adds a controller to the host, which sets up the controller's lifecycle
+   * methods to be called with the host's lifecycle.
+   */
+  addController(controller: Controller): void;
+
+  /**
+   * Requests a host update which is processed asynchronously. The update can
+   * waited on via the `updateComplete` property.
+   */
+  requestUpdate(): void;
+
+  /**
+   * Returns a Promise that resolves when the host has completed updating.
+   * The Promise value is a boolean that is `true` if the element completed the
+   * update without triggering another update. The Promise result is `false` if
+   * a property was set inside `updated()`. If the Promise is rejected, an
+   * exception was thrown during the update.
+   *
+   * @return A promise of a boolean that indicates if the update resolved
+   *     without triggering another update.
+   */
+  readonly updateComplete: Promise<boolean>;
+}
+
+/**
+ * A Reactive Controller is an object that enables sub-component code
+ * organization and reuse by aggregating the state, behavior, and lifecycle
+ * hooks related to a single feature.
+ *
+ * Controllers are added to a host component, or other object that implements
+ * the `ControllerHost` interface, via the `addController()` method. They can
+ * hook their host components's lifecycle by implementing one or more of the
+ * lifecycle callbacks, or initiate an update of the host component by calling
+ * `requestUpdate()` on the host.
+ */
+export interface Controller {
+  /**
+   * Called when the host is connected to the component tree. For custom
+   * element hosts, this corresponds to the `connectedCallback()` lifecycle,
+   * which is only called when the component is connected to the document.
+   */
+  connected?(): void;
+
+  /**
+   * Called when the host is disconnected from the component tree. For custom
+   * element hosts, this corresponds to the `disconnectedCallback()` lifecycle,
+   * which is called the host or an ancestor component is disconnected from the
+   * document.
+   */
+  disconnected?(): void;
+
+  /**
+   * Called before a client-side host update, or a server-side host render.
+   * This is a good point to compute state that the host may use in it's own
+   * update/render.
+   *
+   * The difference from the `update` callback is that code in `willUpdate`
+   * should not depend on the DOM, as it may be called in server-side rendering
+   * contexts.
+   */
+  willUpdate?(): void;
+
+  /**
+   * Called during the client-side host update.
+   *
+   * Code in `update()` can depend on the DOM as it is not called in
+   * server-side rendering.
+   */
+  update?(): void;
+
+  /**
+   * Called after a host update.
+   */
+  updated?(): void;
+}

--- a/packages/reactive-element/src/reactive-controller.ts
+++ b/packages/reactive-element/src/reactive-controller.ts
@@ -1,17 +1,31 @@
 /**
+ * @license
+ * Copyright (c) 2021 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+/**
  * An object that can host Reactive Controllers and call their lifecycle
  * callbacks.
  */
-export interface ControllerHost {
+export interface ReactiveControllerHost {
   /**
    * Adds a controller to the host, which sets up the controller's lifecycle
    * methods to be called with the host's lifecycle.
    */
-  addController(controller: Controller): void;
+  addController(controller: ReactiveController): void;
 
   /**
    * Requests a host update which is processed asynchronously. The update can
-   * waited on via the `updateComplete` property.
+   * be waited on via the `updateComplete` property.
    */
   requestUpdate(): void;
 
@@ -34,12 +48,12 @@ export interface ControllerHost {
  * hooks related to a single feature.
  *
  * Controllers are added to a host component, or other object that implements
- * the `ControllerHost` interface, via the `addController()` method. They can
- * hook their host components's lifecycle by implementing one or more of the
- * lifecycle callbacks, or initiate an update of the host component by calling
- * `requestUpdate()` on the host.
+ * the `ReactiveControllerHost` interface, via the `addController()` method.
+ * They can hook their host components's lifecycle by implementing one or more
+ * of the lifecycle callbacks, or initiate an update of the host component by
+ * calling `requestUpdate()` on the host.
  */
-export interface Controller {
+export interface ReactiveController {
   /**
    * Called when the host is connected to the component tree. For custom
    * element hosts, this corresponds to the `connectedCallback()` lifecycle,
@@ -75,7 +89,7 @@ export interface Controller {
   update?(): void;
 
   /**
-   * Called after a host update.
+   * Called after a host update. It is not called in server-side rendering.
    */
   updated?(): void;
 }

--- a/packages/reactive-element/src/reactive-element.ts
+++ b/packages/reactive-element/src/reactive-element.ts
@@ -26,15 +26,15 @@ import {
   CSSResultFlatArray,
 } from './css-tag.js';
 import type {
-  Controller,
-  ControllerHost,
-} from './controller.js';
+  ReactiveController,
+  ReactiveControllerHost,
+} from './reactive-controller.js';
 
 export * from './css-tag.js';
 export type {
-  Controller,
-  ControllerHost,
-} from './controller.js';
+  ReactiveController,
+  ReactiveControllerHost,
+} from './reactive-controller.js';
 
 const DEV_MODE = true;
 
@@ -296,7 +296,7 @@ export type Warnings = 'change-in-update' | 'migration';
  */
 export abstract class ReactiveElement
   extends HTMLElement
-  implements ControllerHost {
+  implements ReactiveControllerHost {
   // Note, these are patched in only in DEV_MODE.
   static enabledWarnings?: Warnings[];
   static enableWarning?: (type: Warnings) => void;
@@ -650,7 +650,7 @@ export abstract class ReactiveElement
   /**
    * Set of controllers.
    */
-  private __controllers?: Controller[];
+  private __controllers?: ReactiveController[];
 
   constructor() {
     super();
@@ -664,7 +664,7 @@ export abstract class ReactiveElement
     this.requestUpdate();
   }
 
-  addController(controller: Controller) {
+  addController(controller: ReactiveController) {
     (this.__controllers ??= []).push(controller);
   }
 

--- a/packages/reactive-element/src/test/reactive-element-controllers_test.ts
+++ b/packages/reactive-element/src/test/reactive-element-controllers_test.ts
@@ -35,12 +35,12 @@ suite('ReactiveElement controllers', () => {
       this.host.addController(this);
     }
 
-    connectedCallback() {
+    connected() {
       this.connectedCount++;
       this.callbackOrder.push('connectedCallback');
     }
 
-    disconnectedCallback() {
+    disconnected() {
       this.disconnectedCount++;
       this.callbackOrder.push('disconnectedCallback');
     }

--- a/packages/reactive-element/src/test/reactive-element-controllers_test.ts
+++ b/packages/reactive-element/src/test/reactive-element-controllers_test.ts
@@ -15,13 +15,13 @@
 import {
   PropertyValues,
   ReactiveElement,
-  Controller,
+  ReactiveController,
 } from '../reactive-element.js';
 import {generateElementName} from './test-helpers.js';
 import {assert} from '@esm-bundle/chai';
 
 suite('ReactiveElement controllers', () => {
-  class MyController implements Controller {
+  class MyController implements ReactiveController {
     host: ReactiveElement;
     willUpdateCount = 0;
     updateCount = 0;

--- a/packages/reactive-element/src/test/reactive-element_test.ts
+++ b/packages/reactive-element/src/test/reactive-element_test.ts
@@ -2200,7 +2200,7 @@ suite('ReactiveElement', () => {
         return (async () => {
           return (
             (await super.updateComplete) &&
-            (await new Promise((resolve) => {
+            (await new Promise<boolean>((resolve) => {
               setTimeout(() => {
                 this.promiseFulfilled = true;
                 resolve(true);


### PR DESCRIPTION
- Rename Controller to ReactiveController
- Introduce ReactiveControllerHost interface
- Move controller interfaces to `reactive-controller.ts`
- Remove "Callback" suffix from connectedCallback, disconnectedCallback & reconnectedCallback
- Remove `requestUpdate()` methods from ReactiveController
- Type `ReactiveElement.updateComplete` as `Promise<boolean>`