### PR TITLE
[lit-next] Fix failing IE tests

### DIFF
--- a/packages/lit-element/src/test/platform-support/lit-element-sd-ce-cp_test.html
+++ b/packages/lit-element/src/test/platform-support/lit-element-sd-ce-cp_test.html
@@ -1,6 +1,7 @@
 <html>
   <head>
     <link rel="stylesheet" href="../../../node_modules/mocha/mocha.css" />
+    <meta name="manual-polyfills" />
     <script>
       window.ShadyDOM = {
         force: true,

--- a/packages/lit-element/src/test/platform-support/lit-element-sd-ce_test.html
+++ b/packages/lit-element/src/test/platform-support/lit-element-sd-ce_test.html
@@ -1,6 +1,7 @@
 <html>
   <head>
     <link rel="stylesheet" href="../../../node_modules/mocha/mocha.css" />
+    <meta name="manual-polyfills" />
     <script>
       window.ShadyDOM = {
         force: true,

--- a/packages/lit-element/src/test/platform-support/lit-element-sd_test.html
+++ b/packages/lit-element/src/test/platform-support/lit-element-sd_test.html
@@ -1,6 +1,7 @@
 <html>
   <head>
     <link rel="stylesheet" href="../../../node_modules/mocha/mocha.css" />
+    <meta name="manual-polyfills" />
     <script>
       window.ShadyDOM = {
         force: true,

--- a/packages/lit-element/src/test/platform-support/lit-element_test.html
+++ b/packages/lit-element/src/test/platform-support/lit-element_test.html
@@ -2,6 +2,7 @@
   <head>
     <link rel="stylesheet" href="../../../node_modules/mocha/mocha.css" />
     <!-- Loads polyfills but does not force settings... -->
+    <meta name="manual-polyfills" />
     <script src="../../../node_modules/@webcomponents/webcomponentsjs/webcomponents-bundle.js"></script>
     <script src="../../../node_modules/@webcomponents/shadycss/apply-shim.min.js"></script>
   </head>

--- a/packages/lit-html/src/test/platform-support/lit-html-apply_test.html
+++ b/packages/lit-html/src/test/platform-support/lit-html-apply_test.html
@@ -1,6 +1,7 @@
 <html>
   <head>
     <link rel="stylesheet" href="../../../node_modules/mocha/mocha.css" />
+    <meta name="manual-polyfills" />
     <script>
       window.ShadyDOM = {
         force: true,

--- a/packages/lit-html/src/test/platform-support/lit-html-no-wc_test.html
+++ b/packages/lit-html/src/test/platform-support/lit-html-no-wc_test.html
@@ -1,6 +1,7 @@
 <html>
   <head>
     <link rel="stylesheet" href="../../../node_modules/mocha/mocha.css" />
+    <meta name="manual-polyfills" />
     <script>
       // Remove Shadow DOM
       delete window.Element.prototype.assignedSlot;

--- a/packages/lit-html/src/test/platform-support/lit-html-scoping-shim_test.html
+++ b/packages/lit-html/src/test/platform-support/lit-html-scoping-shim_test.html
@@ -1,6 +1,7 @@
 <html>
   <head>
     <link rel="stylesheet" href="../../../node_modules/mocha/mocha.css" />
+    <meta name="manual-polyfills" />
     <script>
       window.ShadyDOM = {
         force: true,

--- a/packages/lit-html/src/test/platform-support/lit-html_test.html
+++ b/packages/lit-html/src/test/platform-support/lit-html_test.html
@@ -1,6 +1,7 @@
 <html>
   <head>
     <link rel="stylesheet" href="../../../node_modules/mocha/mocha.css" />
+    <meta name="manual-polyfills" />
     <script>
       window.ShadyDOM = {
         force: true,

--- a/packages/reactive-element/src/test/platform-support/reactive-element-sd-ce-cp_test.html
+++ b/packages/reactive-element/src/test/platform-support/reactive-element-sd-ce-cp_test.html
@@ -1,6 +1,7 @@
 <html>
   <head>
     <link rel="stylesheet" href="../../../node_modules/mocha/mocha.css" />
+    <meta name="manual-polyfills" />
     <script>
       window.ShadyDOM = {
         force: true,

--- a/packages/reactive-element/src/test/platform-support/reactive-element-sd-ce_test.html
+++ b/packages/reactive-element/src/test/platform-support/reactive-element-sd-ce_test.html
@@ -1,6 +1,7 @@
 <html>
   <head>
     <link rel="stylesheet" href="../../../node_modules/mocha/mocha.css" />
+    <meta name="manual-polyfills" />
     <script>
       window.ShadyDOM = {
         force: true,

--- a/packages/reactive-element/src/test/platform-support/reactive-element-sd_test.html
+++ b/packages/reactive-element/src/test/platform-support/reactive-element-sd_test.html
@@ -1,6 +1,7 @@
 <html>
   <head>
     <link rel="stylesheet" href="../../../node_modules/mocha/mocha.css" />
+    <meta name="manual-polyfills" />
     <script>
       window.ShadyDOM = {
         force: true,

--- a/packages/reactive-element/src/test/platform-support/reactive-element_test.html
+++ b/packages/reactive-element/src/test/platform-support/reactive-element_test.html
@@ -2,6 +2,7 @@
   <head>
     <link rel="stylesheet" href="../../../node_modules/mocha/mocha.css" />
     <!-- Loads polyfills but does not force settings... -->
+    <meta name="manual-polyfills" />
     <script src="../../../node_modules/@webcomponents/webcomponentsjs/webcomponents-bundle.js"></script>
     <script src="../../../node_modules/@webcomponents/shadycss/apply-shim.min.js"></script>
   </head>

--- a/packages/tests/web-test-runner.config.js
+++ b/packages/tests/web-test-runner.config.js
@@ -163,6 +163,15 @@ export default {
     // (https://modern-web.dev/docs/dev-server/plugins/legacy/).
     legacyPlugin({
       polyfills: {
+        // Rather than use the webcomponents polyfill version bundled with the
+        // legacyPlugin, we inject a custom version of the polyfill; this both
+        // gives us more control over the version, but also allows a mechanism
+        // for tests to opt out of automatic injection, so that they can control
+        // the timing when the polyfill loads (i.e. for setting polyfill flags
+        // in an inline script before polyfills are manually loaded). Note that
+        // .html-based tests can add a `<meta name="manual-polyfills">` tag in
+        // the head to opt out of automatic polyfill injection and load them
+        // manually using a `<script>` tag in the page.
         webcomponents: false,
         custom: [
           {
@@ -170,8 +179,9 @@ export default {
             path: require.resolve(
               '@webcomponents/webcomponentsjs/webcomponents-bundle.js'
             ),
-            // Always load.
-            test: 'true',
+            // Don't load if the page is tagged with a special meta indicating
+            // the polyfills will be loaded manually
+            test: '!document.querySelector("meta[name=manual-polyfills")',
             module: false,
           },
         ],


### PR DESCRIPTION
Always inject wcjs polyfill, unless <meta> opt-out is found. All .html tests use this mechanism to manually load the polyfills; avoids double polyfill loading, which was leading to errors on IE.