### PR TITLE
Fix ElementPart when IE reorders attrs. Fixes #1537

### DIFF
--- a/packages/lit-html/src/hydrate.ts
+++ b/packages/lit-html/src/hydrate.ts
@@ -20,6 +20,7 @@ import {
   EventPart,
   ChildPart,
   PropertyPart,
+  ElementPart,
   RenderOptions,
   _Σ,
 } from './lit-html.js';
@@ -37,6 +38,7 @@ const {
   _ChildPart: ChildPart,
   _EventPart: EventPart,
   _PropertyPart: PropertyPart,
+  _ElementPart: ElementPart,
 } = _Σ;
 
 type TemplateInstance = InstanceType<typeof TemplateInstance>;
@@ -358,46 +360,57 @@ const createAttributeParts = (
       const templatePart = instance._$template._parts[state.templatePartIndex];
       if (
         templatePart === undefined ||
-        templatePart._type !== PartType.ATTRIBUTE ||
+        (templatePart._type !== PartType.ATTRIBUTE &&
+         templatePart._type !== PartType.ELEMENT) ||
         templatePart._index !== nodeIndex
       ) {
         break;
       }
       foundOnePart = true;
 
-      // The instance part is created based on the constructor saved in the
-      // template part
-      const instancePart = new templatePart._constructor(
-        node.parentElement as HTMLElement,
-        templatePart._name,
-        templatePart._strings,
-        state.instance,
-        options
-      );
+      if (templatePart._type === PartType.ATTRIBUTE) {
+        // The instance part is created based on the constructor saved in the
+        // template part
+        const instancePart = new templatePart._constructor(
+          node.parentElement as HTMLElement,
+          templatePart._name,
+          templatePart._strings,
+          state.instance,
+          options
+        );
 
-      const value = isSingleExpression(
-        (instancePart as unknown) as AttributePartInfo
-      )
-        ? state.result.values[state.instancePartIndex]
-        : state.result.values;
+        const value = isSingleExpression(
+          (instancePart as unknown) as AttributePartInfo
+        )
+          ? state.result.values[state.instancePartIndex]
+          : state.result.values;
 
-      // Setting the attribute value primes committed value with the resolved
-      // directive value; we only then commit that value for event/property
-      // parts since those were not serialized, and pass `noCommit` for the
-      // others to avoid perf impact of touching the DOM unnecessarily
-      const noCommit = !(
-        instancePart instanceof EventPart ||
-        instancePart instanceof PropertyPart
-      );
-      instancePart._$setValue(
-        value,
-        instancePart,
-        state.instancePartIndex,
-        noCommit
-      );
+        // Setting the attribute value primes committed value with the resolved
+        // directive value; we only then commit that value for event/property
+        // parts since those were not serialized, and pass `noCommit` for the
+        // others to avoid perf impact of touching the DOM unnecessarily
+        const noCommit = !(
+          instancePart instanceof EventPart ||
+          instancePart instanceof PropertyPart
+        );
+        instancePart._$setValue(
+          value,
+          instancePart,
+          state.instancePartIndex,
+          noCommit
+        );
+        state.instancePartIndex += templatePart._strings.length - 1;
+        instance._parts.push(instancePart);
+      } else { // templatePart._type === PartType.ELEMENT
+        const instancePart = new ElementPart(
+          node.parentElement as HTMLElement,
+          state.instance,
+          options
+        );
+        resolveDirective(instancePart, state.result.values[state.instancePartIndex++]);
+        instance._parts.push(instancePart);
+      }
       state.templatePartIndex++;
-      state.instancePartIndex += templatePart._strings.length - 1;
-      instance._parts.push(instancePart);
     }
     if (!foundOnePart) {
       // For a <!--lit-bindings--> marker there should be at least

--- a/packages/lit-html/src/lit-html.ts
+++ b/packages/lit-html/src/lit-html.ts
@@ -365,7 +365,7 @@ export interface DirectiveParent {
 const getTemplateHtml = (
   strings: TemplateStringsArray,
   type: ResultType
-): [string, string[]] => {
+): [string, Array<string|undefined>] => {
   // Insert makers into the template HTML to represent the position of
   // bindings. The following code scans the template strings to determine the
   // syntactic position of the bindings. They can be in text position, where
@@ -373,7 +373,10 @@ const getTemplateHtml = (
   // sentinel string and re-write the attribute name, or inside a tag where
   // we insert the sentinel string.
   const l = strings.length - 1;
-  const attrNames: Array<string> = [];
+  // Stores the case-sensitive bound attribute names in the order of their
+  // parts. Element-position are also reflected in this array as undefined
+  // rather than a string, to disambiguate from attribute bindings.
+  const attrNames: Array<string|undefined> = [];
   let html = type === SVG_RESULT ? '<svg>' : '';
 
   // When we're inside a raw text tag (not it's text content), the regex
@@ -491,7 +494,7 @@ const getTemplateHtml = (
           s.slice(0, attrNameEndIndex) +
             boundAttributeSuffix +
             s.slice(attrNameEndIndex)) + marker
-        : s + marker + (attrNameEndIndex === -2 ? `:${i}` : '');
+        : s + marker + (attrNameEndIndex === -2 ? (attrNames.push(undefined), i) : '');
   }
 
   // Returned as an array for terseness
@@ -558,36 +561,37 @@ class TemplateImpl {
             // contains the attribute name we'll process next. We only need the
             // attribute name here to know if we should process a bound attribute
             // on this element.
-            if (name.endsWith(boundAttributeSuffix)) {
+            if (name.endsWith(boundAttributeSuffix) || name.startsWith(marker)) {
               const realName = attrNames[attrNameIndex++];
-              // Lowercase for case-sensitive SVG attributes like viewBox
-              const value = (node as Element).getAttribute(
-                realName.toLowerCase() + boundAttributeSuffix
-              )!;
               attrsToRemove.push(name);
-              const statics = value.split(marker);
-              const m = /([.?@])?(.*)/.exec(realName)!;
-              this._parts.push({
-                _type: ATTRIBUTE_PART,
-                _index: nodeIndex,
-                _name: m[2],
-                _strings: statics,
-                _constructor:
-                  m[1] === '.'
-                    ? PropertyPartImpl
-                    : m[1] === '?'
-                    ? BooleanAttributePartImpl
-                    : m[1] === '@'
-                    ? EventPartImpl
-                    : AttributePartImpl,
-              });
-              bindingIndex += statics.length - 1;
-            } else if (name.startsWith(marker)) {
-              attrsToRemove.push(name);
-              this._parts.push({
-                _type: ELEMENT_PART,
-                _index: nodeIndex,
-              });
+              if (realName !== undefined) {
+                // Lowercase for case-sensitive SVG attributes like viewBox
+                const value = (node as Element).getAttribute(
+                  realName.toLowerCase() + boundAttributeSuffix
+                )!;
+                const statics = value.split(marker);
+                const m = /([.?@])?(.*)/.exec(realName)!;
+                this._parts.push({
+                  _type: ATTRIBUTE_PART,
+                  _index: nodeIndex,
+                  _name: m[2],
+                  _strings: statics,
+                  _constructor:
+                    m[1] === '.'
+                      ? PropertyPartImpl
+                      : m[1] === '?'
+                      ? BooleanAttributePartImpl
+                      : m[1] === '@'
+                      ? EventPartImpl
+                      : AttributePartImpl,
+                });
+                bindingIndex += statics.length - 1;
+              } else {
+                this._parts.push({
+                  _type: ELEMENT_PART,
+                  _index: nodeIndex,
+                });
+              }
             }
           }
           for (const name of attrsToRemove) {
@@ -805,6 +809,13 @@ type AttributeTemplatePart = {
 type NodeTemplatePart = {
   readonly _type: typeof CHILD_PART;
   readonly _index: number;
+};
+type ElementPartConstructor = {
+  new (
+    element: HTMLElement,
+    parent: Disconnectable | undefined,
+    options: RenderOptions | undefined
+  ): ElementPart;
 };
 type ElementTemplatePart = {
   readonly _type: typeof ELEMENT_PART;
@@ -1418,6 +1429,7 @@ export const _Σ = {
   _BooleanAttributePart: BooleanAttributePartImpl as AttributePartConstructor,
   _EventPart: EventPartImpl as AttributePartConstructor,
   _PropertyPart: PropertyPartImpl as AttributePartConstructor,
+  _ElementPart: ElementPartImpl as ElementPartConstructor,
 };
 
 // Apply polyfills if available

--- a/packages/lit-html/src/lit-html.ts
+++ b/packages/lit-html/src/lit-html.ts
@@ -374,7 +374,7 @@ const getTemplateHtml = (
   // we insert the sentinel string.
   const l = strings.length - 1;
   // Stores the case-sensitive bound attribute names in the order of their
-  // parts. Element-position are also reflected in this array as undefined
+  // parts. ElementParts are also reflected in this array as undefined
   // rather than a string, to disambiguate from attribute bindings.
   const attrNames: Array<string|undefined> = [];
   let html = type === SVG_RESULT ? '<svg>' : '';

--- a/packages/lit-html/src/private-ssr-support.ts
+++ b/packages/lit-html/src/private-ssr-support.ts
@@ -24,8 +24,8 @@ import {_Σ as p, AttributePart, noChange} from './lit-html.js';
  * helper methods for accessing private fields of those members), and then
  * re-export them for use in lit-ssr. This keeps lit-ssr agnostic to whether the
  * client-side code is being used in `dev` mode or `prod` mode.
- *
  * @private
+ *
  */
 export const _Σ = {
   boundAttributeSuffix: p._boundAttributeSuffix,
@@ -56,4 +56,5 @@ export const _Σ = {
   PropertyPart: p._PropertyPart,
   BooleanAttributePart: p._BooleanAttributePart,
   EventPart: p._EventPart,
+  ElementPart: p._ElementPart,
 };

--- a/packages/lit-html/src/test/lit-html_test.ts
+++ b/packages/lit-html/src/test/lit-html_test.ts
@@ -1427,8 +1427,12 @@ suite('lit-html', () => {
     // A stateful directive
     class CountDirective extends Directive {
       count = 0;
-      render(v: unknown) {
-        return `${v}:${++this.count}`;
+      render(id: string, log?: string[]) {
+        const v = `${id}:${++this.count}`;
+        if (log !== undefined) {
+          log.push(v);
+        }
+        return v;
       }
     }
     const count = directive(CountDirective);
@@ -1567,6 +1571,36 @@ suite('lit-html', () => {
         container
       );
       assert.isOk(event);
+    });
+
+    test('renders directives on ElementParts', () => {
+      const log: string[] = [];
+      assertRender(html`<div ${count('x', log)}}></div>`, `<div></div>`);
+      assert.deepEqual(log, ['x:1']);
+
+      log.length = 0;
+      assertRender(html`<div a=${'a'} ${count('x', log)}}></div>`, `<div a="a"></div>`);
+      assert.deepEqual(log, ['x:1']);
+
+      log.length = 0;
+      assertRender(html`<div ${count('x', log)}} a=${'a'}></div>`, `<div a="a"></div>`);
+      assert.deepEqual(log, ['x:1']);
+
+      log.length = 0;
+      assertRender(html`<div a=${'a'} ${count('x', log)}} b=${'b'}></div>`, `<div a="a" b="b"></div>`);
+      assert.deepEqual(log, ['x:1']);
+
+      log.length = 0;
+      assertRender(html`<div ${count('x', log)} ${count('y', log)}}></div>`, `<div></div>`);
+      assert.deepEqual(log, ['x:1', 'y:1']);
+
+      log.length = 0;
+      const template = html`<div ${count('x', log)} a=${'a'} ${count('y', log)}}></div>`;
+      assertRender(template, `<div a="a"></div>`);
+      assert.deepEqual(log, ['x:1', 'y:1']);
+      log.length = 0;
+      assertRender(template, `<div a="a"></div>`);
+      assert.deepEqual(log, ['x:2', 'y:2']);
     });
 
     test('directives have access to renderOptions', () => {

--- a/packages/lit-ssr/src/lib/render-lit-html.ts
+++ b/packages/lit-ssr/src/lib/render-lit-html.ts
@@ -112,7 +112,7 @@ type AttributePartOp = {
 };
 
 /**
- * Operation for and element binding. Although we only support directives in
+ * Operation for an element binding. Although we only support directives in
  * element position which cannot emit anything, the opcode needs to index past
  * the part value
  */
@@ -572,6 +572,9 @@ export function* renderTemplateResult(
         break;
       }
       case 'element-part': {
+        // We don't emit anything for element parts (since we only support
+        // directives for now; since they can't render, we don't even bother
+        // running them), but we still need to advance the part index
         partIndex++;
         break;
       }

--- a/packages/lit-ssr/src/lib/render-lit-html.ts
+++ b/packages/lit-ssr/src/lib/render-lit-html.ts
@@ -99,7 +99,7 @@ type ChildPartOp = {
 
 /**
  * Operation to output an attribute with bindings. Includes all bindings for an
- * attribute, like an attribute template part or AttributeComitter.
+ * attribute.
  */
 type AttributePartOp = {
   type: 'attribute-part';
@@ -109,6 +109,16 @@ type AttributePartOp = {
   strings: Array<string>;
   tagName: string;
   useCustomElementInstance?: boolean;
+};
+
+/**
+ * Operation for and element binding. Although we only support directives in
+ * element position which cannot emit anything, the opcode needs to index past
+ * the part value
+ */
+type ElementPartOp = {
+  type: 'element-part';
+  index: number;
 };
 
 /**
@@ -150,6 +160,7 @@ type Op =
   | TextOp
   | ChildPartOp
   | AttributePartOp
+  | ElementPartOp
   | CustomElementOpenOp
   | CustomElementAttributesOp
   | CustomElementShadowOp
@@ -335,7 +346,9 @@ const getTemplateOpcodes = (result: TemplateResult) => {
         }
         if (node.attrs.length > 0) {
           for (const attr of node.attrs) {
-            if (attr.name.endsWith(boundAttributeSuffix)) {
+            const isAttrBinding = attr.name.endsWith(boundAttributeSuffix);
+            const isElementBinding = attr.name.startsWith(marker);
+            if (isAttrBinding || isElementBinding) {
               writeTag = true;
               boundAttrsCount += 1;
               // Note that although we emit a lit-bindings comment marker for any
@@ -345,31 +358,37 @@ const getTemplateOpcodes = (result: TemplateResult) => {
               // We store the case-sensitive name from `attrNames` (generated
               // while parsing the template strings); note that this assumes
               // parse5 attribute ordering matches string ordering
-              const [, prefix, caseSensitiveName] = /([.?@])?(.*)/.exec(
-                attrNames[attrIndex++]
-              )!;
+              const name = attrNames[attrIndex++];
               const attrSourceLocation = node.sourceCodeLocation!.attrs[
                 attr.name
               ];
               const attrNameStartOffset = attrSourceLocation.startOffset;
               const attrEndOffset = attrSourceLocation.endOffset;
               flushTo(attrNameStartOffset);
-              ops.push({
-                type: 'attribute-part',
-                index: nodeIndex,
-                name: caseSensitiveName,
-                ctor:
-                  prefix === '.'
-                    ? PropertyPart
-                    : prefix === '?'
-                    ? BooleanAttributePart
-                    : prefix === '@'
-                    ? EventPart
-                    : AttributePart,
-                strings,
-                tagName,
-                useCustomElementInstance: ctor !== undefined,
-              });
+              if (isAttrBinding) {
+                const [, prefix, caseSensitiveName] = /([.?@])?(.*)/.exec(name as string)!;
+                ops.push({
+                  type: 'attribute-part',
+                  index: nodeIndex,
+                  name: caseSensitiveName,
+                  ctor:
+                    prefix === '.'
+                      ? PropertyPart
+                      : prefix === '?'
+                      ? BooleanAttributePart
+                      : prefix === '@'
+                      ? EventPart
+                      : AttributePart,
+                  strings,
+                  tagName,
+                  useCustomElementInstance: ctor !== undefined,
+                });
+              } else {
+                ops.push({
+                  type: 'element-part',
+                  index: nodeIndex,
+                });
+              }
               skipTo(attrEndOffset);
             } else if (node.isDefinedCustomElement) {
               // For custom elements, all static attributes are stored along
@@ -550,6 +569,10 @@ export function* renderTemplateResult(
           }
         }
         partIndex += statics.length - 1;
+        break;
+      }
+      case 'element-part': {
+        partIndex++;
         break;
       }
       case 'custom-element-open': {

--- a/packages/lit-ssr/src/test/integration/tests/basic.ts
+++ b/packages/lit-ssr/src/test/integration/tests/basic.ts
@@ -14,8 +14,8 @@
 
 import 'lit-element/hydrate-support.js';
 
-import {html, noChange, nothing} from 'lit-html';
-import {directive, Directive} from 'lit-html/directive.js';
+import {html, noChange, nothing, Part} from 'lit-html';
+import {directive, Directive, DirectiveParameters, DirectiveResult} from 'lit-html/directive.js';
 import {repeat} from 'lit-html/directives/repeat.js';
 import {guard} from 'lit-html/directives/guard.js';
 import {cache} from 'lit-html/directives/cache.js';
@@ -30,6 +30,7 @@ import {ifDefined} from 'lit-html/directives/if-defined.js';
 import {live} from 'lit-html/directives/live.js';
 import {unsafeHTML} from 'lit-html/directives/unsafe-html.js';
 import {unsafeSVG} from 'lit-html/directives/unsafe-svg.js';
+import {createRef, ref} from 'lit-html/directives/ref.js';
 
 import {LitElement} from 'lit-element';
 import {property} from 'lit-element/decorators/property.js';
@@ -39,6 +40,7 @@ import {
 } from 'lit-html/directives/render-light.js';
 
 import {SSRTest} from './ssr-test';
+import { DisconnectableDirective } from 'lit-html/disconnectable-directive';
 
 interface DivWithProp extends HTMLDivElement {
   prop?: unknown;
@@ -3281,6 +3283,80 @@ export const tests: {[name: string]: SSRTest} = {
   },
 
   /******************************************************
+   * ElementPart tests
+   ******************************************************/
+
+  'ElementPart accepts directive: generic': () => {
+    const log: string[] = [];
+    const dir = directive(class extends Directive {
+      render(_v: string) {
+        log.push('render should not be called');
+      }
+      update(_part: Part, [v]: DirectiveParameters<this>) {
+        log.push(v);
+      }
+    });
+    return {
+      render(v: string) {
+        return html`<div attr=${v} ${dir(v)}></div>`;
+      },
+      expectations: [
+        {
+          args: ['a'],
+          html: '<div attr="a"></div>',
+          check(assert: Chai.Assert) {
+            // Note, update is called once during hydration and again
+            // during initial render
+            assert.deepEqual(log, ['a', 'a']);
+          }
+        },
+        {
+          args: ['b'],
+          html: '<div attr="b"></div>',
+          check(assert: Chai.Assert) {
+            assert.deepEqual(log, ['a', 'a', 'b']);
+          }
+        },
+      ],
+      stableSelectors: ['div'],
+    };
+  },
+
+  'ElementPart accepts directive: ref': () => {
+    const ref1 = createRef();
+    const ref2 = createRef();
+    const ref3 = createRef();
+    return {
+      render(v: boolean) {
+        return html`<div id="div1" ${ref(ref1)}><div id="div2" ${ref(ref2)}>${v ? 
+          html`<div id="div3" ${ref(ref3)}></div>` : nothing}
+        </div></div>`;
+      },
+      expectations: [
+        {
+          args: [true],
+          html: '<div id="div1"><div id="div2"><div id="div3"></div></div></div>',
+          check(assert: Chai.Assert) {
+            assert.equal(ref1.value?.id, 'div1');
+            assert.equal(ref2.value?.id, 'div2');
+            assert.equal(ref3.value?.id, 'div3');
+          }
+        },
+        {
+          args: [false],
+          html: '<div id="div1"><div id="div2"></div></div>',
+          check(assert: Chai.Assert) {
+            assert.equal(ref1.value?.id, 'div1');
+            assert.equal(ref2.value?.id, 'div2');
+            assert.notOk(ref3.value);
+          }
+        },
+      ],
+      stableSelectors: ['div'],
+    };
+  },
+
+  /******************************************************
    * Mixed part tests
    ******************************************************/
 
@@ -3322,7 +3398,7 @@ export const tests: {[name: string]: SSRTest} = {
     stableSelectors: ['div'],
   },
 
-  'ChildParts & AttributeParts soup': {
+  'ChildPart, AttributePart, and ElementPart soup': {
     render(x, y, z) {
       return html`text:${x}
         <div>${x}</div>
@@ -3334,14 +3410,14 @@ export const tests: {[name: string]: SSRTest} = {
     },
     expectations: [
       {
-        args: [html`<a></a>`, 'b', 'c'],
+        args: [html`<a attr=${'a'} ${'ignored'}></a>`, 'b', 'c'],
         html:
-          'text:\n<a></a><div><a></a></div><span a1="b" a2="b"><a></a><p a="b">b</p>c</span>',
+          'text:\n<a attr="a"></a><div><a attr="a"></a></div><span a1="b" a2="b"><a attr="a"></a><p a="b">b</p>c</span>',
       },
       {
-        args: ['x', 'y', html`<i></i>`],
+        args: ['x', 'y', html`<i ${'ignored'} attr=${'i'}></i>`],
         html:
-          'text:x\n<div>x</div><span a1="y" a2="y">x<p a="y">y</p><i></i></span>',
+          'text:x\n<div>x</div><span a1="y" a2="y">x<p a="y">y</p><i attr="i"></i></span>',
       },
     ],
     stableSelectors: ['div', 'span', 'p'],
@@ -3747,6 +3823,111 @@ export const tests: {[name: string]: SSRTest} = {
         },
       ],
       stableSelectors: ['div', 'span'],
+    };
+  },
+
+  /******************************************************
+   * DisconnectableDirective tests
+   ******************************************************/
+
+  'DisconnectableDirective': () => {
+    const log: string[] = [];
+    const dir = directive(class extends DisconnectableDirective {
+      id!: string;
+      render(id: string) {
+        this.id = id;
+        log.push(`render-${this.id}`);
+        return id;
+      }
+      disconnected() {
+        log.push(`disconnected-${this.id}`);
+      }
+    });
+    return {
+      render(bool: boolean, id: string) {
+        return html`<span>${dir('x')}${bool ? html`<div attr=${dir(`attr-${id}`)}>${dir(`node-${id}`)}</div>` : nothing}</span>`;
+      },
+      expectations: [
+        {
+          args: [true, 'a'],
+          html: '<span>x<div attr="attr-a">node-a</div></span>',
+          check(assert: Chai.Assert) {
+            // Note, update is called once during hydration and again
+            // during initial render
+            assert.deepEqual(log, ['render-x', 'render-attr-a', 'render-node-a', 'render-x', 'render-attr-a', 'render-node-a']);
+            log.length = 0;
+          }
+        },
+        {
+          args: [false, 'a'],
+          html: '<span>x</span>',
+          check(assert: Chai.Assert) {
+            assert.deepEqual(log, ['render-x', 'disconnected-attr-a', 'disconnected-node-a']);
+            log.length = 0;
+          }
+        },
+        {
+          args: [true, 'b'],
+          html: '<span>x<div attr="attr-b">node-b</div></span>',
+          check(assert: Chai.Assert) {
+            assert.deepEqual(log, ['render-x', 'render-attr-b', 'render-node-b']);
+            log.length = 0;
+          }
+        },
+        {
+          args: [false, 'b'],
+          html: '<span>x</span>',
+          check(assert: Chai.Assert) {
+            assert.deepEqual(log, ['render-x', 'disconnected-attr-b', 'disconnected-node-b']);
+            log.length = 0;
+          }
+        },
+      ],
+      stableSelectors: ['span'],
+    };
+  },
+
+  /******************************************************
+   * Nested directive tests
+   ******************************************************/
+
+  'Nested directives': () => {
+    const log: number[] = [];
+    const nest = directive(class extends Directive {
+      render(n: number): string | DirectiveResult {
+        log.push(n);
+        if (n > 1) {
+          return nest(n-1);
+        } else {
+          return 'nested!'
+        }
+      }
+    });
+    return {
+      render() {
+        return html`<span>${nest(3)}</span>`;
+      },
+      expectations: [
+        {
+          args: [],
+          html: '<span>nested!</span>',
+          check(assert: Chai.Assert) {
+            // Note, update is called once during hydration and again
+            // during initial render
+            assert.deepEqual(log, [3, 2, 1, 3, 2, 1]);
+            log.length = 0;
+          }
+        },
+        {
+          args: [],
+          html: '<span>nested!</span>',
+          check(assert: Chai.Assert) {
+            assert.deepEqual(log, [3, 2, 1]);
+            log.length = 0;
+          }
+        },
+      ],
+      stableSelectors: ['span'],
     };
   },
 


### PR DESCRIPTION
Fix `ElementPart` when IE reorders attributes. The `attrNames` array now holds `undefined` for `ElementPart`s, and uses the same logic as `AttributePart` to ensure parts are created in the original order, despite bound attributes possibly being re-ordered.

Also adds SSR support for `ElementPart`, and adds belated SSR adds tests for `ElementPart`, `DisconnectableDirective`, and nested directives also.

Uncompressed code size when up a tad but gzip/brotli went down:

```
Name                            Size       Minified   Gzipped    Brotli    
---------------------------------------------------------------------------
lit-html.js                     6.086 KB   6.078 KB   2.759 KB   2.501 KB
lit-html.js                     6.101 KB   6.093 KB   2.758 KB   2.488 KB  
```

Fixes #1537