### PR TITLE
WIP: feat: add compatibility with scoped registries

### DIFF
--- a/src/lib/dom.ts
+++ b/src/lib/dom.ts
@@ -25,6 +25,14 @@ export const isCEPolyfill = typeof window !== 'undefined' &&
         undefined;
 
 /**
+ * True if scoped registries are supported
+ */
+export const scopedRegistriesSupported = typeof ShadowRoot !== 'undefined' &&
+    // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+    // @ts-ignore
+    ShadowRoot.prototype.importNode !== undefined;
+
+/**
  * Reparents nodes, starting from `start` (inclusive) to `end` (exclusive),
  * into another container (could be the same container), before `before`. If
  * `before` is null, it appends the nodes to the container.

--- a/src/lib/parts.ts
+++ b/src/lib/parts.ts
@@ -13,7 +13,7 @@
  */
 
 import {isDirective} from './directive.js';
-import {removeNodes} from './dom.js';
+import {removeNodes, scopedRegistriesSupported} from './dom.js';
 import {noChange, nothing, Part} from './part.js';
 import {RenderOptions} from './render-options.js';
 import {TemplateInstance} from './template-instance.js';
@@ -252,6 +252,20 @@ export class NodePart implements Part {
     }
   }
 
+  private __getRootNode(): Node {
+    if (scopedRegistriesSupported) {
+      const rootNode = this.endNode.getRootNode();
+
+      // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+      // @ts-ignore
+      if (rootNode.importNode !== undefined) {
+        return rootNode;
+      }
+    }
+
+    return document;
+  }
+
   private __insert(node: Node) {
     this.endNode.parentNode!.insertBefore(node, this.endNode);
   }
@@ -296,7 +310,7 @@ export class NodePart implements Part {
       // caching and preprocessing.
       const instance =
           new TemplateInstance(template, value.processor, this.options);
-      const fragment = instance._clone();
+      const fragment = instance._clone(this.__getRootNode());
       instance.update(value.values);
       this.__commitNode(fragment);
       this.value = instance;

--- a/src/lib/template-instance.ts
+++ b/src/lib/template-instance.ts
@@ -51,7 +51,7 @@ export class TemplateInstance {
     }
   }
 
-  _clone(): DocumentFragment {
+  _clone(rootNode: Node = document): DocumentFragment {
     // There are a number of steps in the lifecycle of a template instance's
     // DOM fragment:
     //  1. Clone - create the instance fragment
@@ -92,7 +92,9 @@ export class TemplateInstance {
 
     const fragment = isCEPolyfill ?
         this.template.element.content.cloneNode(true) as DocumentFragment :
-        document.importNode(this.template.element.content, true);
+        // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+        // @ts-ignore
+        rootNode.importNode(this.template.element.content, true);
 
     const stack: Node[] = [];
     const parts = this.template.parts;


### PR DESCRIPTION
When a TemplateInstance is cloned, we must import the template content not only from the document but the ShadowRoot of the components, so in this way the new nodes are going to be created with the correct scope and registry.

I didn't add automatic test because I'm not sure how I could add it using wct and the scoped registries polyfill. However I did a manual test with a pet project using open-wc scoped-elements, updating the mixin to use the scoped registries, and it worked fine 👍

PokeApp using scoped elements before applying the scoped registries polyfill
https://user-images.githubusercontent.com/329771/104722801-aa2b2b00-572e-11eb-9f1d-5fb1519c67be.mp4

PokeApp using scoped elements after applying the scoped registries polyfill
https://user-images.githubusercontent.com/329771/104723197-30477180-572f-11eb-8678-2917a5c2feef.mp4
