### PR TITLE
[lit-next] Adds `removeController`

### DIFF
--- a/packages/lit-element/src/test/lit-element_test.ts
+++ b/packages/lit-element/src/test/lit-element_test.ts
@@ -17,6 +17,8 @@ import {
   LitElement,
   UpdatingElement,
   ReactiveElement,
+  Part,
+  nothing,
 } from '../lit-element.js';
 import {
   directive,
@@ -31,6 +33,7 @@ import {
 import {assert} from '@esm-bundle/chai';
 
 import {createRef, ref} from 'lit-html/directives/ref.js';
+import {ReactiveController} from '@lit/reactive-element';
 
 (canTestLitElement ? suite : suite.skip)('LitElement', () => {
   let container: HTMLElement;
@@ -345,180 +348,182 @@ import {createRef, ref} from 'lit-html/directives/ref.js';
     }
   );
 
-  suite('disconnection handling', () => {
-    let host: Host;
-    const log: string[] = [];
+  suite('directives', () => {
+    suite('disconnection handling', () => {
+      let host: Host;
+      const log: string[] = [];
 
-    const d = directive(
-      class extends DisconnectableDirective {
-        id!: unknown;
-        render(id: unknown) {
-          log.push(`render-${id}`);
-          return (this.id = id);
+      const d = directive(
+        class extends DisconnectableDirective {
+          id!: unknown;
+          render(id: unknown) {
+            log.push(`render-${id}`);
+            return (this.id = id);
+          }
+          disconnected() {
+            log.push(`disconnect-${this.id}`);
+          }
+          reconnected() {
+            log.push(`reconnect-${this.id}`);
+          }
         }
-        disconnected() {
-          log.push(`disconnect-${this.id}`);
+      );
+
+      class Child extends LitElement {
+        static properties = {
+          attr: {type: String},
+          prop: {type: String},
+        };
+        attr = 'default';
+        prop = 'default';
+        render() {
+          return html`<div attr=${d('child-attr')} .prop=${d('child-prop')}>
+            ${d('child-node')}
+          </div>`;
         }
-        reconnected() {
-          log.push(`reconnect-${this.id}`);
+        get child() {
+          // Cast to child so we can access .prop off of the div
+          return this.shadowRoot!.firstElementChild as Child;
         }
       }
-    );
+      customElements.define('disc-child', Child);
 
-    class Child extends LitElement {
-      static properties = {
-        attr: {type: String},
-        prop: {type: String},
+      class Host extends LitElement {
+        render() {
+          return html`<disc-child attr=${d('host-attr')} .prop=${d('host-prop')}
+            >${d('host-node')}</disc-child
+          >`;
+        }
+        get child() {
+          // Cast to child so we can access .prop off of the div
+          return this.shadowRoot!.firstElementChild as Child;
+        }
+      }
+      customElements.define('disc-host', Host);
+
+      const assertRendering = (host: Host) => {
+        let child = host.child;
+        assert.equal(child.getAttribute('attr'), 'host-attr');
+        assert.equal(child.prop, 'host-prop');
+        assert.equal(child.textContent?.trim(), 'host-node');
+        child = child.child;
+        assert.equal(child.getAttribute('attr'), 'child-attr');
+        assert.equal(child.prop, 'child-prop');
+        assert.equal(child.textContent?.trim(), 'child-node');
       };
-      attr = 'default';
-      prop = 'default';
-      render() {
-        return html`<div attr=${d('child-attr')} .prop=${d('child-prop')}>
-          ${d('child-node')}
-        </div>`;
-      }
-      get child() {
-        // Cast to child so we can access .prop off of the div
-        return this.shadowRoot!.firstElementChild as Child;
-      }
-    }
-    customElements.define('disc-child', Child);
 
-    class Host extends LitElement {
-      render() {
-        return html`<disc-child attr=${d('host-attr')} .prop=${d('host-prop')}
-          >${d('host-node')}</disc-child
-        >`;
-      }
-      get child() {
-        // Cast to child so we can access .prop off of the div
-        return this.shadowRoot!.firstElementChild as Child;
-      }
-    }
-    customElements.define('disc-host', Host);
+      setup(() => {
+        log.length = 0;
+        host = new Host();
+      });
 
-    const assertRendering = (host: Host) => {
-      let child = host.child;
-      assert.equal(child.getAttribute('attr'), 'host-attr');
-      assert.equal(child.prop, 'host-prop');
-      assert.equal(child.textContent?.trim(), 'host-node');
-      child = child.child;
-      assert.equal(child.getAttribute('attr'), 'child-attr');
-      assert.equal(child.prop, 'child-prop');
-      assert.equal(child.textContent?.trim(), 'child-node');
-    };
+      teardown(() => {
+        if (host.isConnected) {
+          container.removeChild(host);
+        }
+      });
 
-    setup(() => {
-      log.length = 0;
-      host = new Host();
-    });
+      test('directives render on connection', async () => {
+        container.appendChild(host);
+        await nextFrame();
+        assertRendering(host);
+        assert.deepEqual(log, [
+          'render-host-attr',
+          'render-host-prop',
+          'render-host-node',
+          'render-child-attr',
+          'render-child-prop',
+          'render-child-node',
+        ]);
+      });
 
-    teardown(() => {
-      if (host.isConnected) {
+      test('directives disconnect on disconnection', async () => {
+        container.appendChild(host);
+        await nextFrame();
+        assertRendering(host);
+        log.length = 0;
         container.removeChild(host);
-      }
-    });
+        assertRendering(host);
+        // Note: directive disconnection/reconnection is synchronous to
+        // connected/disconnectedCallback
+        assert.deepEqual(log, [
+          'disconnect-host-attr',
+          'disconnect-host-prop',
+          'disconnect-host-node',
+          'disconnect-child-attr',
+          'disconnect-child-prop',
+          'disconnect-child-node',
+        ]);
+      });
 
-    test('directives render on connection', async () => {
-      container.appendChild(host);
-      await nextFrame();
-      assertRendering(host);
-      assert.deepEqual(log, [
-        'render-host-attr',
-        'render-host-prop',
-        'render-host-node',
-        'render-child-attr',
-        'render-child-prop',
-        'render-child-node',
-      ]);
-    });
+      test('directives reconnect on reconnection', async () => {
+        container.appendChild(host);
+        await nextFrame();
+        assertRendering(host);
+        container.removeChild(host);
+        log.length = 0;
+        container.appendChild(host);
+        assertRendering(host);
+        assert.deepEqual(log, [
+          'reconnect-host-attr',
+          'reconnect-host-prop',
+          'reconnect-host-node',
+          'reconnect-child-attr',
+          'reconnect-child-prop',
+          'reconnect-child-node',
+        ]);
+      });
 
-    test('directives disconnect on disconnection', async () => {
-      container.appendChild(host);
-      await nextFrame();
-      assertRendering(host);
-      log.length = 0;
-      container.removeChild(host);
-      assertRendering(host);
-      // Note: directive disconnection/reconnection is synchronous to
-      // connected/disconnectedCallback
-      assert.deepEqual(log, [
-        'disconnect-host-attr',
-        'disconnect-host-prop',
-        'disconnect-host-node',
-        'disconnect-child-attr',
-        'disconnect-child-prop',
-        'disconnect-child-node',
-      ]);
-    });
+      test('directives reconnect on reconnection', async () => {
+        container.appendChild(host);
+        await nextFrame();
+        assertRendering(host);
+        container.removeChild(host);
+        await nextFrame();
+        log.length = 0;
+        container.appendChild(host);
+        await nextFrame();
+        assertRendering(host);
+        assert.deepEqual(log, [
+          'reconnect-host-attr',
+          'reconnect-host-prop',
+          'reconnect-host-node',
+          'reconnect-child-attr',
+          'reconnect-child-prop',
+          'reconnect-child-node',
+        ]);
+      });
 
-    test('directives reconnect on reconnection', async () => {
-      container.appendChild(host);
-      await nextFrame();
-      assertRendering(host);
-      container.removeChild(host);
-      log.length = 0;
-      container.appendChild(host);
-      assertRendering(host);
-      assert.deepEqual(log, [
-        'reconnect-host-attr',
-        'reconnect-host-prop',
-        'reconnect-host-node',
-        'reconnect-child-attr',
-        'reconnect-child-prop',
-        'reconnect-child-node',
-      ]);
-    });
-
-    test('directives reconnect on reconnection', async () => {
-      container.appendChild(host);
-      await nextFrame();
-      assertRendering(host);
-      container.removeChild(host);
-      await nextFrame();
-      log.length = 0;
-      container.appendChild(host);
-      await nextFrame();
-      assertRendering(host);
-      assert.deepEqual(log, [
-        'reconnect-host-attr',
-        'reconnect-host-prop',
-        'reconnect-host-node',
-        'reconnect-child-attr',
-        'reconnect-child-prop',
-        'reconnect-child-node',
-      ]);
-    });
-
-    test('directives reconnect and render on reconnection with pending render', async () => {
-      container.appendChild(host);
-      await nextFrame();
-      assertRendering(host);
-      container.removeChild(host);
-      log.length = 0;
-      host.requestUpdate();
-      host.child.requestUpdate();
-      container.appendChild(host);
-      assertRendering(host);
-      assert.deepEqual(log, [
-        'reconnect-host-attr',
-        'reconnect-host-prop',
-        'reconnect-host-node',
-        'reconnect-child-attr',
-        'reconnect-child-prop',
-        'reconnect-child-node',
-      ]);
-      log.length = 0;
-      await nextFrame();
-      assertRendering(host);
-      assert.deepEqual(log, [
-        'render-host-attr',
-        'render-host-prop',
-        'render-host-node',
-        'render-child-attr',
-        'render-child-prop',
-        'render-child-node',
-      ]);
+      test('directives reconnect and render on reconnection with pending render', async () => {
+        container.appendChild(host);
+        await nextFrame();
+        assertRendering(host);
+        container.removeChild(host);
+        log.length = 0;
+        host.requestUpdate();
+        host.child.requestUpdate();
+        container.appendChild(host);
+        assertRendering(host);
+        assert.deepEqual(log, [
+          'reconnect-host-attr',
+          'reconnect-host-prop',
+          'reconnect-host-node',
+          'reconnect-child-attr',
+          'reconnect-child-prop',
+          'reconnect-child-node',
+        ]);
+        log.length = 0;
+        await nextFrame();
+        assertRendering(host);
+        assert.deepEqual(log, [
+          'render-host-attr',
+          'render-host-prop',
+          'render-host-node',
+          'render-child-attr',
+          'render-child-prop',
+          'render-child-node',
+        ]);
+      });
     });
   });
 
@@ -598,5 +603,109 @@ import {createRef, ref} from 'lit-html/directives/ref.js';
     assert.equal(host.el, host.child.trueDiv);
     assert.equal(host.elRef.value, host.child.trueDiv);
     assert.equal(host.count, 3);
+  });
+
+  test('directive as controller can be added/removed via connect/disconnect', async () => {
+    const log: string[] = [];
+    const controllerDirective = directive(
+      class extends DisconnectableDirective {
+        part?: Part;
+        host?: Host;
+        private _controller?: ReactiveController;
+
+        render() {
+          log.push(`render-${this.host!.x}`);
+          return nothing;
+        }
+        ensureHost() {
+          if (this.host === undefined) {
+            this.host = this.part!.options!.host as Host;
+            // eslint-disable-next-line @typescript-eslint/no-this-alias
+            const self = this;
+            this.host.addController(
+              (this._controller = {
+                willUpdate() {
+                  log.push(`willUpdate-${self.host?.x}`);
+                },
+                updated() {
+                  log.push(`updated-${self.host!.x}`);
+                },
+              })
+            );
+          }
+        }
+        update(part: Part) {
+          if (this.part === undefined) {
+            this.part = part;
+          }
+          this.ensureHost();
+          this.render();
+        }
+        disconnected() {
+          this.host?.removeController(this._controller!);
+          this.host = undefined;
+        }
+        reconnected() {
+          this.ensureHost();
+        }
+      }
+    );
+
+    class Host extends LitElement {
+      static properties = {
+        bool: {},
+        x: {},
+      };
+      bool: boolean;
+      x: number;
+
+      constructor() {
+        super();
+        this.bool = true;
+        this.x = 0;
+      }
+      render() {
+        return html` ${this.bool
+          ? html`<div ${controllerDirective()}></div>`
+          : nothing}`;
+      }
+    }
+    customElements.define('controller-host', Host);
+
+    const host = container.appendChild(new Host());
+    await host.updateComplete;
+    assert.deepEqual(log, [`render-${host.x}`, `updated-${host.x}`]);
+    log.length = 0;
+    host.x = 1;
+    await host.updateComplete;
+    assert.deepEqual(log, [
+      `willUpdate-${host.x}`,
+      `render-${host.x}`,
+      `updated-${host.x}`,
+    ]);
+    log.length = 0;
+    // disconnects directive
+    host.bool = false;
+    await host.updateComplete;
+    assert.deepEqual(log, [`willUpdate-${host.x}`]);
+    log.length = 0;
+    // reconnects directive
+    host.bool = true;
+    await host.updateComplete;
+    assert.deepEqual(log, [`render-${host.x}`, `updated-${host.x}`]);
+    // disconnects directive
+    log.length = 0;
+    host.bool = false;
+    await host.updateComplete;
+    assert.deepEqual(log, [`willUpdate-${host.x}`]);
+    log.length = 0;
+    // render while directive is disconnected
+    host.x = 2;
+    await host.updateComplete;
+    assert.deepEqual(log, []);
+    // reconnects directive
+    host.bool = true;
+    await host.updateComplete;
+    assert.deepEqual(log, [`render-${host.x}`, `updated-${host.x}`]);
   });
 });

--- a/packages/lit-element/src/test/lit-element_test.ts
+++ b/packages/lit-element/src/test/lit-element_test.ts
@@ -639,7 +639,7 @@ import {ReactiveController} from '@lit/reactive-element';
             this.part = part;
           }
           this.ensureHost();
-          this.render();
+          return this.render();
         }
         disconnected() {
           this.host?.removeController(this._controller!);

--- a/packages/reactive-element/CHANGELOG.md
+++ b/packages/reactive-element/CHANGELOG.md
@@ -19,6 +19,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+### Added
+
+- Added `removeController(controller)` which can be used to remove a controller from a `ReactiveElement`.
+
 ### Changed
 
 - (Since 1.0.0-pre.1) Renamed `Controller`'s `dis/connectedCallback` methods.

--- a/packages/reactive-element/src/reactive-controller.ts
+++ b/packages/reactive-element/src/reactive-controller.ts
@@ -24,6 +24,11 @@ export interface ReactiveControllerHost {
   addController(controller: ReactiveController): void;
 
   /**
+   * Removes a controller from the host.
+   */
+  removeController(controller: ReactiveController): void;
+
+  /**
    * Requests a host update which is processed asynchronously. The update can
    * be waited on via the `updateComplete` property.
    */

--- a/packages/reactive-element/src/reactive-element.ts
+++ b/packages/reactive-element/src/reactive-element.ts
@@ -668,6 +668,12 @@ export abstract class ReactiveElement
     (this.__controllers ??= []).push(controller);
   }
 
+  removeController(controller: ReactiveController) {
+    if (this.__controllers !== undefined) {
+      this.__controllers = this.__controllers?.filter((c) => c !== controller);
+    }
+  }
+
   /**
    * Fixes any properties set on the instance before upgrade time.
    * Otherwise these would shadow the accessor and break these properties.

--- a/packages/reactive-element/src/reactive-element.ts
+++ b/packages/reactive-element/src/reactive-element.ts
@@ -669,9 +669,9 @@ export abstract class ReactiveElement
   }
 
   removeController(controller: ReactiveController) {
-    if (this.__controllers !== undefined) {
-      this.__controllers = this.__controllers?.filter((c) => c !== controller);
-    }
+    // Note, if the indexOf is -1, the >>> will flip the sign which makes the
+    // splice do nothing.
+    this.__controllers?.splice(this.__controllers.indexOf(controller) >>> 0, 1);
   }
 
   /**

--- a/packages/reactive-element/src/test/reactive-element-controllers_test.ts
+++ b/packages/reactive-element/src/test/reactive-element-controllers_test.ts
@@ -150,6 +150,23 @@ suite('ReactiveElement controllers', () => {
     assert.equal(el.controller.updatedCount, 2);
   });
 
+  test('controllers can be removed', async () => {
+    assert.equal(el.controller.connectedCount, 1);
+    assert.equal(el.controller.disconnectedCount, 0);
+    assert.equal(el.controller.willUpdateCount, 1);
+    assert.equal(el.controller.updateCount, 1);
+    assert.equal(el.controller.updatedCount, 1);
+    el.removeController(el.controller);
+    el.foo = 'new';
+    await el.updateComplete;
+    el.remove();
+    assert.equal(el.controller.connectedCount, 1);
+    assert.equal(el.controller.disconnectedCount, 0);
+    assert.equal(el.controller.willUpdateCount, 1);
+    assert.equal(el.controller.updateCount, 1);
+    assert.equal(el.controller.updatedCount, 1);
+  });
+
   test('controllers callback order', async () => {
     assert.deepEqual(el.controller.callbackOrder, [
       'connectedCallback',


### PR DESCRIPTION
Fixes #1539. Note, please review with `w=1` option to ignore whitespace changes.

* added to `ReactiveController` interface
* implemented in `ReactiveElement`
* also adds a test to `LitElement` for a controller directive