### PR TITLE
[lit-next] Fix builds by removing `.tsbuildinfo` files

### DIFF
--- a/packages/labs/package.json
+++ b/packages/labs/package.json
@@ -44,7 +44,7 @@
   ],
   "scripts": {
     "build": "npm run clean && tsc --build && rollup -c",
-    "clean": "rm -rf index.{js,js.map,d.ts} development/ controllers/ frameworks/",
+    "clean": "rm -rf index.{js,js.map,d.ts} development/ controllers/ frameworks/ tsconfig.tsbuildinfo",
     "dev": "scripts/dev.sh",
     "build:ts": "tsc --build",
     "build:ts:watch": "tsc --build --watch",

--- a/packages/lit-element/package.json
+++ b/packages/lit-element/package.json
@@ -47,7 +47,7 @@
     "build:ts:watch": "tsc --build --watch",
     "check-version": "node scripts/check-version-tracker.js",
     "checksize": "rollup -c --environment=CHECKSIZE",
-    "clean": "rm -rf index.{js,js.map,d.ts} lit-element.{js,js.map,d.ts} decorators.{js,js.map,d.ts} polyfill-support.{js,js.map,d.ts} hydrate-support.{js,js.map,d.ts} decorators/ development/",
+    "clean": "rm -rf index.{js,js.map,d.ts} lit-element.{js,js.map,d.ts} decorators.{js,js.map,d.ts} polyfill-support.{js,js.map,d.ts} hydrate-support.{js,js.map,d.ts} decorators/ development/ tsconfig.tsbuildinfo",
     "dev": "scripts/dev.sh",
     "prepublishOnly": "npm run check-version",
     "publish-dev": "npm test && VERSION=${npm_package_version%-*}-dev.`git rev-parse --short HEAD` && npm version --no-git-tag-version $VERSION && npm publish --tag dev",

--- a/packages/lit-html/package.json
+++ b/packages/lit-html/package.json
@@ -49,7 +49,7 @@
     "build:ts:watch": "tsc --build --watch",
     "check-version": "node scripts/check-version-tracker.js",
     "checksize": "rollup -c --environment=CHECKSIZE",
-    "clean": "rm -rf lit-html.{js,js.map,d.ts} polyfill-support.{js,js.map,d.ts} directive.{js,js.map,d.ts} directive-helpers.{js,js.map,d.ts} disconnectable-directive.{js,js.map,d.ts} hydrate.{js,js.map,d.ts} private-ssr-support.{js,js.map,d.ts} directives/ development/",
+    "clean": "rm -rf lit-html.{js,js.map,d.ts} polyfill-support.{js,js.map,d.ts} directive.{js,js.map,d.ts} directive-helpers.{js,js.map,d.ts} disconnectable-directive.{js,js.map,d.ts} hydrate.{js,js.map,d.ts} private-ssr-support.{js,js.map,d.ts} directives/ development/ tsconfig.tsbuildinfo",
     "dev": "scripts/dev.sh",
     "prepublishOnly": "npm run check-version",
     "test": "npm run test:dev && npm run test:prod",

--- a/packages/lit/package.json
+++ b/packages/lit/package.json
@@ -55,7 +55,7 @@
     "build:watch": "rollup -c --watch",
     "build:ts": "tsc",
     "build:ts:watch": "tsc --watch",
-    "clean": "rm -rf decorators.{d.ts.map,d.ts,js.map,js} decorators/ directive-helpers.{d.ts.map,d.ts,js.map,js} directive.{d.ts.map,d.ts,js.map,js} directives/ disconnectable-directive.{d.ts.map,d.ts,js.map,js} html.{d.ts.map,d.ts,js.map,js} hydrate-support.{d.ts.map,d.ts,js.map,js} hydrate.{d.ts.map,d.ts,js.map,js} index.{d.ts.map,d.ts,js.map,js} lit.min.{js,js.map,d.ts} polyfill-support.{d.ts.map,d.ts,js.map,js} static-html.{d.ts.map,d.ts,js.map,js}",
+    "clean": "rm -rf decorators.{d.ts.map,d.ts,js.map,js} decorators/ directive-helpers.{d.ts.map,d.ts,js.map,js} directive.{d.ts.map,d.ts,js.map,js} directives/ disconnectable-directive.{d.ts.map,d.ts,js.map,js} html.{d.ts.map,d.ts,js.map,js} hydrate-support.{d.ts.map,d.ts,js.map,js} hydrate.{d.ts.map,d.ts,js.map,js} index.{d.ts.map,d.ts,js.map,js} lit.min.{js,js.map,d.ts} polyfill-support.{d.ts.map,d.ts,js.map,js} static-html.{d.ts.map,d.ts,js.map,js} tsconfig.tsbuildinfo",
     "publish-dev": "VERSION=${npm_package_version%-*}-dev.`git rev-parse --short HEAD` && npm version --no-git-tag-version $VERSION && npm publish --tag dev",
     "regen-package-lock": "rm -rf node_modules package-lock.json; npm install",
     "test": "MODE=prod cd ../tests && npx wtr '../lit/test/**/*_test.(js|html)'"

--- a/packages/reactive-element/package.json
+++ b/packages/reactive-element/package.json
@@ -41,7 +41,7 @@
     "build:ts:watch": "tsc --build --watch",
     "check-version": "node scripts/check-version-tracker.js",
     "checksize": "rollup -c --environment=CHECKSIZE",
-    "clean": "rm -rf reactive-element.{js,js.map,d.ts} decorators.{js,js.map,d.ts} css-tag.{js,js.map,d.ts} polyfill-support.{js,js.map,d.ts} decorators/ development/",
+    "clean": "rm -rf reactive-element.{js,js.map,d.ts} decorators.{js,js.map,d.ts} css-tag.{js,js.map,d.ts} polyfill-support.{js,js.map,d.ts} decorators/ development/ tsconfig.tsbuildinfo",
     "dev": "scripts/dev.sh",
     "prepublishOnly": "npm run check-version",
     "publish-dev": "npm test && VERSION=${npm_package_version%-*}-dev.`git rev-parse --short HEAD` && npm version --no-git-tag-version $VERSION && npm publish --tag dev",


### PR DESCRIPTION
Removes the `tsconfig.tsbuildinfo` when doing `clean`. This makes repeated builds work correctly.