### PR TITLE
More minor compilability improvements.

### DIFF
--- a/packages/lit-element/src/hydrate-support.ts
+++ b/packages/lit-element/src/hydrate-support.ts
@@ -19,13 +19,16 @@
  */
 
 import {PropertyValues, ReactiveElement} from '@lit/reactive-element';
-import {render} from 'lit-html';
+import {render, RenderOptions} from 'lit-html';
 import {hydrate} from 'lit-html/hydrate.js';
 
 interface PatchableLitElement extends HTMLElement {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-misused-new
   new (...args: any[]): PatchableLitElement;
   createRenderRoot(): Element | ShadowRoot;
+  renderRoot: Element | ShadowRoot;
+  render(): unknown;
+  _$renderOptions: RenderOptions;
   _$needsHydration: boolean;
 }
 
@@ -37,7 +40,7 @@ interface PatchableLitElement extends HTMLElement {
 }) => {
   // Capture whether we need hydration or not
   const createRenderRoot = LitElement.prototype.createRenderRoot;
-  LitElement.prototype.createRenderRoot = function () {
+  LitElement.prototype.createRenderRoot = function (this: PatchableLitElement) {
     if (this.shadowRoot) {
       this._$needsHydration = true;
       return this.shadowRoot;
@@ -47,7 +50,7 @@ interface PatchableLitElement extends HTMLElement {
   };
 
   // Hydrate on first update when needed
-  LitElement.prototype.update = function (changedProperties: PropertyValues) {
+  LitElement.prototype.update = function (this: PatchableLitElement, changedProperties: PropertyValues) {
     const value = this.render();
     // Since this is a patch, we can't call super.update()
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -56,7 +59,7 @@ interface PatchableLitElement extends HTMLElement {
       this._$needsHydration = false;
       hydrate(value, this.renderRoot, this._$renderOptions);
     } else {
-      render(value, this.renderRoot, this._$renderOptions);
+      render(value, this.renderRoot as HTMLElement, this._$renderOptions);
     }
   };
 };

--- a/packages/reactive-element/src/polyfill-support.ts
+++ b/packages/reactive-element/src/polyfill-support.ts
@@ -11,6 +11,7 @@
  * subject to an additional IP rights grant found at
  * http://polymer.github.io/PATENTS.txt
  */
+
 /**
  * ReactiveElement patch to support browsers without native web components.
  *

--- a/packages/reactive-element/src/reactive-element.ts
+++ b/packages/reactive-element/src/reactive-element.ts
@@ -298,8 +298,11 @@ export abstract class ReactiveElement
   extends HTMLElement
   implements ReactiveControllerHost {
   // Note, these are patched in only in DEV_MODE.
+  /** @nocollapse */
   static enabledWarnings?: Warnings[];
+  /** @nocollapse */
   static enableWarning?: (type: Warnings) => void;
+  /** @nocollapse */
   static disableWarning?: (type: Warnings) => void;
   /*
    * Due to closure compiler ES6 compilation bugs, @nocollapse is required on
@@ -311,6 +314,7 @@ export abstract class ReactiveElement
    * Maps attribute names to properties; for example `foobar` attribute to
    * `fooBar` property. Created lazily on user subclasses when finalizing the
    * class.
+   * @nocollapse
    */
   private static __attributeToPropertyMap: AttributeMap;
 
@@ -322,6 +326,7 @@ export abstract class ReactiveElement
   /**
    * Memoized list of all element properties, including any superclass properties.
    * Created lazily on user subclasses when finalizing the class.
+   * @nocollapse
    */
   static elementProperties?: PropertyDeclarationMap;
 
@@ -347,18 +352,21 @@ export abstract class ReactiveElement
    * private property set with the `state: true` option should be used. When
    * needed, state properties can be initialized via public properties to
    * facilitate complex interactions.
+   * @nocollapse
    */
   static properties: PropertyDeclarations;
 
   /**
    * Memoized list of all element styles.
    * Created lazily on user subclasses when finalizing the class.
+   * @nocollapse
    */
   static elementStyles?: CSSResultFlatArray;
 
   /**
    * Array of styles to apply to the element. The styles should be defined
    * using the [[`css`]] tag function or via constructible stylesheets.
+   * @nocollapse
    */
   static styles?: CSSResultGroup;
 
@@ -563,6 +571,7 @@ export abstract class ReactiveElement
    *
    * Note, these options are used in `createRenderRoot`. If this method
    * is customized, options should be respected if possible.
+   * @nocollapse
    */
   static shadowRootOptions: ShadowRootInit = {mode: 'open'};
 
@@ -864,7 +873,7 @@ export abstract class ReactiveElement
     name?: PropertyKey,
     oldValue?: unknown,
     options?: PropertyDeclaration
-  ) {
+  ): void {
     let shouldRequestUpdate = true;
     // If we have a property key, perform property update steps.
     if (name !== undefined) {
@@ -896,7 +905,7 @@ export abstract class ReactiveElement
     }
     // Note, since this no longer returns a promise, in dev mode we return a
     // thenable which warns if it's called.
-    return DEV_MODE ? requestUpdateThenable : undefined;
+    return DEV_MODE ? requestUpdateThenable as unknown as void : undefined;
   }
 
   /**
@@ -1151,13 +1160,13 @@ if (DEV_MODE) {
       ctor.enabledWarnings = ctor.enabledWarnings!.slice();
     }
   };
-  ReactiveElement.enableWarning = function (warning: Warnings) {
+  ReactiveElement.enableWarning = function (this: typeof ReactiveElement, warning: Warnings) {
     ensureOwnWarnings(this);
     if (this.enabledWarnings!.indexOf(warning) < 0) {
       this.enabledWarnings!.push(warning);
     }
   };
-  ReactiveElement.disableWarning = function (warning: Warnings) {
+  ReactiveElement.disableWarning = function (this: typeof ReactiveElement, warning: Warnings) {
     ensureOwnWarnings(this);
     const i = this.enabledWarnings!.indexOf(warning);
     if (i >= 0) {


### PR DESCRIPTION
`this` must always be typed.

static fields must be `@nocollapse` to behave per spec

requestUpdate logically returns a void, even if in dev mode we return an object that warns if you try to use it as a promise

the first comment in a file must be followed with two newlines before another comment may begin (yes this is silly, but 🤷‍♂️)