### PR TITLE
Fix for bindings before end of self-closing tags

### DIFF
--- a/packages/lit-html/src/lit-html.ts
+++ b/packages/lit-html/src/lit-html.ts
@@ -495,8 +495,10 @@ const getTemplateHtml = (
     //     position (attrNameEndIndex === -2), add a sequential suffix to
     //     generate a unique attribute name.
 
-    // detect a binding next to self-closing tag end
-    const end = strings[i + 1].startsWith('/>') ? ' ' : '';
+    // Detect a binding next to self-closing tag end and insert a space to
+    // separate the marker from the tag end:
+    const end =
+      regex === tagEndRegex && strings[i + 1].startsWith('/>') ? ' ' : '';
     html +=
       regex === textEndRegex
         ? s + nodeMarker

--- a/packages/lit-html/src/lit-html.ts
+++ b/packages/lit-html/src/lit-html.ts
@@ -494,6 +494,9 @@ const getTemplateHtml = (
     //  4. We're somewhere else inside the tag. If we're in attribute name
     //     position (attrNameEndIndex === -2), add a sequential suffix to
     //     generate a unique attribute name.
+
+    // detect a binding next to self-closing tag end
+    const end = strings[i + 1].startsWith('/>') ? ' ' : '';
     html +=
       regex === textEndRegex
         ? s + nodeMarker
@@ -501,10 +504,12 @@ const getTemplateHtml = (
         ? (attrNames.push(attrName!),
           s.slice(0, attrNameEndIndex) +
             boundAttributeSuffix +
-            s.slice(attrNameEndIndex)) + marker
+            s.slice(attrNameEndIndex)) +
+          marker +
+          end
         : s +
           marker +
-          (attrNameEndIndex === -2 ? (attrNames.push(undefined), i) : '');
+          (attrNameEndIndex === -2 ? (attrNames.push(undefined), i) : end);
   }
 
   // Returned as an array for terseness

--- a/packages/lit-html/src/test/lit-html_test.ts
+++ b/packages/lit-html/src/test/lit-html_test.ts
@@ -280,6 +280,7 @@ suite('lit-html', () => {
       assertRender(html`<div a="${'A'}"></div>`, '<div a="A"></div>');
       assertRender(html`<div abc="${'A'}"></div>`, '<div abc="A"></div>');
       assertRender(html`<div abc = "${'A'}"></div>`, '<div abc="A"></div>');
+      assertRender(html`<div abc="${'A'}/>"></div>`, '<div abc="A/>"></div>');
       assertRender(html`<input value="${'A'}"/>`, '<input value="A">');
     });
 

--- a/packages/lit-html/src/test/lit-html_test.ts
+++ b/packages/lit-html/src/test/lit-html_test.ts
@@ -272,12 +272,15 @@ suite('lit-html', () => {
       assertRender(html`<div a=${'A'}></div>`, '<div a="A"></div>');
       assertRender(html`<div abc=${'A'}></div>`, '<div abc="A"></div>');
       assertRender(html`<div abc = ${'A'}></div>`, '<div abc="A"></div>');
+      assertRender(html`<input value=${'A'}/>`, '<input value="A">');
+      assertRender(html`<input value=${'A'}${'B'}/>`, '<input value="AB">');
     });
 
     test('quoted attribute', () => {
       assertRender(html`<div a="${'A'}"></div>`, '<div a="A"></div>');
       assertRender(html`<div abc="${'A'}"></div>`, '<div abc="A"></div>');
       assertRender(html`<div abc = "${'A'}"></div>`, '<div abc="A"></div>');
+      assertRender(html`<input value="${'A'}"/>`, '<input value="A">');
     });
 
     test('second quoted attribute', () => {
@@ -1137,6 +1140,18 @@ suite('lit-html', () => {
       assert.equal(count, 1);
     });
 
+    test('adds event listeners on self-closing tags', () => {
+      let count = 0;
+      const listener = () => {
+        count++;
+      };
+      render(html`<div @click=${listener}/></div>`, container);
+
+      const div = container.querySelector('div')!;
+      div.click();
+      assert.equal(count, 1);
+    });
+
     test('allows updating event listener', () => {
       let count1 = 0;
       const listener1 = () => {
@@ -1580,33 +1595,34 @@ suite('lit-html', () => {
 
     test('renders directives on ElementParts', () => {
       const log: string[] = [];
-      assertRender(html`<div ${count('x', log)}}></div>`, `<div></div>`);
+      assertRender(html`<div ${count('x', log)}></div>`, `<div></div>`);
       assert.deepEqual(log, ['x:1']);
 
       log.length = 0;
       assertRender(
-        html`<div a=${'a'} ${count('x', log)}}></div>`,
+        // Purposefully adds a self-closing tag slash
+        html`<div a=${'a'} ${count('x', log)}/></div>`,
         `<div a="a"></div>`
       );
       assert.deepEqual(log, ['x:1']);
 
       log.length = 0;
       assertRender(
-        html`<div ${count('x', log)}} a=${'a'}></div>`,
+        html`<div ${count('x', log)} a=${'a'}></div>`,
         `<div a="a"></div>`
       );
       assert.deepEqual(log, ['x:1']);
 
       log.length = 0;
       assertRender(
-        html`<div a=${'a'} ${count('x', log)}} b=${'b'}></div>`,
+        html`<div a=${'a'} ${count('x', log)} b=${'b'}></div>`,
         `<div a="a" b="b"></div>`
       );
       assert.deepEqual(log, ['x:1']);
 
       log.length = 0;
       assertRender(
-        html`<div ${count('x', log)} ${count('y', log)}}></div>`,
+        html`<div ${count('x', log)} ${count('y', log)}></div>`,
         `<div></div>`
       );
       assert.deepEqual(log, ['x:1', 'y:1']);
@@ -1615,7 +1631,7 @@ suite('lit-html', () => {
       const template = html`<div ${count('x', log)} a=${'a'} ${count(
         'y',
         log
-      )}}></div>`;
+      )}></div>`;
       assertRender(template, `<div a="a"></div>`);
       assert.deepEqual(log, ['x:1', 'y:1']);
       log.length = 0;

--- a/packages/tests/web-test-runner.config.js
+++ b/packages/tests/web-test-runner.config.js
@@ -22,7 +22,11 @@ if (mode === 'prod') {
 
 const browserPresets = {
   // Default set of Playwright browsers to test when running locally.
-  local: ['chromium', 'firefox', 'webkit'],
+  local: [
+    'chromium', // keep browsers on separate lines
+    'firefox', // to make it easier to comment out
+    'webkit', // individual browsers
+  ],
 
   // Browsers to test during automated continuous integration.
   //


### PR DESCRIPTION
Fixes #1594 and adds support for bindings like:

```ts
html`<input .value=${v}/>`
```