### PR TITLE
Add newline after license comment

### DIFF
--- a/packages/lit-element/src/polyfill-support.ts
+++ b/packages/lit-element/src/polyfill-support.ts
@@ -11,6 +11,7 @@
  * subject to an additional IP rights grant found at
  * http://polymer.github.io/PATENTS.txt
  */
+
 /**
  * LitElement patch to support browsers without native web components.
  *


### PR DESCRIPTION
Internal tooling needs this. Yes this is silly.