### PR TITLE
[lit-ssr] Fix usage of non-stable properties in private-ssr-support

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -81,6 +81,7 @@ packages/lit-ssr/lib/
 packages/lit-ssr/node_modules/
 packages/lit-ssr/test/
 packages/lit-ssr/index.*
+packages/lit-ssr/**/*.d.ts
 
 packages/lit-starter-ts/node_modules/
 packages/lit-starter-ts/lib/

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -37,7 +37,7 @@ jobs:
             ${{ env.PLAYWRIGHT_BROWSERS_PATH }}
           # Bump the number after `lit-node-modules` to force a cache update
           # Note there are 2 cache actions in `tests.yml` that should all keep keys in sync
-          key: lit-node-modules-0-${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
+          key: lit-node-modules-1-${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
 
       - name: NPM install
         if: steps.cache.outputs.cache-hit != 'true'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,7 +46,7 @@ jobs:
           # Bump the number after `lit-node-modules` to force a cache update
           # Note there are cache actions in below in `tests-sauce` and in `benchmarks.yml`
           # that should all keep keys in sync
-          key: lit-node-modules-0-${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
+          key: lit-node-modules-1-${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
 
       # Installs system dependencies needed for playwright. Not sure how to
       # cache this.
@@ -106,7 +106,7 @@ jobs:
           # Bump the number after `lit-node-modules` to force a cache update
           # Note there are cache actions in above in `tests-local` and in `benchmarks.yml`
           # that should all keep keys in sync
-          key: lit-node-modules-0-${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
+          key: lit-node-modules-1-${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
 
       # Installs system dependencies needed for playwright. Not sure how to
       # cache this.

--- a/.prettierignore
+++ b/.prettierignore
@@ -81,6 +81,7 @@ packages/lit-ssr/lib/
 packages/lit-ssr/node_modules/
 packages/lit-ssr/test/
 packages/lit-ssr/index.*
+packages/lit-ssr/**/*.d.ts
 
 packages/lit-starter-ts/node_modules/
 packages/lit-starter-ts/lib/

--- a/.vscode/terminals.json
+++ b/.vscode/terminals.json
@@ -20,6 +20,12 @@
       "command": "npm run build:ts:watch"
     },
     {
+      "name": "TS: lit",
+      "icon": "checklist",
+      "cwd": "[workspaceFolder]/packages/lit",
+      "command": "npm run build:ts:watch"
+    },
+    {
       "name": "TS: lit-ssr",
       "icon": "checklist",
       "cwd": "[workspaceFolder]/packages/lit-ssr",
@@ -42,6 +48,12 @@
       "name": "Rollup: lit-element",
       "icon": "checklist",
       "cwd": "[workspaceFolder]/packages/lit-element",
+      "command": "npm run build:watch"
+    },
+    {
+      "name": "Rollup: lit",
+      "icon": "checklist",
+      "cwd": "[workspaceFolder]/packages/lit",
       "command": "npm run build:watch"
     }
   ]

--- a/packages/lit-html/CHANGELOG.md
+++ b/packages/lit-html/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 #### Changed
 
+- (Since 2.0.0-pre.4) Removes second `klass` argument from `isDirectiveResult` since it is generally not version-agnostic to test directives using `instanceof`. A new `classForDirectiveResult` helper is introduced, which allows for e.g. directive class branding checks instead.
 - (Since 2.0.0-pre.4) `DisconnectableDirective` was renamed to `AsyncDirective`, and its module name was renamed from `disconnectable-directive` to `async-directive`.
 - (Since 2.0.0-pre.4) Rendering `null`, `undefined`, or empty string in a `ChildPart` now has the same affect as rendering `nothing`: it does not produce an empty text node. When rendering into an element with Shadow DOM, this makes it harder to inadvertently prevent `<slot>` fallback content from rendering.
 - (Since 2.0.0-pre.4) `DisconnectableDirective`'s `disconnectedCallback` and `reconnectedCallback` were renamed to `disconnected` and `reconnected`.

--- a/packages/lit-html/CHANGELOG.md
+++ b/packages/lit-html/CHANGELOG.md
@@ -28,7 +28,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 #### Changed
 
-- (Since 2.0.0-pre.4) Removes second `klass` argument from `isDirectiveResult` since it is generally not version-agnostic to test directives using `instanceof`. A new `classForDirectiveResult` helper is introduced, which allows for e.g. directive class branding checks instead.
+- (Since 2.0.0-pre.4) Removes second `klass` argument from `isDirectiveResult` since it is generally not version-agnostic to test directives using `instanceof`. A new `getDirectiveClass` helper is introduced, which allows for directive class branding checks instead.
 - (Since 2.0.0-pre.4) `DisconnectableDirective` was renamed to `AsyncDirective`, and its module name was renamed from `disconnectable-directive` to `async-directive`.
 - (Since 2.0.0-pre.4) Rendering `null`, `undefined`, or empty string in a `ChildPart` now has the same affect as rendering `nothing`: it does not produce an empty text node. When rendering into an element with Shadow DOM, this makes it harder to inadvertently prevent `<slot>` fallback content from rendering.
 - (Since 2.0.0-pre.4) `DisconnectableDirective`'s `disconnectedCallback` and `reconnectedCallback` were renamed to `disconnected` and `reconnected`.

--- a/packages/lit-html/src/async-directive.ts
+++ b/packages/lit-html/src/async-directive.ts
@@ -130,6 +130,7 @@ import {
   ChildPart,
   Disconnectable,
   noChange,
+  Part,
 } from './lit-html.js';
 import {isSingleExpression} from './directive-helpers.js';
 import {Directive, PartInfo, PartType} from './directive.js';
@@ -356,14 +357,14 @@ export abstract class AsyncDirective extends Directive {
    * @override
    * @internal
    */
-  _$resolve(props: Array<unknown>): unknown {
+  _$resolve(part: Part, props: Array<unknown>): unknown {
     if (!this.isConnected) {
       throw new Error(
         `AsyncDirective ${this.constructor.name} was ` +
           `rendered while its tree was disconnected.`
       );
     }
-    return super._$resolve(props);
+    return super._$resolve(part, props);
   }
 
   /**

--- a/packages/lit-html/src/async-directive.ts
+++ b/packages/lit-html/src/async-directive.ts
@@ -356,14 +356,14 @@ export abstract class AsyncDirective extends Directive {
    * @override
    * @internal
    */
-  _resolve(props: Array<unknown>): unknown {
+  _$resolve(props: Array<unknown>): unknown {
     if (!this.isConnected) {
       throw new Error(
         `AsyncDirective ${this.constructor.name} was ` +
           `rendered while its tree was disconnected.`
       );
     }
-    return super._resolve(props);
+    return super._$resolve(props);
   }
 
   /**

--- a/packages/lit-html/src/directive-helpers.ts
+++ b/packages/lit-html/src/directive-helpers.ts
@@ -67,13 +67,15 @@ export const isTemplateResult = (
 /**
  * Tests if a value is a DirectiveResult.
  */
-export const isDirectiveResult = (
-  value: unknown,
-  klass?: DirectiveClass
-): value is DirectiveResult =>
-  klass === undefined
-    ? (value as DirectiveResult)?._$litDirective$ !== undefined
-    : (value as DirectiveResult)?._$litDirective$ === klass;
+export const isDirectiveResult = (value: unknown): value is DirectiveResult =>
+  (value as DirectiveResult)?._$litDirective$ !== undefined;
+
+/**
+ * Retrieves the Directive class for a DirectiveResult
+ */
+export const classForDirectiveResult = (
+  value: unknown
+): DirectiveClass | undefined => (value as DirectiveResult)?._$litDirective$;
 
 /**
  * Tests whether a part has only a single-expression with no strings to

--- a/packages/lit-html/src/directive-helpers.ts
+++ b/packages/lit-html/src/directive-helpers.ts
@@ -73,9 +73,8 @@ export const isDirectiveResult = (value: unknown): value is DirectiveResult =>
 /**
  * Retrieves the Directive class for a DirectiveResult
  */
-export const classForDirectiveResult = (
-  value: unknown
-): DirectiveClass | undefined => (value as DirectiveResult)?._$litDirective$;
+export const getDirectiveClass = (value: unknown): DirectiveClass | undefined =>
+  (value as DirectiveResult)?._$litDirective$;
 
 /**
  * Tests whether a part has only a single-expression with no strings to

--- a/packages/lit-html/src/directive.ts
+++ b/packages/lit-html/src/directive.ts
@@ -129,7 +129,7 @@ export abstract class Directive {
     this.__attributeIndex = partInfo._$attributeIndex;
   }
   /** @internal */
-  _resolve(props: Array<unknown>): unknown {
+  _$resolve(props: Array<unknown>): unknown {
     const {__part, __attributeIndex} = this;
     return resolveDirective(
       __part,

--- a/packages/lit-html/src/directive.ts
+++ b/packages/lit-html/src/directive.ts
@@ -13,15 +13,12 @@
  */
 
 import {
-  _Σ,
   AttributePart,
   Disconnectable,
   ChildPart,
   Part,
   ElementPart,
 } from './lit-html';
-
-const resolveDirective = _Σ._resolveDirective;
 
 export type DirectiveClass = {
   new (part: PartInfo): Directive;
@@ -108,7 +105,7 @@ export const directive = <C extends DirectiveClass>(c: C) => (
  */
 export abstract class Directive {
   //@internal
-  __part: ChildPart | AttributePart | ElementPart;
+  __part: Part;
   //@internal
   __attributeIndex: number | undefined;
   //@internal
@@ -129,14 +126,8 @@ export abstract class Directive {
     this.__attributeIndex = partInfo._$attributeIndex;
   }
   /** @internal */
-  _$resolve(props: Array<unknown>): unknown {
-    const {__part, __attributeIndex} = this;
-    return resolveDirective(
-      __part,
-      this.update(__part, props),
-      this,
-      __attributeIndex
-    );
+  _$resolve(part: Part, props: Array<unknown>): unknown {
+    return this.update(part, props);
   }
   abstract render(...props: Array<unknown>): unknown;
   update(_part: Part, props: Array<unknown>): unknown {

--- a/packages/lit-html/src/directives/render-light.ts
+++ b/packages/lit-html/src/directives/render-light.ts
@@ -14,13 +14,14 @@
 
 import {ChildPart} from '../lit-html.js';
 import {directive, Directive} from '../directive.js';
-import {isDirectiveResult} from '../directive-helpers.js';
+import {classForDirectiveResult} from '../directive-helpers.js';
 
 export interface RenderLightHost extends HTMLElement {
   renderLight(): unknown;
 }
 
 class RenderLight extends Directive {
+  static _$litRenderLight = true;
   render() {
     /* SSR handled specially in render-lit-html */
   }
@@ -119,4 +120,4 @@ class RenderLight extends Directive {
 export const renderLight = directive(RenderLight);
 
 export const isRenderLightDirective = (value: unknown): boolean =>
-  isDirectiveResult(value, RenderLight);
+  (classForDirectiveResult(value) as typeof RenderLight)?._$litRenderLight;

--- a/packages/lit-html/src/directives/render-light.ts
+++ b/packages/lit-html/src/directives/render-light.ts
@@ -14,7 +14,7 @@
 
 import {ChildPart} from '../lit-html.js';
 import {directive, Directive} from '../directive.js';
-import {classForDirectiveResult} from '../directive-helpers.js';
+import {getDirectiveClass} from '../directive-helpers.js';
 
 export interface RenderLightHost extends HTMLElement {
   renderLight(): unknown;
@@ -120,4 +120,4 @@ class RenderLight extends Directive {
 export const renderLight = directive(RenderLight);
 
 export const isRenderLightDirective = (value: unknown): boolean =>
-  (classForDirectiveResult(value) as typeof RenderLight)?._$litRenderLight;
+  (getDirectiveClass(value) as typeof RenderLight)?._$litRenderLight;

--- a/packages/lit-html/src/hydrate.ts
+++ b/packages/lit-html/src/hydrate.ts
@@ -12,8 +12,7 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-// Type-only imports
-import {TemplateResult} from './lit-html.js';
+import type {TemplateResult} from './lit-html.js';
 
 import {
   noChange,

--- a/packages/lit-html/src/lit-html.ts
+++ b/packages/lit-html/src/lit-html.ts
@@ -707,7 +707,12 @@ function resolveDirective(
     }
   }
   if (currentDirective !== undefined) {
-    value = currentDirective._$resolve((value as DirectiveResult).values);
+    value = resolveDirective(
+      part,
+      currentDirective._$resolve(part, (value as DirectiveResult).values),
+      currentDirective,
+      _$attributeIndex
+    );
   }
   return value;
 }

--- a/packages/lit-html/src/lit-html.ts
+++ b/packages/lit-html/src/lit-html.ts
@@ -707,7 +707,7 @@ function resolveDirective(
     }
   }
   if (currentDirective !== undefined) {
-    value = currentDirective._resolve((value as DirectiveResult).values);
+    value = currentDirective._$resolve((value as DirectiveResult).values);
   }
   return value;
 }

--- a/packages/lit-html/src/lit-html.ts
+++ b/packages/lit-html/src/lit-html.ts
@@ -13,7 +13,7 @@
  */
 
 // IMPORTANT: these imports must be type-only
-import {Directive, DirectiveResult, PartInfo} from './directive.js';
+import type {Directive, DirectiveResult, PartInfo} from './directive.js';
 
 const DEV_MODE = true;
 const ENABLE_EXTRA_SECURITY_HOOKS = true;

--- a/packages/lit-html/src/private-ssr-support.ts
+++ b/packages/lit-html/src/private-ssr-support.ts
@@ -34,11 +34,12 @@ export const _Σ = {
   HTML_RESULT: p._HTML_RESULT,
   getTemplateHtml: p._getTemplateHtml,
   overrideDirectiveResolve: (
-    directiveClass: new (part: PartInfo) => Directive & {render(): unknown}
+    directiveClass: new (part: PartInfo) => Directive & {render(): unknown},
+    resolveOverrideFn: (directive: Directive, values: unknown[]) => unknown
   ) =>
     class extends directiveClass {
       _$resolve(this: Directive, _part: Part, values: unknown[]): unknown {
-        return this.render(...values);
+        return resolveOverrideFn(this, values);
       }
     },
   getAttributePartCommittedValue: (

--- a/packages/lit-html/src/private-ssr-support.ts
+++ b/packages/lit-html/src/private-ssr-support.ts
@@ -37,7 +37,7 @@ export const _Σ = {
     directive: Directive,
     fn: (this: Directive, values: unknown[]) => unknown
   ) => {
-    directive._resolve = fn;
+    directive._$resolve = fn;
   },
   getAttributePartCommittedValue: (
     part: AttributePart,
@@ -47,6 +47,9 @@ export const _Σ = {
     // Use the part setter to resolve directives/concatenate multiple parts
     // into a final value (captured by passing in a commitValue override)
     let committedValue: unknown = noChange;
+    // Note that _commitValue need not be in `stableProperties` because this
+    // method is only run on `AttributePart`s created by lit-ssr using the same
+    // version of the library as this file
     part._commitValue = (value: unknown) => (committedValue = value);
     part._$setValue(value, part, index);
     return committedValue;

--- a/packages/lit-html/src/private-ssr-support.ts
+++ b/packages/lit-html/src/private-ssr-support.ts
@@ -12,8 +12,8 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {Directive} from './directive.js';
-import {_Σ as p, AttributePart, noChange} from './lit-html.js';
+import {Directive, PartInfo} from './directive.js';
+import {_Σ as p, AttributePart, noChange, Part} from './lit-html.js';
 
 /**
  * END USERS SHOULD NOT RELY ON THIS OBJECT.
@@ -33,12 +33,14 @@ export const _Σ = {
   markerMatch: p._markerMatch,
   HTML_RESULT: p._HTML_RESULT,
   getTemplateHtml: p._getTemplateHtml,
-  patchDirectiveResolve: (
-    directive: Directive,
-    fn: (this: Directive, values: unknown[]) => unknown
-  ) => {
-    directive._$resolve = fn;
-  },
+  overrideDirectiveResolve: (
+    directiveClass: new (part: PartInfo) => Directive & {render(): unknown}
+  ) =>
+    class extends directiveClass {
+      _$resolve(this: Directive, _part: Part, values: unknown[]): unknown {
+        return this.render(...values);
+      }
+    },
   getAttributePartCommittedValue: (
     part: AttributePart,
     value: unknown,

--- a/packages/lit-html/src/test/directive-helpers_test.ts
+++ b/packages/lit-html/src/test/directive-helpers_test.ts
@@ -16,6 +16,7 @@ import {directive, Directive} from '../directive.js';
 import {assert} from '@esm-bundle/chai';
 import {stripExpressionComments} from './test-utils/strip-markers.js';
 import {
+  classForDirectiveResult,
   insertPart,
   isDirectiveResult,
   isPrimitive,
@@ -24,7 +25,6 @@ import {
   TemplateResultType,
 } from '../directive-helpers.js';
 import {classMap} from '../directives/class-map.js';
-import {UnsafeHTML, unsafeHTML} from '../directives/unsafe-html.js';
 
 suite('directive-helpers', () => {
   let container: HTMLDivElement;
@@ -66,15 +66,20 @@ suite('directive-helpers', () => {
 
   test('isDirectiveResult', () => {
     assert.isTrue(isDirectiveResult(classMap({})));
-    assert.isTrue(isDirectiveResult(unsafeHTML(''), UnsafeHTML));
 
     assert.isFalse(isDirectiveResult(null));
     assert.isFalse(isDirectiveResult(undefined));
     assert.isFalse(isDirectiveResult({}));
-    assert.isFalse(isDirectiveResult(classMap({}), UnsafeHTML));
-    assert.isFalse(isDirectiveResult(null, UnsafeHTML));
-    assert.isFalse(isDirectiveResult(undefined, UnsafeHTML));
-    assert.isFalse(isDirectiveResult({}, UnsafeHTML));
+  });
+
+  test('classForDirectiveResult', () => {
+    assert.instanceOf(
+      classForDirectiveResult(classMap({}))?.prototype,
+      Directive
+    );
+    assert.equal(classForDirectiveResult(null), undefined);
+    assert.equal(classForDirectiveResult(undefined), undefined);
+    assert.equal(classForDirectiveResult({}), undefined);
   });
 
   test('insertPart', () => {

--- a/packages/lit-html/src/test/directive-helpers_test.ts
+++ b/packages/lit-html/src/test/directive-helpers_test.ts
@@ -16,7 +16,7 @@ import {directive, Directive} from '../directive.js';
 import {assert} from '@esm-bundle/chai';
 import {stripExpressionComments} from './test-utils/strip-markers.js';
 import {
-  classForDirectiveResult,
+  getDirectiveClass,
   insertPart,
   isDirectiveResult,
   isPrimitive,
@@ -72,14 +72,11 @@ suite('directive-helpers', () => {
     assert.isFalse(isDirectiveResult({}));
   });
 
-  test('classForDirectiveResult', () => {
-    assert.instanceOf(
-      classForDirectiveResult(classMap({}))?.prototype,
-      Directive
-    );
-    assert.equal(classForDirectiveResult(null), undefined);
-    assert.equal(classForDirectiveResult(undefined), undefined);
-    assert.equal(classForDirectiveResult({}), undefined);
+  test('getDirectiveClass', () => {
+    assert.instanceOf(getDirectiveClass(classMap({}))?.prototype, Directive);
+    assert.equal(getDirectiveClass(null), undefined);
+    assert.equal(getDirectiveClass(undefined), undefined);
+    assert.equal(getDirectiveClass({}), undefined);
   });
 
   test('insertPart', () => {

--- a/packages/lit-ssr/.gitignore
+++ b/packages/lit-ssr/.gitignore
@@ -3,3 +3,4 @@
 /node_modules/
 /test/
 /index.*
+*.d.ts

--- a/packages/lit-ssr/package.json
+++ b/packages/lit-ssr/package.json
@@ -58,6 +58,7 @@
     "koa": "^2.7.0",
     "koa-node-resolve": "^1.0.0-pre.5",
     "koa-static": "^5.0.0",
+    "lit": "^2.0.0-pre.1",
     "lit-element": "^3.0.0-pre.2",
     "lit-html": "^2.0.0-pre.4",
     "node-fetch": "^2.6.0",

--- a/packages/lit-ssr/src/demo/app-client.ts
+++ b/packages/lit-ssr/src/demo/app-client.ts
@@ -2,9 +2,9 @@
  * This is a client-only file used to boot the page.
  */
 
-import {render} from 'lit-html';
-import {hydrate} from 'lit-html/hydrate.js';
-import 'lit-element/hydrate-support.js';
+import {render} from 'lit';
+import {hydrate} from 'lit/hydrate.js';
+import 'lit/hydrate-support.js';
 import {template, initialData} from './module.js';
 
 console.log('Page hydrating with same data as rendered with SSR.');

--- a/packages/lit-ssr/src/demo/module.ts
+++ b/packages/lit-ssr/src/demo/module.ts
@@ -2,10 +2,10 @@
  * This is a shared client/server module.
  */
 
-import {html} from 'lit-html';
-import {LitElement, css} from 'lit-element';
-import {property} from 'lit-element/decorators/property.js';
-//import {repeat} from 'lit-html/directives/repeat.js';
+import {html} from 'lit';
+import {LitElement, css} from 'lit';
+import {property} from 'lit/decorators/property.js';
+//import {repeat} from 'lit/directives/repeat.js';
 
 export const initialData = {
   name: 'SSR',

--- a/packages/lit-ssr/src/lib/import-module.ts
+++ b/packages/lit-ssr/src/lib/import-module.ts
@@ -52,6 +52,9 @@ const resolveSpecifier = (specifier: string, referrer: string): URL => {
     throw new Error('referrer is undefined');
   }
 
+  const specifierMatches = (specifier: string, match: string) =>
+    specifier === match || specifier.startsWith(match + '/');
+
   try {
     // First see if the specifier is a full URL, and if so, use that.
 
@@ -61,8 +64,9 @@ const resolveSpecifier = (specifier: string, referrer: string): URL => {
     return new URL(specifier);
   } catch (e) {
     if (
-      specifier.startsWith('lit-html') ||
-      specifier.startsWith('lit-element')
+      specifierMatches(specifier, 'lit') ||
+      specifierMatches(specifier, 'lit') ||
+      specifierMatches(specifier, 'lit')
     ) {
       // Override where we resolve lit-html from so that we always resolve to
       // a single version of lit-html.

--- a/packages/lit-ssr/src/lib/import-module.ts
+++ b/packages/lit-ssr/src/lib/import-module.ts
@@ -65,8 +65,8 @@ const resolveSpecifier = (specifier: string, referrer: string): URL => {
   } catch (e) {
     if (
       specifierMatches(specifier, 'lit') ||
-      specifierMatches(specifier, 'lit') ||
-      specifierMatches(specifier, 'lit')
+      specifierMatches(specifier, 'lit-html') ||
+      specifierMatches(specifier, 'lit-element')
     ) {
       // Override where we resolve lit-html from so that we always resolve to
       // a single version of lit-html.

--- a/packages/lit-ssr/src/lib/lit-element-renderer.ts
+++ b/packages/lit-ssr/src/lib/lit-element-renderer.ts
@@ -13,7 +13,7 @@
  */
 
 import {ElementRenderer} from './element-renderer.js';
-import {LitElement, CSSResult, ReactiveElement} from 'lit-element';
+import {LitElement, CSSResult, ReactiveElement} from 'lit';
 import {_Φ} from 'lit-element/private-ssr-support.js';
 import {render, renderValue, RenderInfo} from './render-lit-html.js';
 

--- a/packages/lit-ssr/src/lib/render-lit-html.ts
+++ b/packages/lit-ssr/src/lib/render-lit-html.ts
@@ -15,11 +15,11 @@
  */
 
 // Type-only imports
-import {TemplateResult, ChildPart} from 'lit-html';
+import {TemplateResult, ChildPart} from 'lit';
 
-import {nothing, noChange} from 'lit-html';
-import {PartType} from 'lit-html/directive.js';
-import {isTemplateResult} from 'lit-html/directive-helpers.js';
+import {nothing, noChange} from 'lit';
+import {PartType} from 'lit/directive.js';
+import {isTemplateResult} from 'lit/directive-helpers.js';
 import {_Σ} from 'lit-html/private-ssr-support.js';
 
 const {
@@ -36,7 +36,7 @@ const {
   EventPart,
 } = _Σ;
 
-import {digestForTemplateResult} from 'lit-html/hydrate.js';
+import {digestForTemplateResult} from 'lit/hydrate.js';
 
 import {ElementRenderer} from './element-renderer.js';
 
@@ -53,11 +53,11 @@ import {
   isElement,
 } from './util/parse5-utils.js';
 
-import {isRenderLightDirective} from 'lit-html/directives/render-light.js';
-import {LitElement} from 'lit-element';
+import {isRenderLightDirective} from 'lit/directives/render-light.js';
+import {LitElement} from 'lit';
 import {LitElementRenderer} from './lit-element-renderer.js';
 import {reflectedAttributeName} from './reflected-attributes.js';
-import {Directive} from 'lit-html/directive';
+import {Directive} from 'lit/directive';
 
 declare module 'parse5' {
   interface DefaultTreeElement {

--- a/packages/lit-ssr/src/lib/render-lit-html.ts
+++ b/packages/lit-ssr/src/lib/render-lit-html.ts
@@ -14,11 +14,11 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-// Type-only imports
-import {TemplateResult, ChildPart} from 'lit';
+import type {TemplateResult, ChildPart} from 'lit';
+import type {DirectiveClass, DirectiveResult} from 'lit/directive.js';
 
 import {nothing, noChange} from 'lit';
-import {DirectiveClass, DirectiveResult, PartType} from 'lit/directive.js';
+import {PartType} from 'lit/directive.js';
 import {isTemplateResult} from 'lit/directive-helpers.js';
 import {_Σ} from 'lit-html/private-ssr-support.js';
 

--- a/packages/lit-ssr/src/lib/render-lit-html.ts
+++ b/packages/lit-ssr/src/lib/render-lit-html.ts
@@ -15,7 +15,11 @@
  */
 
 import type {TemplateResult, ChildPart} from 'lit';
-import type {DirectiveClass, DirectiveResult} from 'lit/directive.js';
+import type {
+  Directive,
+  DirectiveClass,
+  DirectiveResult,
+} from 'lit/directive.js';
 
 import {nothing, noChange} from 'lit';
 import {PartType} from 'lit/directive.js';
@@ -43,8 +47,7 @@ import {ElementRenderer} from './element-renderer.js';
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const escapeHtml = require('escape-html') as typeof import('escape-html');
 
-// types only
-import {DefaultTreeDocumentFragment} from 'parse5';
+import type {DefaultTreeDocumentFragment} from 'parse5';
 
 import {
   traverse,
@@ -78,7 +81,14 @@ const patchIfDirective = (value: unknown) => {
   if (directiveCtor !== undefined) {
     let patchedCtor = patchedDirectiveCache.get(directiveCtor);
     if (patchedCtor === undefined) {
-      patchedCtor = overrideDirectiveResolve(directiveCtor);
+      patchedCtor = overrideDirectiveResolve(
+        directiveCtor,
+        (directive: Directive, values: unknown[]) => {
+          // Since the return value may also be a directive result in the case of
+          // nested directives, we may need to patch that as well
+          return patchIfDirective(directive.render(...values));
+        }
+      );
       patchedDirectiveCache.set(directiveCtor, patchedCtor);
     }
     (value as DirectiveResult)._$litDirective$ = patchedCtor;

--- a/packages/lit-ssr/src/lib/render-lit-html.ts
+++ b/packages/lit-ssr/src/lib/render-lit-html.ts
@@ -78,13 +78,14 @@ const patchDirective = (value: unknown) => {
         const {__part, __attributeIndex} = this;
         return resolveDirective(
           __part,
-          this.render(...values),
+          patchDirective(this.render(...values)),
           this,
           __attributeIndex
         );
       }
     );
   }
+  return value;
 };
 
 /**

--- a/packages/lit-ssr/src/test/integration/client/basic_test.ts
+++ b/packages/lit-ssr/src/test/integration/client/basic_test.ts
@@ -15,8 +15,8 @@
 import '@open-wc/testing';
 
 import {tests} from '../tests/basic.js';
-import {render} from 'lit-html';
-import {hydrate} from 'lit-html/hydrate.js';
+import {render} from 'lit';
+import {hydrate} from 'lit/hydrate.js';
 import {hydrateShadowRoots} from 'template-shadowroot/template-shadowroot.js';
 import {SSRExpectedHTML} from '../tests/ssr-test.js';
 

--- a/packages/lit-ssr/src/test/integration/tests/basic.ts
+++ b/packages/lit-ssr/src/test/integration/tests/basic.ts
@@ -54,6 +54,12 @@ interface ClickableButton extends HTMLButtonElement {
   __wasClicked2: boolean;
 }
 
+const throwIfRunOnServer = () => {
+  if (!(globalThis instanceof window.constructor)) {
+    throw new Error('Upate should not be run on the server');
+  }
+};
+
 const filterNodes = (nodes: ArrayLike<Node>, nodeType: number) =>
   Array.from(nodes).filter((n) => n.nodeType === nodeType);
 
@@ -449,6 +455,10 @@ export const tests: {[name: string]: SSRTest} = {
       class extends Directive {
         count = 0;
         lastValue: string | undefined = undefined;
+        update(_part: Part, [v]: DirectiveParameters<this>) {
+          throwIfRunOnServer();
+          return this.render(v);
+        }
         render(v: string) {
           if (v !== this.lastValue) {
             this.lastValue = v;
@@ -479,6 +489,10 @@ export const tests: {[name: string]: SSRTest} = {
   'ChildPart accepts nested directives': () => {
     const aDirective = directive(
       class extends Directive {
+        update(_part: Part, [bool, v]: DirectiveParameters<this>) {
+          throwIfRunOnServer();
+          return this.render(bool, v);
+        }
         render(bool: boolean, v: unknown) {
           return bool ? v : nothing;
         }
@@ -488,6 +502,10 @@ export const tests: {[name: string]: SSRTest} = {
       class extends Directive {
         count = 0;
         lastValue: string | undefined = undefined;
+        update(_part: Part, [v]: DirectiveParameters<this>) {
+          throwIfRunOnServer();
+          return this.render(v);
+        }
         render(v: string) {
           if (v !== this.lastValue) {
             this.lastValue = v;
@@ -1007,6 +1025,10 @@ export const tests: {[name: string]: SSRTest} = {
       class extends Directive {
         count = 0;
         lastValue: string | undefined = undefined;
+        update(_part: Part, [v]: DirectiveParameters<this>) {
+          throwIfRunOnServer();
+          return this.render(v);
+        }
         render(v: string) {
           if (v !== this.lastValue) {
             this.lastValue = v;
@@ -1037,6 +1059,10 @@ export const tests: {[name: string]: SSRTest} = {
   'AttributePart accepts nested directives': () => {
     const aDirective = directive(
       class extends Directive {
+        update(_part: Part, [bool, v]: DirectiveParameters<this>) {
+          throwIfRunOnServer();
+          return this.render(bool, v);
+        }
         render(bool: boolean, v: unknown) {
           return bool ? v : nothing;
         }
@@ -1046,6 +1072,10 @@ export const tests: {[name: string]: SSRTest} = {
       class extends Directive {
         count = 0;
         lastValue: string | undefined = undefined;
+        update(_part: Part, [v]: DirectiveParameters<this>) {
+          throwIfRunOnServer();
+          return this.render(v);
+        }
         render(v: string) {
           if (v !== this.lastValue) {
             this.lastValue = v;
@@ -3296,6 +3326,7 @@ export const tests: {[name: string]: SSRTest} = {
           log.push('render should not be called');
         }
         update(_part: Part, [v]: DirectiveParameters<this>) {
+          throwIfRunOnServer();
           log.push(v);
         }
       }
@@ -3461,6 +3492,10 @@ export const tests: {[name: string]: SSRTest} = {
     const dir = directive(
       class extends Directive {
         value: string | undefined;
+        update(_part: Part, [v]: DirectiveParameters<this>) {
+          throwIfRunOnServer();
+          return this.render(v);
+        }
         render(value: string) {
           if (this.value !== value) {
             this.value = value;
@@ -3939,6 +3974,10 @@ export const tests: {[name: string]: SSRTest} = {
     const log: number[] = [];
     const nest = directive(
       class extends Directive {
+        update(_part: Part, [n]: DirectiveParameters<this>) {
+          throwIfRunOnServer();
+          return this.render(n);
+        }
         render(n: number): string | DirectiveResult {
           log.push(n);
           if (n > 1) {

--- a/packages/lit-ssr/src/test/integration/tests/basic.ts
+++ b/packages/lit-ssr/src/test/integration/tests/basic.ts
@@ -12,40 +12,37 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import 'lit-element/hydrate-support.js';
+import 'lit/hydrate-support.js';
 
-import {html, noChange, nothing, Part} from 'lit-html';
+import {html, noChange, nothing, Part} from 'lit';
 import {
   directive,
   Directive,
   DirectiveParameters,
   DirectiveResult,
-} from 'lit-html/directive.js';
-import {repeat} from 'lit-html/directives/repeat.js';
-import {guard} from 'lit-html/directives/guard.js';
-import {cache} from 'lit-html/directives/cache.js';
-import {classMap} from 'lit-html/directives/class-map.js';
-import {styleMap} from 'lit-html/directives/style-map.js';
-import {until} from 'lit-html/directives/until.js';
+} from 'lit/directive.js';
+import {repeat} from 'lit/directives/repeat.js';
+import {guard} from 'lit/directives/guard.js';
+import {cache} from 'lit/directives/cache.js';
+import {classMap} from 'lit/directives/class-map.js';
+import {styleMap} from 'lit/directives/style-map.js';
+import {until} from 'lit/directives/until.js';
 // TODO(kschaaf): Enable once async directives are implemented
-// import {asyncAppend} from 'lit-html/directives/async-append.js';
-// import {asyncReplace} from 'lit-html/directives/async-replace.js';
-// import {TestAsyncIterable} from 'lit-html/test/lib/test-async-iterable.js';
-import {ifDefined} from 'lit-html/directives/if-defined.js';
-import {live} from 'lit-html/directives/live.js';
-import {unsafeHTML} from 'lit-html/directives/unsafe-html.js';
-import {unsafeSVG} from 'lit-html/directives/unsafe-svg.js';
-import {createRef, ref} from 'lit-html/directives/ref.js';
+// import {asyncAppend} from 'lit/directives/async-append.js';
+// import {asyncReplace} from 'lit/directives/async-replace.js';
+// import {TestAsyncIterable} from 'lit/test/lib/test-async-iterable.js';
+import {ifDefined} from 'lit/directives/if-defined.js';
+import {live} from 'lit/directives/live.js';
+import {unsafeHTML} from 'lit/directives/unsafe-html.js';
+import {unsafeSVG} from 'lit/directives/unsafe-svg.js';
+import {createRef, ref} from 'lit/directives/ref.js';
 
-import {LitElement, PropertyValues} from 'lit-element';
-import {property} from 'lit-element/decorators/property.js';
-import {
-  renderLight,
-  RenderLightHost,
-} from 'lit-html/directives/render-light.js';
+import {LitElement, PropertyValues} from 'lit';
+import {property} from 'lit/decorators/property.js';
+import {renderLight, RenderLightHost} from 'lit/directives/render-light.js';
 
 import {SSRTest} from './ssr-test';
-import {AsyncDirective} from 'lit-html/async-directive';
+import {AsyncDirective} from 'lit/async-directive';
 
 interface DivWithProp extends HTMLDivElement {
   prop?: unknown;

--- a/packages/lit-ssr/src/test/integration/tests/ssr-test.ts
+++ b/packages/lit-ssr/src/test/integration/tests/ssr-test.ts
@@ -12,7 +12,7 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {TemplateResult} from 'lit-html';
+import {TemplateResult} from 'lit';
 
 export type SSRExpectedHTML =
   | string

--- a/packages/lit-ssr/src/test/test-files/render-test-module.ts
+++ b/packages/lit-ssr/src/test/test-files/render-test-module.ts
@@ -12,12 +12,12 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {html, nothing} from 'lit-html';
-import {repeat} from 'lit-html/directives/repeat.js';
-import {classMap} from 'lit-html/directives/class-map.js';
-import {LitElement, css, PropertyValues} from 'lit-element';
-import {property, customElement} from 'lit-element/decorators.js';
-export {digestForTemplateResult} from 'lit-html/hydrate.js';
+import {html, nothing} from 'lit';
+import {repeat} from 'lit/directives/repeat.js';
+import {classMap} from 'lit/directives/class-map.js';
+import {LitElement, css, PropertyValues} from 'lit';
+import {property, customElement} from 'lit/decorators.js';
+export {digestForTemplateResult} from 'lit/hydrate.js';
 
 export {render} from '../../lib/render-lit-html.js';
 

--- a/rollup-common.js
+++ b/rollup-common.js
@@ -87,9 +87,9 @@ const stableProperties = {
   _$setValue: 'M',
   // polyfill-support: LitElement (added by polyfill-support)
   _$handlesPrepareStyles: 'N',
-  // lit-element: ReactiveElement (used bby ssr-support)
+  // lit-element: ReactiveElement (used by private-ssr-support)
   _$attributeToProperty: 'O',
-  // lit-element: ReactiveElement (used bby ssr-support)
+  // lit-element: ReactiveElement (used by private-ssr-support)
   _$changedProperties: 'P',
   // lit-html: ChildPart, AttributePart, TemplateInstance, Directive (accessed by
   // async-directive)
@@ -103,6 +103,8 @@ const stableProperties = {
   _$reparentDisconnectables: 'U',
   // lit-html: ChildPart (used by directive-helpers)
   _$clear: 'V',
+  // lit-html: Directive (used by private-ssr-support)
+  _$resolve: 'W',
 };
 
 // Validate stableProperties list, just to be safe; catches dupes and


### PR DESCRIPTION
The main issue was that `patchDirectiveResolve` in `lit-html/private-ssr-support.ts` was patching `_resolve`, despite the fact that directives may possibly come from any version of the library.  So `_$resolve` is now in `stableProperties`.

However, it also pointed out that `lit-ssr` was directly importing `Directive` from `lit-html` and patching it, and relying on that to affect all directive instances. This is only a safe assumption if lit-ssr is only seeing Directives created with the exact same version of the library that it is importing. Although the `import-module.ts` does force module resolution for user code to use the same version, we don't necessarily want the VM-sandbox to be the _only_ environment where you can run SSR.

For this reason, this change makes lit-ssr no longer import & patch `Directive`, but instead patches `Directive` constructors in any `DirectiveResult` values that are being rendered by lit-ssr.

The PR also includes a change from using the individual `lit-html` and `lit-element` packages to using `lit`, to avoid all the warning spamming from using the deprecated `lit-element` entrypoint.

Fixes #1554