### PR TITLE
Enable stripInternal in tsconfig

### DIFF
--- a/packages/lit-element/src/lit-element.ts
+++ b/packages/lit-element/src/lit-element.ts
@@ -216,7 +216,7 @@ export const _Φ = {
     name: string,
     value: string | null
   ) => {
-    el._$attributeToProperty(name, value);
+    (el as any)._$attributeToProperty(name, value);
   },
-  _$changedProperties: (el: LitElement) => el._$changedProperties,
+  _$changedProperties: (el: LitElement) => (el as any)._$changedProperties,
 };

--- a/packages/lit-element/src/lit-element.ts
+++ b/packages/lit-element/src/lit-element.ts
@@ -216,7 +216,9 @@ export const _Φ = {
     name: string,
     value: string | null
   ) => {
+    // eslint-disable-next-line
     (el as any)._$attributeToProperty(name, value);
   },
+  // eslint-disable-next-line
   _$changedProperties: (el: LitElement) => (el as any)._$changedProperties,
 };

--- a/packages/lit-element/tsconfig.json
+++ b/packages/lit-element/tsconfig.json
@@ -3,7 +3,11 @@
     "composite": true,
     "target": "es2020",
     "module": "es2015",
-    "lib": ["es2020", "DOM", "DOM.Iterable"],
+    "lib": [
+      "es2020",
+      "DOM",
+      "DOM.Iterable"
+    ],
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,
@@ -20,9 +24,19 @@
     "moduleResolution": "node",
     "allowSyntheticDefaultImports": true,
     "experimentalDecorators": true,
-    "importHelpers": true
+    "importHelpers": true,
+    "stripInternal": true
   },
-  "include": ["src/**/*.ts"],
+  "include": [
+    "src/**/*.ts"
+  ],
   "exclude": [],
-  "references": [{"path": "../lit-html"}, {"path": "../reactive-element"}]
+  "references": [
+    {
+      "path": "../lit-html"
+    },
+    {
+      "path": "../reactive-element"
+    }
+  ]
 }

--- a/packages/lit-element/tsconfig.json
+++ b/packages/lit-element/tsconfig.json
@@ -3,11 +3,7 @@
     "composite": true,
     "target": "es2020",
     "module": "es2015",
-    "lib": [
-      "es2020",
-      "DOM",
-      "DOM.Iterable"
-    ],
+    "lib": ["es2020", "DOM", "DOM.Iterable"],
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,
@@ -27,9 +23,7 @@
     "importHelpers": true,
     "stripInternal": true
   },
-  "include": [
-    "src/**/*.ts"
-  ],
+  "include": ["src/**/*.ts"],
   "exclude": [],
   "references": [
     {

--- a/packages/lit-html/src/directive.ts
+++ b/packages/lit-html/src/directive.ts
@@ -36,10 +36,11 @@ export type DirectiveParameters<C extends Directive> = Parameters<C['render']>;
 /**
  * A generated directive function doesn't evaluate the directive, but just
  * returns a DirectiveResult object that captures the arguments.
- * @internal
  */
 export type DirectiveResult<C extends DirectiveClass = DirectiveClass> = {
+  /** @internal */
   _$litDirective$: C;
+  /** @internal */
   values: DirectiveParameters<InstanceType<C>>;
 };
 

--- a/packages/lit-html/tsconfig.json
+++ b/packages/lit-html/tsconfig.json
@@ -3,11 +3,7 @@
     "composite": true,
     "target": "es2020",
     "module": "es2020",
-    "lib": [
-      "es2020",
-      "DOM",
-      "DOM.Iterable"
-    ],
+    "lib": ["es2020", "DOM", "DOM.Iterable"],
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,
@@ -23,10 +19,8 @@
     "noImplicitThis": true,
     "moduleResolution": "node",
     "allowSyntheticDefaultImports": true,
-    "stripInternal": true
+    "stripInternal": false
   },
-  "include": [
-    "src/**/*.ts"
-  ],
+  "include": ["src/**/*.ts"],
   "exclude": []
 }

--- a/packages/lit-html/tsconfig.json
+++ b/packages/lit-html/tsconfig.json
@@ -3,7 +3,11 @@
     "composite": true,
     "target": "es2020",
     "module": "es2020",
-    "lib": ["es2020", "DOM", "DOM.Iterable"],
+    "lib": [
+      "es2020",
+      "DOM",
+      "DOM.Iterable"
+    ],
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,
@@ -18,8 +22,11 @@
     "noImplicitAny": true,
     "noImplicitThis": true,
     "moduleResolution": "node",
-    "allowSyntheticDefaultImports": true
+    "allowSyntheticDefaultImports": true,
+    "stripInternal": true
   },
-  "include": ["src/**/*.ts"],
+  "include": [
+    "src/**/*.ts"
+  ],
   "exclude": []
 }

--- a/packages/reactive-element/tsconfig.json
+++ b/packages/reactive-element/tsconfig.json
@@ -3,7 +3,11 @@
     "composite": true,
     "target": "es2020",
     "module": "es2015",
-    "lib": ["es2020", "DOM", "DOM.Iterable"],
+    "lib": [
+      "es2020",
+      "DOM",
+      "DOM.Iterable"
+    ],
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,
@@ -19,8 +23,11 @@
     "noImplicitThis": true,
     "moduleResolution": "node",
     "allowSyntheticDefaultImports": true,
-    "experimentalDecorators": true
+    "experimentalDecorators": true,
+    "stripInternal": true
   },
-  "include": ["src/**/*.ts"],
+  "include": [
+    "src/**/*.ts"
+  ],
   "exclude": []
 }

--- a/packages/reactive-element/tsconfig.json
+++ b/packages/reactive-element/tsconfig.json
@@ -3,11 +3,7 @@
     "composite": true,
     "target": "es2020",
     "module": "es2015",
-    "lib": [
-      "es2020",
-      "DOM",
-      "DOM.Iterable"
-    ],
+    "lib": ["es2020", "DOM", "DOM.Iterable"],
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,
@@ -26,8 +22,6 @@
     "experimentalDecorators": true,
     "stripInternal": true
   },
-  "include": [
-    "src/**/*.ts"
-  ],
+  "include": ["src/**/*.ts"],
   "exclude": []
 }


### PR DESCRIPTION
This means that we won't emit declarations in .d.ts files for things annotated with @internal.

I believe this is desirable, to make it clearer to users which fields they can count on existing and which we're free to change.

This also aligns with the internal tsconfig.