### PR TITLE
[lit-next] Use new global patterns at ignore-sync

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -20,14 +20,6 @@ packages/benchmarks/**/*.d.ts.map
 packages/benchmarks/**/*.js
 packages/benchmarks/**/*.js.map
 
-packages/labs/task/development/
-packages/labs/task/node_modules/
-packages/labs/task/index.*
-packages/labs/task/task.*
-packages/labs/react/development/
-packages/labs/react/node_modules/
-packages/labs/react/index.*
-packages/labs/react/create-component.*
 packages/lit/decorators/
 packages/lit/development/
 packages/lit/directives/
@@ -82,6 +74,22 @@ packages/lit-ssr/node_modules/
 packages/lit-ssr/test/
 packages/lit-ssr/index.*
 
+packages/lit-starter-js/node_modules/*
+packages/lit-starter-js/docs/*
+packages/lit-starter-js/docs-src/*
+packages/lit-starter-js/**/rollup-config.js
+packages/lit-starter-js/**/custom-elements.json
+
+packages/lit-starter-js/node_modules/
+packages/lit-starter-js/**/custom-elements.json
+# only generated for size check
+packages/lit-starter-js/**/my-element.bundled.js
+packages/lit-starter-ts/node_modules/*
+packages/lit-starter-ts/docs/*
+packages/lit-starter-ts/docs-src/*
+packages/lit-starter-ts/**/rollup-config.js
+packages/lit-starter-ts/**/custom-elements.json
+
 packages/lit-starter-ts/node_modules/
 packages/lit-starter-ts/lib/
 packages/lit-starter-ts/test/
@@ -91,22 +99,6 @@ packages/lit-starter-ts/**/my-element.js
 packages/lit-starter-ts/**/my-element.js.map
 packages/lit-starter-ts/**/my-element.d.ts
 packages/lit-starter-ts/**/my-element.d.ts.map
-
-packages/lit-starter-ts/node_modules/*
-packages/lit-starter-ts/docs/*
-packages/lit-starter-ts/docs-src/*
-packages/lit-starter-ts/**/rollup-config.js
-packages/lit-starter-ts/**/custom-elements.json
-
-packages/lit-starter-js/node_modules/
-packages/lit-starter-js/**/custom-elements.json
-# only generated for size check
-packages/lit-starter-js/**/my-element.bundled.js
-packages/lit-starter-js/node_modules/*
-packages/lit-starter-js/docs/*
-packages/lit-starter-js/docs-src/*
-packages/lit-starter-js/**/rollup-config.js
-packages/lit-starter-js/**/custom-elements.json
 
 packages/localize/lib/
 packages/localize/lib_client/
@@ -120,8 +112,6 @@ packages/localize/examples/*/node_modules/
 packages/localize/fnv1a64.*
 packages/localize/id-generation.*
 
-packages/tests/node_modules/
-
 packages/reactive-element/decorators/
 packages/reactive-element/development/
 packages/reactive-element/test/
@@ -130,5 +120,18 @@ packages/reactive-element/decorators.*
 packages/reactive-element/polyfill-support.*
 packages/reactive-element/reactive-element.*
 packages/reactive-element/reactive-controller.*
+
+packages/tests/node_modules/
+
+packages/labs/react/development/
+packages/labs/react/node_modules/
+packages/labs/react/index.*
+packages/labs/react/create-component.*
+packages/labs/task/development/
+packages/labs/task/node_modules/
+packages/labs/task/index.*
+packages/labs/task/task.*
+packages/localize/examples/runtime/lib/
+packages/localize/examples/transform/lib/
 
 packages/localize/testdata/

--- a/.eslintignore-sync
+++ b/.eslintignore-sync
@@ -2,20 +2,7 @@
 .gitignore
 
 [relative]
-packages/benchmarks/.gitignore
-packages/labs/task/.gitignore
-packages/labs/react/.gitignore
-packages/lit/.gitignore
-packages/lit-element/.gitignore
-packages/lit-html/.gitignore
-packages/lit-ssr/.gitignore
-packages/lit-starter-ts/.gitignore
-packages/lit-starter-ts/.eslintignore
-packages/lit-starter-js/.gitignore
-packages/lit-starter-js/.eslintignore
-packages/localize/.gitignore
-packages/tests/.gitignore
-packages/reactive-element/.gitignore
+packages/**/{.gitignore,.eslintignore}
 
 [inline]
 packages/localize/testdata/

--- a/.prettierignore
+++ b/.prettierignore
@@ -20,14 +20,6 @@ packages/benchmarks/**/*.d.ts.map
 packages/benchmarks/**/*.js
 packages/benchmarks/**/*.js.map
 
-packages/labs/task/development/
-packages/labs/task/node_modules/
-packages/labs/task/index.*
-packages/labs/task/task.*
-packages/labs/react/development/
-packages/labs/react/node_modules/
-packages/labs/react/index.*
-packages/labs/react/create-component.*
 packages/lit/decorators/
 packages/lit/development/
 packages/lit/directives/
@@ -82,6 +74,10 @@ packages/lit-ssr/node_modules/
 packages/lit-ssr/test/
 packages/lit-ssr/index.*
 
+packages/lit-starter-js/node_modules/
+packages/lit-starter-js/**/custom-elements.json
+# only generated for size check
+packages/lit-starter-js/**/my-element.bundled.js
 packages/lit-starter-ts/node_modules/
 packages/lit-starter-ts/lib/
 packages/lit-starter-ts/test/
@@ -91,22 +87,6 @@ packages/lit-starter-ts/**/my-element.js
 packages/lit-starter-ts/**/my-element.js.map
 packages/lit-starter-ts/**/my-element.d.ts
 packages/lit-starter-ts/**/my-element.d.ts.map
-
-packages/lit-starter-ts/node_modules/*
-packages/lit-starter-ts/docs/*
-packages/lit-starter-ts/docs-src/*
-packages/lit-starter-ts/**/rollup-config.js
-packages/lit-starter-ts/**/custom-elements.json
-
-packages/lit-starter-js/node_modules/
-packages/lit-starter-js/**/custom-elements.json
-# only generated for size check
-packages/lit-starter-js/**/my-element.bundled.js
-packages/lit-starter-js/node_modules/*
-packages/lit-starter-js/docs/*
-packages/lit-starter-js/docs-src/*
-packages/lit-starter-js/**/rollup-config.js
-packages/lit-starter-js/**/custom-elements.json
 
 packages/localize/lib/
 packages/localize/lib_client/
@@ -120,8 +100,6 @@ packages/localize/examples/*/node_modules/
 packages/localize/fnv1a64.*
 packages/localize/id-generation.*
 
-packages/tests/node_modules/
-
 packages/reactive-element/decorators/
 packages/reactive-element/development/
 packages/reactive-element/test/
@@ -130,6 +108,19 @@ packages/reactive-element/decorators.*
 packages/reactive-element/polyfill-support.*
 packages/reactive-element/reactive-element.*
 packages/reactive-element/reactive-controller.*
+
+packages/tests/node_modules/
+
+packages/labs/react/development/
+packages/labs/react/node_modules/
+packages/labs/react/index.*
+packages/labs/react/create-component.*
+packages/labs/task/development/
+packages/labs/task/node_modules/
+packages/labs/task/index.*
+packages/labs/task/task.*
+packages/localize/examples/runtime/lib/
+packages/localize/examples/transform/lib/
 
 packages/localize/examples/
 packages/localize/testdata/

--- a/.prettierignore-sync
+++ b/.prettierignore-sync
@@ -2,20 +2,7 @@
 .gitignore
 
 [relative]
-packages/benchmarks/.gitignore
-packages/labs/task/.gitignore
-packages/labs/react/.gitignore
-packages/lit/.gitignore
-packages/lit-element/.gitignore
-packages/lit-html/.gitignore
-packages/lit-ssr/.gitignore
-packages/lit-starter-ts/.gitignore
-packages/lit-starter-ts/.eslintignore
-packages/lit-starter-js/.gitignore
-packages/lit-starter-js/.eslintignore
-packages/localize/.gitignore
-packages/tests/.gitignore
-packages/reactive-element/.gitignore
+packages/**/{.gitignore,.prettierignore}
 
 [inline]
 packages/localize/examples/

--- a/package-lock.json
+++ b/package-lock.json
@@ -2199,9 +2199,9 @@
       "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA=="
     },
     "axios": {
-      "version": "0.21.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.0.tgz",
-      "integrity": "sha512-fmkJBknJKoZwem3/IKSSLpkdNXZeBu5Q7GA/aRsr2btgrptmSCxi2oFjZHqGdK9DoTil9PIHlPIZw2EcRJXRvw==",
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
+      "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
       "dev": true,
       "requires": {
         "follow-redirects": "^1.10.0"
@@ -4203,9 +4203,9 @@
       }
     },
     "follow-redirects": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.0.tgz",
-      "integrity": "sha512-aq6gF1BEKje4a9i9+5jimNFIpq4Q1WiwBToeRK5NvZBd/TRsmW8BsJfOEGkr76TbOyPVD3OVDN910EcUNtRYEA==",
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.2.tgz",
+      "integrity": "sha512-6mPTgLxYm3r6Bkkg0vNM0HTjfGrOEtsfbhagQvbxDEsEkpNhw582upBaoRZylzen6krEmxXJgt9Ju6HiI4O7BA==",
       "dev": true
     },
     "for-in": {
@@ -5128,21 +5128,85 @@
       "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg=="
     },
     "ignore-sync": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/ignore-sync/-/ignore-sync-3.0.1.tgz",
-      "integrity": "sha512-MGRyFQX7PYAG9oGpgY4j1TCZ2ITTQ6qqNZg36PrcQCSZZvT63yL7kcXrUJLBCcWFYvncAJk9V5DXwjARmmXCCA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/ignore-sync/-/ignore-sync-3.1.0.tgz",
+      "integrity": "sha512-WDnxiNMSICYQxDm0KxyKstKgl6sdA3D9wbIiIyWQorKdXq78tY7htGt8anQKPSaubFf9ZqpYHynEx9dGMMyF8g==",
       "dev": true,
       "requires": {
-        "axios": "0.21.0",
+        "axios": "0.21.1",
+        "fast-glob": "3.2.5",
         "ignore": "5.1.8",
         "ramda": "0.27.1"
       },
       "dependencies": {
+        "@nodelib/fs.stat": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.4.tgz",
+          "integrity": "sha512-IYlHJA0clt2+Vg7bccq+TzRdJvv19c2INqBSsoOLp1je7xjtr7J26+WXR72MCdvU9q1qTzIWDfhMf+DRvQJK4Q==",
+          "dev": true
+        },
+        "braces": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+          "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+          "dev": true,
+          "requires": {
+            "fill-range": "^7.0.1"
+          }
+        },
+        "fast-glob": {
+          "version": "3.2.5",
+          "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.5.tgz",
+          "integrity": "sha512-2DtFcgT68wiTTiwZ2hNdJfcHNke9XOfnwmBRWXhmeKM8rF0TGwmC/Qto3S7RoZKp5cilZbxzO5iTNTQsJ+EeDg==",
+          "dev": true,
+          "requires": {
+            "@nodelib/fs.stat": "^2.0.2",
+            "@nodelib/fs.walk": "^1.2.3",
+            "glob-parent": "^5.1.0",
+            "merge2": "^1.3.0",
+            "micromatch": "^4.0.2",
+            "picomatch": "^2.2.1"
+          }
+        },
+        "fill-range": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+          "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+          "dev": true,
+          "requires": {
+            "to-regex-range": "^5.0.1"
+          }
+        },
         "ignore": {
           "version": "5.1.8",
           "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
           "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
           "dev": true
+        },
+        "is-number": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+          "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+          "dev": true
+        },
+        "micromatch": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+          "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+          "dev": true,
+          "requires": {
+            "braces": "^3.0.1",
+            "picomatch": "^2.0.5"
+          }
+        },
+        "to-regex-range": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+          "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+          "dev": true,
+          "requires": {
+            "is-number": "^7.0.0"
+          }
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "eslint": "^7.17.0",
     "eslint-plugin-no-only-tests": "^2.4.0",
     "husky": "^4.3.0",
-    "ignore-sync": "^3.0.0",
+    "ignore-sync": "^3.1.0",
     "lint-staged": "^10.4.0",
     "prettier": "^2.1.2",
     "rollup-plugin-copy": "^3.3.0",


### PR DESCRIPTION
The last version of ignore-sync allows global patterns.

<img width="1118" alt="Screenshot 2021-02-05 at 17 03 17" src="https://user-images.githubusercontent.com/1007051/107057755-1223dd00-67d4-11eb-9964-a13180fb7311.png">
