### PR TITLE
[lit-starter-ts/js] Fix .pretterignore syncing with lit-starter templates

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -132,7 +132,5 @@ packages/labs/task/development/
 packages/labs/task/node_modules/
 packages/labs/task/index.*
 packages/labs/task/task.*
-packages/localize/examples/runtime/lib/
-packages/localize/examples/transform/lib/
 
 packages/localize/testdata/

--- a/.eslintignore-sync
+++ b/.eslintignore-sync
@@ -2,7 +2,7 @@
 .gitignore
 
 [relative]
-packages/**/{.gitignore,.eslintignore}
+packages/{*,labs/*}/{.gitignore,.eslintignore}
 
 [inline]
 packages/localize/testdata/

--- a/.prettierignore
+++ b/.prettierignore
@@ -120,8 +120,17 @@ packages/labs/task/development/
 packages/labs/task/node_modules/
 packages/labs/task/index.*
 packages/labs/task/task.*
-packages/localize/examples/runtime/lib/
-packages/localize/examples/transform/lib/
+packages/lit-starter-js/node_modules/*
+packages/lit-starter-js/docs/*
+packages/lit-starter-js/docs-src/*
+packages/lit-starter-js/**/rollup-config.js
+packages/lit-starter-js/**/custom-elements.json
+
+packages/lit-starter-ts/node_modules/*
+packages/lit-starter-ts/docs/*
+packages/lit-starter-ts/docs-src/*
+packages/lit-starter-ts/**/rollup-config.js
+packages/lit-starter-ts/**/custom-elements.json
 
 packages/localize/examples/
 packages/localize/testdata/

--- a/.prettierignore-sync
+++ b/.prettierignore-sync
@@ -2,7 +2,10 @@
 .gitignore
 
 [relative]
-packages/**/{.gitignore,.prettierignore}
+packages/{*,labs/*}/{.gitignore,.prettierignore}
+# Starter templates specify the lint/format ignore in .eslintignore to stay DRY
+packages/{lit-starter-ts,lit-starter-js}/.eslintignore
+
 
 [inline]
 packages/localize/examples/


### PR DESCRIPTION
Also changes the glob just to look in the top level of packages, so that it doesn't unnecessarily recurse into node_modules