### PR TITLE
[lit-html] Add asyncAppend and asyncReplace

### DIFF
--- a/packages/lit-html/CHANGELOG.md
+++ b/packages/lit-html/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+- (Since 2.0.0-pre.4) Added `asyncappend` and `asyncReplace` directives.
+
 ### Fixed
 
 - Nested directives whose parent returns `noChange` are now unchanged. This

--- a/packages/lit-html/README.md
+++ b/packages/lit-html/README.md
@@ -28,20 +28,11 @@ changes:
 - `render()` no longer clears its container on first render
 - Custom `templateFactory`, `TemplateProcessor`, and custom tag functions are no
   longer supported
+- The `polyfill-support.js` file must be loaded when using the `webcomponents`
+  polyfills
 
 See the full [changelog](CHANGELOG.md) for more details on
 these and other minor breaking changes.
-
-## 🚨 Known issues/limitations
-
-- **Browser support**: This pre-release should run on modern browsers, however a
-  change to factor legacy browser support (IE11, etc.) into an opt-in package is
-  ongoing. As such, this release will not run on some older browsers. This is a
-  temporary state.
-- **Limited directive implementation**: The following directives are not yet
-  implemented. This is a temporary state:
-  - `asyncAppend`
-  - `asyncReplace`
 
 ## 🚨 Migrating directives
 

--- a/packages/lit-html/rollup.config.js
+++ b/packages/lit-html/rollup.config.js
@@ -17,6 +17,8 @@ import {litProdConfig} from '../../rollup-common.js';
 export default litProdConfig({
   classPropertyPrefix: 'Σ',
   entryPoints: [
+    'directives/async-append',
+    'directives/async-replace',
     'directives/cache',
     'directives/class-map',
     'directives/guard',

--- a/packages/lit-html/src/directive-helpers.ts
+++ b/packages/lit-html/src/directive-helpers.ts
@@ -103,7 +103,7 @@ const createMarker = () => document.createComment('');
  */
 export const insertPart = (
   containerPart: ChildPart,
-  refPart: ChildPart | undefined,
+  refPart?: ChildPart,
   part?: ChildPart
 ): ChildPart => {
   const container = wrap(containerPart._$startNode).parentNode!;

--- a/packages/lit-html/src/directives/async-append.ts
+++ b/packages/lit-html/src/directives/async-append.ts
@@ -40,7 +40,9 @@ class AsyncAppendDirective extends AsyncDirective {
     }
   }
 
-  render<T>(_value: AsyncIterable<T>, _mapper?: Mapper<T>) {
+  // @ts-expect-error value not used, but we want a nice parameter for docs
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  render<T>(value: AsyncIterable<T>, _mapper?: Mapper<T>) {
     return noChange;
   }
 
@@ -90,15 +92,15 @@ class AsyncAppendDirective extends AsyncDirective {
     }
   }
 
-  // Pause iteration while disconnected
   disconnected() {
+    // Pause iteration while disconnected
     this.reconnectPromise = new Promise(
       (resolve) => (this.reconnectResolver = resolve)
     );
   }
 
-  // Resume iteration when reconnected
   reconnected() {
+    // Resume iteration when reconnected
     this.reconnectPromise = undefined;
     this.reconnectResolver!();
   }
@@ -107,6 +109,7 @@ class AsyncAppendDirective extends AsyncDirective {
 /**
  * A directive that renders the items of an async iterable[1], appending new
  * values after previous values, similar to the built-in support for iterables.
+ * This directive is usable only in child expressions.
  *
  * Async iterables are objects with a [Symbol.asyncIterator] method, which
  * returns an iterator who's `next()` method returns a Promise. When a new
@@ -115,7 +118,7 @@ class AsyncAppendDirective extends AsyncDirective {
  * directive has been set on the Part, the iterable will no longer be listened
  * to and new values won't be written to the Part.
  *
- * [1]: https://github.com/tc39/proposal-async-iteration
+ * [1]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for-await...of
  *
  * @param value An async iterable
  * @param mapper An optional function that maps from (value, index) to another

--- a/packages/lit-html/src/directives/async-append.ts
+++ b/packages/lit-html/src/directives/async-append.ts
@@ -1,0 +1,124 @@
+/**
+ * @license
+ * Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+import {ChildPart, noChange} from '../lit-html.js';
+import {
+  directive,
+  DirectiveParameters,
+  PartInfo,
+  PartType,
+} from '../directive.js';
+import {AsyncDirective} from '../async-directive.js';
+import {
+  clearPart,
+  insertPart,
+  setChildPartValue,
+} from '../directive-helpers.js';
+
+type Mapper<T> = (v: T, index?: number) => unknown;
+
+class AsyncAppendDirective extends AsyncDirective {
+  value?: AsyncIterable<unknown>;
+  reconnectResolver?: () => void;
+  reconnectPromise?: Promise<void>;
+
+  constructor(partInfo: PartInfo) {
+    super(partInfo);
+    if (partInfo.type !== PartType.CHILD) {
+      throw new Error('asyncAppend can only be used in child expressions');
+    }
+  }
+
+  render<T>(_value: AsyncIterable<T>, _mapper?: Mapper<T>) {
+    return noChange;
+  }
+
+  update(part: ChildPart, [value, mapper]: DirectiveParameters<this>) {
+    // If we've already set up this particular iterable, we don't need
+    // to do anything.
+    if (value === this.value) {
+      return;
+    }
+    this.value = value;
+    this.__iterate(part, mapper);
+    return noChange;
+  }
+
+  // Separate function to avoid an iffe in update; update can't be async
+  // because its return value must be `noChange`
+  private async __iterate(part: ChildPart, mapper?: Mapper<unknown>) {
+    let i = 0;
+    const {value} = this;
+    for await (let v of value!) {
+      // Check to make sure that value is the still the current value of
+      // the part, and if not bail because a new value owns this part
+      if (this.value !== value) {
+        break;
+      }
+
+      // If we were disconnected, pause until reconnected
+      if (this.reconnectPromise) {
+        await this.reconnectPromise;
+      }
+
+      // When we get the first value, clear the part. This lets the
+      // previous value display until we can replace it.
+      if (i === 0) {
+        clearPart(part);
+      }
+      // As a convenience, because functional-programming-style
+      // transforms of iterables and async iterables requires a library,
+      // we accept a mapper function. This is especially convenient for
+      // rendering a template for each item.
+      if (mapper !== undefined) {
+        v = mapper(v, i);
+      }
+      const newPart = insertPart(part);
+      setChildPartValue(newPart, v);
+      i++;
+    }
+  }
+
+  // Pause iteration while disconnected
+  disconnected() {
+    this.reconnectPromise = new Promise(
+      (resolve) => (this.reconnectResolver = resolve)
+    );
+  }
+
+  // Resume iteration when reconnected
+  reconnected() {
+    this.reconnectPromise = undefined;
+    this.reconnectResolver!();
+  }
+}
+
+/**
+ * A directive that renders the items of an async iterable[1], appending new
+ * values after previous values, similar to the built-in support for iterables.
+ *
+ * Async iterables are objects with a [Symbol.asyncIterator] method, which
+ * returns an iterator who's `next()` method returns a Promise. When a new
+ * value is available, the Promise resolves and the value is appended to the
+ * Part controlled by the directive. If another value other than this
+ * directive has been set on the Part, the iterable will no longer be listened
+ * to and new values won't be written to the Part.
+ *
+ * [1]: https://github.com/tc39/proposal-async-iteration
+ *
+ * @param value An async iterable
+ * @param mapper An optional function that maps from (value, index) to another
+ *     value. Useful for generating templates for each item in the iterable.
+ */
+export const asyncAppend = directive(AsyncAppendDirective);

--- a/packages/lit-html/src/directives/async-replace.ts
+++ b/packages/lit-html/src/directives/async-replace.ts
@@ -13,12 +13,7 @@
  */
 
 import {ChildPart, noChange} from '../lit-html.js';
-import {
-  directive,
-  DirectiveParameters,
-  PartInfo,
-  PartType,
-} from '../directive.js';
+import {directive, DirectiveParameters} from '../directive.js';
 import {AsyncDirective} from '../async-directive.js';
 
 type Mapper<T> = (v: T, index?: number) => unknown;
@@ -28,14 +23,9 @@ class AsyncReplaceDirective extends AsyncDirective {
   reconnectResolver?: () => void;
   reconnectPromise?: Promise<void>;
 
-  constructor(partInfo: PartInfo) {
-    super(partInfo);
-    if (partInfo.type !== PartType.CHILD) {
-      throw new Error('asyncAppend can only be used in child expressions');
-    }
-  }
-
-  render<T>(_value: AsyncIterable<T>, _mapper?: Mapper<T>) {
+  // @ts-expect-error value not used, but we want a nice parameter for docs
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  render<T>(value: AsyncIterable<T>, _mapper?: Mapper<T>) {
     return noChange;
   }
 
@@ -80,15 +70,15 @@ class AsyncReplaceDirective extends AsyncDirective {
     }
   }
 
-  // Pause iteration while disconnected
   disconnected() {
+    // Pause iteration while disconnected
     this.reconnectPromise = new Promise(
       (resolve) => (this.reconnectResolver = resolve)
     );
   }
 
-  // Resume iteration when reconnected
   reconnected() {
+    // Resume iteration when reconnected
     this.reconnectPromise = undefined;
     this.reconnectResolver!();
   }
@@ -97,7 +87,7 @@ class AsyncReplaceDirective extends AsyncDirective {
 /**
  * A directive that renders the items of an async iterable[1], replacing
  * previous values with new values, so that only one value is ever rendered
- * at a time.
+ * at a time. This directive may be used in any expression type.
  *
  * Async iterables are objects with a [Symbol.asyncIterator] method, which
  * returns an iterator who's `next()` method returns a Promise. When a new
@@ -106,7 +96,7 @@ class AsyncReplaceDirective extends AsyncDirective {
  * directive has been set on the Part, the iterable will no longer be listened
  * to and new values won't be written to the Part.
  *
- * [1]: https://github.com/tc39/proposal-async-iteration
+ * [1]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for-await...of
  *
  * @param value An async iterable
  * @param mapper An optional function that maps from (value, index) to another

--- a/packages/lit-html/src/directives/async-replace.ts
+++ b/packages/lit-html/src/directives/async-replace.ts
@@ -1,0 +1,115 @@
+/**
+ * @license
+ * Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+import {ChildPart, noChange} from '../lit-html.js';
+import {
+  directive,
+  DirectiveParameters,
+  PartInfo,
+  PartType,
+} from '../directive.js';
+import {AsyncDirective} from '../async-directive.js';
+
+type Mapper<T> = (v: T, index?: number) => unknown;
+
+class AsyncReplaceDirective extends AsyncDirective {
+  value?: AsyncIterable<unknown>;
+  reconnectResolver?: () => void;
+  reconnectPromise?: Promise<void>;
+
+  constructor(partInfo: PartInfo) {
+    super(partInfo);
+    if (partInfo.type !== PartType.CHILD) {
+      throw new Error('asyncAppend can only be used in child expressions');
+    }
+  }
+
+  render<T>(_value: AsyncIterable<T>, _mapper?: Mapper<T>) {
+    return noChange;
+  }
+
+  update(_part: ChildPart, [value, mapper]: DirectiveParameters<this>) {
+    // If we've already set up this particular iterable, we don't need
+    // to do anything.
+    if (value === this.value) {
+      return;
+    }
+    this.value = value;
+    this.__iterate(mapper);
+    return noChange;
+  }
+
+  // Separate function to avoid an iffe in update; update can't be async
+  // because its return value must be `noChange`
+  private async __iterate(mapper?: Mapper<unknown>) {
+    let i = 0;
+    const {value} = this;
+    for await (let v of value!) {
+      // Check to make sure that value is the still the current value of
+      // the part, and if not bail because a new value owns this part
+      if (this.value !== value) {
+        break;
+      }
+
+      // If we were disconnected, pause until reconnected
+      if (this.reconnectPromise) {
+        await this.reconnectPromise;
+      }
+
+      // As a convenience, because functional-programming-style
+      // transforms of iterables and async iterables requires a library,
+      // we accept a mapper function. This is especially convenient for
+      // rendering a template for each item.
+      if (mapper !== undefined) {
+        v = mapper(v, i);
+      }
+
+      this.setValue(v);
+      i++;
+    }
+  }
+
+  // Pause iteration while disconnected
+  disconnected() {
+    this.reconnectPromise = new Promise(
+      (resolve) => (this.reconnectResolver = resolve)
+    );
+  }
+
+  // Resume iteration when reconnected
+  reconnected() {
+    this.reconnectPromise = undefined;
+    this.reconnectResolver!();
+  }
+}
+
+/**
+ * A directive that renders the items of an async iterable[1], replacing
+ * previous values with new values, so that only one value is ever rendered
+ * at a time.
+ *
+ * Async iterables are objects with a [Symbol.asyncIterator] method, which
+ * returns an iterator who's `next()` method returns a Promise. When a new
+ * value is available, the Promise resolves and the value is rendered to the
+ * Part controlled by the directive. If another value other than this
+ * directive has been set on the Part, the iterable will no longer be listened
+ * to and new values won't be written to the Part.
+ *
+ * [1]: https://github.com/tc39/proposal-async-iteration
+ *
+ * @param value An async iterable
+ * @param mapper An optional function that maps from (value, index) to another
+ *     value. Useful for generating templates for each item in the iterable.
+ */
+export const asyncReplace = directive(AsyncReplaceDirective);

--- a/packages/lit-html/src/directives/until.ts
+++ b/packages/lit-html/src/directives/until.ts
@@ -17,25 +17,6 @@ import {directive} from '../directive.js';
 import {isPrimitive} from '../directive-helpers.js';
 import {AsyncDirective} from '../async-directive.js';
 
-const DEV_MODE = true;
-
-if (DEV_MODE) {
-  console.warn(
-    'lit-html: The `until` directive is deprecated and will be removed in ' +
-      'the next major version.'
-  );
-}
-
-interface AsyncState {
-  /**
-   * The last rendered index of a call to until(). A value only renders if its
-   * index is less than the `lastRenderedIndex`.
-   */
-  lastRenderedIndex: number;
-
-  values: unknown[];
-}
-
 const isPromise = (x: unknown) => {
   return !isPrimitive(x) && typeof (x as {then?: unknown}).then === 'function';
 };
@@ -43,28 +24,21 @@ const isPromise = (x: unknown) => {
 const _infinity = 0x7fffffff;
 
 class UntilDirective extends AsyncDirective {
-  private _state: WeakMap<Part, AsyncState> = new WeakMap<Part, AsyncState>();
+  private lastRenderedIndex: number = _infinity;
+  private values: unknown[] = [];
 
   render(...args: Array<unknown>) {
     return args.find((x) => !isPromise(x)) ?? noChange;
   }
 
-  update(part: Part, args: Array<unknown>) {
-    let state = this._state.get(part)!;
-    if (state === undefined) {
-      state = {
-        lastRenderedIndex: _infinity,
-        values: [],
-      };
-      this._state.set(part, state);
-    }
-    const previousValues = state.values;
+  update(_part: Part, args: Array<unknown>) {
+    const previousValues = this.values;
     let previousLength = previousValues.length;
-    state.values = args;
+    this.values = args;
 
     for (let i = 0; i < args.length; i++) {
       // If we've rendered a higher-priority value already, stop.
-      if (i > state.lastRenderedIndex) {
+      if (i > this.lastRenderedIndex) {
         break;
       }
 
@@ -72,7 +46,7 @@ class UntilDirective extends AsyncDirective {
 
       // Render non-Promise values immediately
       if (!isPromise(value)) {
-        state.lastRenderedIndex = i;
+        this.lastRenderedIndex = i;
         // Since a lower-priority value will never overwrite a higher-priority
         // synchronous value, we can stop processing now.
         return value;
@@ -85,16 +59,16 @@ class UntilDirective extends AsyncDirective {
 
       // We have a Promise that we haven't seen before, so priorities may have
       // changed. Forget what we rendered before.
-      state.lastRenderedIndex = _infinity;
+      this.lastRenderedIndex = _infinity;
       previousLength = 0;
 
       Promise.resolve(value).then((resolvedValue: unknown) => {
-        const index = state.values.indexOf(value);
+        const index = this.values.indexOf(value);
         // If state.values doesn't contain the value, we've re-rendered without
         // the value, so don't render it. Then, only render if the value is
         // higher-priority than what's already been rendered.
-        if (index > -1 && index < state.lastRenderedIndex) {
-          state.lastRenderedIndex = index;
+        if (index > -1 && index < this.lastRenderedIndex) {
+          this.lastRenderedIndex = index;
           this.setValue(resolvedValue);
         }
       });

--- a/packages/lit-html/src/test/directives/async-append_test.ts
+++ b/packages/lit-html/src/test/directives/async-append_test.ts
@@ -1,0 +1,163 @@
+/**
+ * @license
+ * Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+import {asyncAppend} from '../../directives/async-append.js';
+import {render, html} from '../../lit-html.js';
+import {TestAsyncIterable} from './test-async-iterable.js';
+import {stripExpressionMarkers} from '../test-utils/strip-markers.js';
+import {assert} from '@esm-bundle/chai';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+// Set Symbol.asyncIterator on browsers without it
+if (typeof Symbol !== undefined && Symbol.asyncIterator === undefined) {
+  Object.defineProperty(Symbol, 'Symbol.asyncIterator', {value: Symbol()});
+}
+
+suite('asyncAppend', () => {
+  let container: HTMLDivElement;
+  let iterable: TestAsyncIterable<string>;
+
+  setup(() => {
+    container = document.createElement('div');
+    iterable = new TestAsyncIterable<string>();
+  });
+
+  test('appends content as the async iterable yields new values', async () => {
+    render(html`<div>${asyncAppend(iterable)}</div>`, container);
+    assert.equal(stripExpressionMarkers(container.innerHTML), '<div></div>');
+
+    await iterable.push('foo');
+    assert.equal(stripExpressionMarkers(container.innerHTML), '<div>foo</div>');
+
+    await iterable.push('bar');
+    assert.equal(
+      stripExpressionMarkers(container.innerHTML),
+      '<div>foobar</div>'
+    );
+  });
+
+  test('appends nothing with a value is undefined', async () => {
+    render(html`<div>${asyncAppend(iterable)}</div>`, container);
+    assert.equal(stripExpressionMarkers(container.innerHTML), '<div></div>');
+
+    await iterable.push('foo');
+    assert.equal(stripExpressionMarkers(container.innerHTML), '<div>foo</div>');
+
+    await iterable.push((undefined as unknown) as string);
+    assert.equal(stripExpressionMarkers(container.innerHTML), '<div>foo</div>');
+  });
+
+  test('uses a mapper function', async () => {
+    render(
+      html`<div>${asyncAppend(iterable, (v, i) => html`${i}: ${v} `)}</div>`,
+      container
+    );
+    assert.equal(stripExpressionMarkers(container.innerHTML), '<div></div>');
+
+    await iterable.push('foo');
+    assert.equal(
+      stripExpressionMarkers(container.innerHTML),
+      '<div>0: foo </div>'
+    );
+
+    await iterable.push('bar');
+    assert.equal(
+      stripExpressionMarkers(container.innerHTML),
+      '<div>0: foo 1: bar </div>'
+    );
+  });
+
+  test('renders new iterable over a pending iterable', async () => {
+    const t = (iterable: any) => html`<div>${asyncAppend(iterable)}</div>`;
+    render(t(iterable), container);
+    assert.equal(stripExpressionMarkers(container.innerHTML), '<div></div>');
+
+    await iterable.push('foo');
+    assert.equal(stripExpressionMarkers(container.innerHTML), '<div>foo</div>');
+
+    const iterable2 = new TestAsyncIterable<string>();
+    render(t(iterable2), container);
+
+    // The last value is preserved until we receive the first
+    // value from the new iterable
+    assert.equal(stripExpressionMarkers(container.innerHTML), '<div>foo</div>');
+
+    await iterable2.push('hello');
+    assert.equal(
+      stripExpressionMarkers(container.innerHTML),
+      '<div>hello</div>'
+    );
+
+    await iterable.push('bar');
+    assert.equal(
+      stripExpressionMarkers(container.innerHTML),
+      '<div>hello</div>'
+    );
+  });
+
+  test('renders new value over a pending iterable', async () => {
+    const t = (v: any) => html`<div>${v}</div>`;
+    // This is a little bit of an odd usage of directives as values, but it
+    // is possible, and we check here that asyncAppend plays nice in this case
+    render(t(asyncAppend(iterable)), container);
+    assert.equal(stripExpressionMarkers(container.innerHTML), '<div></div>');
+
+    await iterable.push('foo');
+    assert.equal(stripExpressionMarkers(container.innerHTML), '<div>foo</div>');
+
+    render(t('hello'), container);
+    assert.equal(
+      stripExpressionMarkers(container.innerHTML),
+      '<div>hello</div>'
+    );
+
+    await iterable.push('bar');
+    assert.equal(
+      stripExpressionMarkers(container.innerHTML),
+      '<div>hello</div>'
+    );
+  });
+
+  test('does not render the first value if it is replaced first', async () => {
+    const iterable2 = new TestAsyncIterable<string>();
+
+    const component = (value: any) => html`<p>${asyncAppend(value)}</p>`;
+
+    render(component(iterable), container);
+    render(component(iterable2), container);
+
+    await iterable2.push('fast');
+
+    // This write should not render, since the whole iterator was replaced
+    await iterable.push('slow');
+
+    assert.equal(stripExpressionMarkers(container.innerHTML), '<p>fast</p>');
+  });
+
+  test('does not render while disconnected', async () => {
+    const component = (value: any) => html`<p>${asyncAppend(value)}</p>`;
+    const part = render(component(iterable), container);
+    await iterable.push('1');
+    assert.equal(stripExpressionMarkers(container.innerHTML), '<p>1</p>');
+    part.setConnected(false);
+    await iterable.push('2');
+    assert.equal(stripExpressionMarkers(container.innerHTML), '<p>1</p>');
+    part.setConnected(true);
+    await new Promise<void>((r) => requestAnimationFrame(() => r()));
+    assert.equal(stripExpressionMarkers(container.innerHTML), '<p>12</p>');
+    await iterable.push('3');
+    assert.equal(stripExpressionMarkers(container.innerHTML), '<p>123</p>');
+  });
+});

--- a/packages/lit-html/src/test/directives/async-replace_test.ts
+++ b/packages/lit-html/src/test/directives/async-replace_test.ts
@@ -1,0 +1,181 @@
+/**
+ * @license
+ * Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+import {asyncReplace} from '../../directives/async-replace.js';
+import {render, html} from '../../lit-html.js';
+import {TestAsyncIterable} from './test-async-iterable.js';
+import {stripExpressionMarkers} from '../test-utils/strip-markers.js';
+import {assert} from '@esm-bundle/chai';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+// Set Symbol.asyncIterator on browsers without it
+if (typeof Symbol !== undefined && Symbol.asyncIterator === undefined) {
+  Object.defineProperty(Symbol, 'Symbol.asyncIterator', {value: Symbol()});
+}
+
+suite('asyncReplace', () => {
+  let container: HTMLDivElement;
+  let iterable: TestAsyncIterable<string>;
+
+  setup(() => {
+    container = document.createElement('div');
+    iterable = new TestAsyncIterable<string>();
+  });
+
+  test('replaces content as the async iterable yields new values', async () => {
+    render(html`<div>${asyncReplace(iterable)}</div>`, container);
+    assert.equal(stripExpressionMarkers(container.innerHTML), '<div></div>');
+
+    await iterable.push('foo');
+    assert.equal(stripExpressionMarkers(container.innerHTML), '<div>foo</div>');
+
+    await iterable.push('bar');
+    assert.equal(stripExpressionMarkers(container.innerHTML), '<div>bar</div>');
+  });
+
+  test('clears the Part when a value is undefined', async () => {
+    render(html`<div>${asyncReplace(iterable)}</div>`, container);
+    assert.equal(stripExpressionMarkers(container.innerHTML), '<div></div>');
+
+    await iterable.push('foo');
+    assert.equal(stripExpressionMarkers(container.innerHTML), '<div>foo</div>');
+
+    await iterable.push((undefined as unknown) as string);
+    assert.equal(stripExpressionMarkers(container.innerHTML), '<div></div>');
+  });
+
+  test('uses the mapper function', async () => {
+    render(
+      html`<div>${asyncReplace(iterable, (v, i) => html`${i}: ${v} `)}</div>`,
+      container
+    );
+    assert.equal(stripExpressionMarkers(container.innerHTML), '<div></div>');
+
+    await iterable.push('foo');
+    assert.equal(
+      stripExpressionMarkers(container.innerHTML),
+      '<div>0: foo </div>'
+    );
+
+    await iterable.push('bar');
+    assert.equal(
+      stripExpressionMarkers(container.innerHTML),
+      '<div>1: bar </div>'
+    );
+  });
+
+  test('renders new iterable over a pending iterable', async () => {
+    const t = (iterable: any) => html`<div>${asyncReplace(iterable)}</div>`;
+    render(t(iterable), container);
+    assert.equal(stripExpressionMarkers(container.innerHTML), '<div></div>');
+
+    await iterable.push('foo');
+    assert.equal(stripExpressionMarkers(container.innerHTML), '<div>foo</div>');
+
+    const iterable2 = new TestAsyncIterable<string>();
+    render(t(iterable2), container);
+
+    // The last value is preserved until we receive the first
+    // value from the new iterable
+    assert.equal(stripExpressionMarkers(container.innerHTML), '<div>foo</div>');
+
+    await iterable2.push('hello');
+    assert.equal(
+      stripExpressionMarkers(container.innerHTML),
+      '<div>hello</div>'
+    );
+
+    await iterable.push('bar');
+    assert.equal(
+      stripExpressionMarkers(container.innerHTML),
+      '<div>hello</div>'
+    );
+  });
+
+  test('renders the same iterable even when the iterable new value is emitted at the same time as a re-render', async () => {
+    const t = (iterable: any) => html`<div>${asyncReplace(iterable)}</div>`;
+    let wait: Promise<void>;
+    render(t(iterable), container);
+    assert.equal(stripExpressionMarkers(container.innerHTML), '<div></div>');
+
+    wait = iterable.push('hello');
+    render(t(iterable), container);
+    await wait;
+    assert.equal(
+      stripExpressionMarkers(container.innerHTML),
+      '<div>hello</div>'
+    );
+
+    wait = iterable.push('bar');
+    render(t(iterable), container);
+    await wait;
+    assert.equal(stripExpressionMarkers(container.innerHTML), '<div>bar</div>');
+  });
+
+  test('renders new value over a pending iterable', async () => {
+    const t = (v: any) => html`<div>${v}</div>`;
+    // This is a little bit of an odd usage of directives as values, but it
+    // is possible, and we check here that asyncReplace plays nice in this case
+    render(t(asyncReplace(iterable)), container);
+    assert.equal(stripExpressionMarkers(container.innerHTML), '<div></div>');
+
+    await iterable.push('foo');
+    assert.equal(stripExpressionMarkers(container.innerHTML), '<div>foo</div>');
+
+    render(t('hello'), container);
+    assert.equal(
+      stripExpressionMarkers(container.innerHTML),
+      '<div>hello</div>'
+    );
+
+    await iterable.push('bar');
+    assert.equal(
+      stripExpressionMarkers(container.innerHTML),
+      '<div>hello</div>'
+    );
+  });
+
+  test('does not render the first value if it is replaced first', async () => {
+    async function* generator(delay: Promise<any>, value: any) {
+      await delay;
+      yield value;
+    }
+
+    const component = (value: any) => html`<p>${asyncReplace(value)}</p>`;
+    const delay = (delay: number) =>
+      new Promise((res) => setTimeout(res, delay));
+
+    render(component(generator(delay(20), 'slow')), container);
+    render(component(generator(delay(10), 'fast')), container);
+    await delay(30);
+
+    assert.equal(stripExpressionMarkers(container.innerHTML), '<p>fast</p>');
+  });
+
+  test('does not render while disconnected', async () => {
+    const component = (value: any) => html`<p>${asyncReplace(value)}</p>`;
+    const part = render(component(iterable), container);
+    await iterable.push('1');
+    assert.equal(stripExpressionMarkers(container.innerHTML), '<p>1</p>');
+    part.setConnected(false);
+    await iterable.push('2');
+    assert.equal(stripExpressionMarkers(container.innerHTML), '<p>1</p>');
+    part.setConnected(true);
+    await new Promise<void>((r) => requestAnimationFrame(() => r()));
+    assert.equal(stripExpressionMarkers(container.innerHTML), '<p>2</p>');
+    await iterable.push('3');
+    assert.equal(stripExpressionMarkers(container.innerHTML), '<p>3</p>');
+  });
+});

--- a/packages/lit-html/src/test/directives/test-async-iterable.ts
+++ b/packages/lit-html/src/test/directives/test-async-iterable.ts
@@ -1,0 +1,62 @@
+/**
+ * @license
+ * Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+// Set Symbol.asyncIterator on browsers without it
+if (typeof Symbol !== undefined && Symbol.asyncIterator === undefined) {
+  Object.defineProperty(Symbol, 'asyncIterator', {value: Symbol()});
+}
+
+/**
+ * An async iterable that can have values pushed into it for testing code
+ * that consumes async iterables. This iterable can only be safely consumed
+ * by one listener.
+ */
+export class TestAsyncIterable<T> implements AsyncIterable<T> {
+  /**
+   * A Promise that resolves with the next value to be returned by the
+   * async iterable returned from iterable()
+   */
+  private _nextValue: Promise<T> = new Promise(
+    (resolve) => (this._resolveNextValue = resolve)
+  );
+  private _resolveNextValue!: (value: T) => void;
+
+  async *[Symbol.asyncIterator]() {
+    while (true) {
+      yield await this._nextValue;
+    }
+  }
+
+  /**
+   * Pushes a new value and returns a Promise that resolves when the value
+   * has been emitted by the iterator. push() must not be called before
+   * a previous call has completed, so always await a push() call.
+   */
+  async push(value: T): Promise<void> {
+    const currentValue = this._nextValue;
+    const currentResolveValue = this._resolveNextValue;
+    this._nextValue = new Promise(
+      (resolve) => (this._resolveNextValue = resolve)
+    );
+    // Resolves the previous value of _nextValue (now currentValue in this
+    // scope), making `yield await this._nextValue` go.
+    currentResolveValue(value);
+    // Waits for the value to be emitted
+    await currentValue;
+    // Need to wait for one more microtask for value to be rendered, but only
+    // when devtools is closed. Waiting for rAF might be more reliable, but
+    // this waits the minimum that seems reliable now.
+    await Promise.resolve();
+  }
+}

--- a/packages/lit/rollup.config.js
+++ b/packages/lit/rollup.config.js
@@ -28,6 +28,8 @@ export default litProdConfig({
     'decorators/state',
     'directive-helpers',
     'directive',
+    'directives/async-append',
+    'directives/async-replace',
     'directives/cache',
     'directives/class-map',
     'directives/guard',

--- a/packages/lit/src/directives/async-append.ts
+++ b/packages/lit/src/directives/async-append.ts
@@ -1,0 +1,15 @@
+/**
+ * @license
+ * Copyright (c) 2021 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+export * from 'lit-html/directives/async-append.js';

--- a/packages/lit/src/directives/async-replace.ts
+++ b/packages/lit/src/directives/async-replace.ts
@@ -1,0 +1,15 @@
+/**
+ * @license
+ * Copyright (c) 2021 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+export * from 'lit-html/directives/async-replace.js';


### PR DESCRIPTION
Port from 1.x, tests are wholly unchanged apart from adding test.

Also fixes `until` to be more idiomatic by using class fields for state (noticed when comparing code).

Fixes #1610 