### PR TITLE
Fix a selector that determines if the polyfills are injected into tests.

### DIFF
--- a/packages/tests/web-test-runner.config.js
+++ b/packages/tests/web-test-runner.config.js
@@ -184,7 +184,7 @@ export default {
             ),
             // Don't load if the page is tagged with a special meta indicating
             // the polyfills will be loaded manually
-            test: '!document.querySelector("meta[name=manual-polyfills")',
+            test: '!document.querySelector("meta[name=manual-polyfills]")',
             module: false,
           },
         ],


### PR DESCRIPTION
This doesn't actually seem to be affecting anything. I tried out calling `querySelector` with a similarly 'broken' selector and returns the element you'd expect if the `]` was there.