### PR TITLE
[lit-next] Re-escape null characters after Terser minification

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "husky": "^4.3.0",
     "ignore-sync": "^3.1.0",
     "lint-staged": "^10.4.0",
+    "magic-string": "^0.25.7",
     "prettier": "^2.1.2",
     "rollup-plugin-copy": "^3.3.0",
     "rollup-plugin-sourcemaps": "^0.6.2",


### PR DESCRIPTION
Replace literal null bytes with escaped `\0`, assuming they only appear inside strings.

With unsafe minifications on, Terser replaces `\0` and `\x00` escape sequences with actual null bytes. This can cause problems with tools, especially if the null byte appears early in the file. E.g. VSCode will not detect the file as UTF-8, and a bug caused @web/dev-server to crash.

See https://github.com/Polymer/lit-html/issues/1633