### PR TITLE
[lit-html] Fix IE11 asyncReplace test race condition

### DIFF
--- a/packages/lit-html/src/test/directives/async-replace_test.ts
+++ b/packages/lit-html/src/test/directives/async-replace_test.ts
@@ -213,9 +213,14 @@ suite('asyncReplace', () => {
     const delay = (delay: number) =>
       new Promise((res) => setTimeout(res, delay));
 
-    render(component(generator(delay(20), 'slow')), container);
-    render(component(generator(delay(10), 'fast')), container);
-    await delay(30);
+    const slowDelay = delay(20);
+    const fastDelay = delay(10);
+
+    render(component(generator(slowDelay, 'slow')), container);
+    render(component(generator(fastDelay, 'fast')), container);
+
+    await slowDelay;
+    await delay(10);
 
     assert.equal(stripExpressionMarkers(container.innerHTML), '<p>fast</p>');
   });


### PR DESCRIPTION
When running in the wtr sauce iframe runner, the `delay(30)` appears to not be long enough to wait on IE11 to ensure the stacking asyncs that occur through the generators and async directives have completed. Doesn't seem to be flaky outside of the iframe runner, so probably related to setTimeout/setImmediate throttling or something.

The change in test maintains the spirit of waiting until both promises have resolved and then ensuring that the faster one was not overwritten by the slower one (which should have been discarded).