### PR TITLE
Reintroduce `startNode` and `endNode` on `ChildPart`.

### DIFF
--- a/packages/lit-html/src/lit-html.ts
+++ b/packages/lit-html/src/lit-html.ts
@@ -909,19 +909,39 @@ class ChildPartImpl {
     this._$setChildPartConnected?.(isConnected);
   }
 
+  /**
+   * The parent node into which the part renders its content.
+   *
+   * A ChildPart's content consists of a range of adjacent child nodes of
+   * `.parentNode`, possibly bordered by 'marker nodes' (`.startNode` and
+   * `.endNode`).
+   *
+   * - If both `.startNode` and `.endNode` are defined, then the part's content
+   * consists of all siblings between `.startNode` and `.endNode`, exclusively.
+   *
+   * - If `.startNode` is defined but `.endNode` is undefined, then the part's
+   * content consists of all siblings following `.startNode`, up to and
+   * including the last child of `.parentNode`. (If `.endNode` is defined, then
+   * `.startNode` will always be defined.)
+   *
+   * - If both `.endNode` and `.startNode` are undefined, then the part's
+   * content consists of all child nodes of `.parentNode`.
+   */
   get parentNode(): Node {
     return wrap(this._$startNode).parentNode!;
   }
 
   /**
-   * The first node within the part.
+   * The part's leading marker node, if any. See `.parentNode` for more
+   * information.
    */
   get startNode(): Node | undefined {
     return this._$startNode === this._$endNode ? undefined : this._$startNode;
   }
 
   /**
-   * The last node within the part.
+   * The part's trailing marker node, if any. See `.parentNode` for more
+   * information.
    */
   get endNode(): Node | undefined {
     return this._$startNode === this._$endNode

--- a/packages/lit-html/src/lit-html.ts
+++ b/packages/lit-html/src/lit-html.ts
@@ -938,7 +938,7 @@ class ChildPartImpl {
    * information.
    */
   get startNode(): Node | undefined {
-    return this._$startNode === this._$endNode ? undefined : this._$startNode;
+    return this._$startNode;
   }
 
   /**
@@ -946,9 +946,7 @@ class ChildPartImpl {
    * information.
    */
   get endNode(): Node | undefined {
-    return this._$startNode === this._$endNode
-      ? undefined
-      : this._$endNode ?? undefined;
+    return this._$endNode ?? undefined;
   }
 
   _$setValue(value: unknown, directiveParent: DirectiveParent = this): void {

--- a/packages/lit-html/src/lit-html.ts
+++ b/packages/lit-html/src/lit-html.ts
@@ -913,6 +913,22 @@ class ChildPartImpl {
     return wrap(this._$startNode).parentNode!;
   }
 
+  /**
+   * The first node within the part.
+   */
+  get startNode(): Node | undefined {
+    return this._$startNode === this._$endNode ? undefined : this._$startNode;
+  }
+
+  /**
+   * The last node within the part.
+   */
+  get endNode(): Node | undefined {
+    return this._$startNode === this._$endNode
+      ? undefined
+      : this._$endNode ?? undefined;
+  }
+
   _$setValue(value: unknown, directiveParent: DirectiveParent = this): void {
     value = resolveDirective(this, value, directiveParent);
     if (isPrimitive(value)) {

--- a/packages/lit-html/src/lit-html.ts
+++ b/packages/lit-html/src/lit-html.ts
@@ -918,16 +918,16 @@ class ChildPartImpl {
    * `.parentNode`, possibly bordered by 'marker nodes' (`.startNode` and
    * `.endNode`).
    *
-   * - If both `.startNode` and `.endNode` are defined, then the part's content
+   * - If both `.startNode` and `.endNode` are non-null, then the part's content
    * consists of all siblings between `.startNode` and `.endNode`, exclusively.
    *
-   * - If `.startNode` is defined but `.endNode` is undefined, then the part's
+   * - If `.startNode` is non-null but `.endNode` is null, then the part's
    * content consists of all siblings following `.startNode`, up to and
-   * including the last child of `.parentNode`. (If `.endNode` is defined, then
-   * `.startNode` will always be defined.)
+   * including the last child of `.parentNode`. If `.endNode` is non-null, then
+   * `.startNode` will always be non-null.
    *
-   * - If both `.endNode` and `.startNode` are undefined, then the part's
-   * content consists of all child nodes of `.parentNode`.
+   * - If both `.endNode` and `.startNode` are null, then the part's content
+   * consists of all child nodes of `.parentNode`.
    */
   get parentNode(): Node {
     return wrap(this._$startNode).parentNode!;

--- a/packages/lit-html/src/lit-html.ts
+++ b/packages/lit-html/src/lit-html.ts
@@ -937,7 +937,7 @@ class ChildPartImpl {
    * The part's leading marker node, if any. See `.parentNode` for more
    * information.
    */
-  get startNode(): Node | undefined {
+  get startNode(): Node | null {
     return this._$startNode;
   }
 
@@ -945,8 +945,8 @@ class ChildPartImpl {
    * The part's trailing marker node, if any. See `.parentNode` for more
    * information.
    */
-  get endNode(): Node | undefined {
-    return this._$endNode ?? undefined;
+  get endNode(): Node | null {
+    return this._$endNode;
   }
 
   _$setValue(value: unknown, directiveParent: DirectiveParent = this): void {

--- a/packages/lit-html/src/test/lit-html_test.ts
+++ b/packages/lit-html/src/test/lit-html_test.ts
@@ -1503,15 +1503,15 @@ suite('lit-html', () => {
         update(part: ChildPart) {
           const {parentNode, startNode, endNode} = part;
 
-          if (endNode !== undefined) {
-            assert.notEqual(startNode, undefined);
+          if (endNode !== null) {
+            assert.notEqual(startNode, null);
           }
 
-          if (startNode === undefined) {
+          if (startNode === null) {
             // The part covers all children in `parentNode`.
             assert.equal(parentNode.childNodes.length, 0);
-            assert.equal(endNode, undefined);
-          } else if (endNode === undefined) {
+            assert.equal(endNode, null);
+          } else if (endNode === null) {
             // The part covers all siblings following `startNode`.
             assert.equal(startNode.nextSibling, null);
           } else {


### PR DESCRIPTION
This PR exposes the start and end marker nodes of `ChildPart` through `startNode` and `endNode` getters, like `NodePart` in Lit 1.

Fixes #1641.