### PR TITLE
[labs/task] Better typing for Task and initialState

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ following links for details on the changes being made:
   - [`lit-starter-ts`](./packages/lit-starter-ts) ([template repo](https://github.com/PolymerLabs/lit-element-starter-ts/tree/lit-next))
   - [`lit-starter-js`](./packages/lit-starter-js) ([template repo](https://github.com/PolymerLabs/lit-element-starter-js/tree/lit-next))
 - Internal packages (not published to npm)
-  - [`tests`](./packages/tests) 
+  - [`tests`](./packages/tests)
   - [`benchmarks`](./packages/benchmarks)
 
 ## Development guide

--- a/packages/labs/task/CHANGELOG.md
+++ b/packages/labs/task/CHANGELOG.md
@@ -17,8 +17,21 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 <!-- ### Removed -->
 <!-- ### Fixed -->
 
+## Unreleased
+
+### Changed
+
+- Added result and dependency type arguments to Task
+
+### Added
+
+- Added an `initialState` sentinal value that task functions can return to reset the task state to INITIAL.
+
+<!-- ### Removed -->
+<!-- ### Fixed -->
+
 ## [1.0.0-pre.1] - 2021-02-11
 
 ### Added
 
-- Adds `Task` controller which can be used to perform tasks when a host element updates. When the task completes, an update is requested on the host element and the task value can be used as desired  ([#1489](https://github.com/Polymer/lit-html/pulls/1489)).
+- Adds `Task` controller which can be used to perform tasks when a host element updates. When the task completes, an update is requested on the host element and the task value can be used as desired ([#1489](https://github.com/Polymer/lit-html/pulls/1489)).

--- a/packages/labs/task/src/task.ts
+++ b/packages/labs/task/src/task.ts
@@ -6,9 +6,11 @@
 import {notEqual} from '@lit/reactive-element';
 import {ReactiveControllerHost} from '@lit/reactive-element/reactive-controller.js';
 
-export type TaskFunction = (args: Array<unknown>) => unknown;
-export type Deps = Array<unknown>;
-export type DepsFunction = () => Deps;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type TaskFunction<D extends [...unknown[]], R = any> = (
+  args: D
+) => R | typeof initialState | Promise<R | typeof initialState>;
+export type DepsFunction<D extends [...unknown[]]> = () => D;
 
 /**
  * States for task status
@@ -20,12 +22,18 @@ export const TaskStatus = {
   ERROR: 3,
 } as const;
 
+/**
+ * A special value that can be returned from task functions to reset the task
+ * status to INITIAL.
+ */
+export const initialState = Symbol();
+
 export type TaskStatus = typeof TaskStatus[keyof typeof TaskStatus];
 
-export type StatusRenderer = {
+export type StatusRenderer<R> = {
   initial?: () => unknown;
   pending?: () => unknown;
-  complete?: (value: unknown) => unknown;
+  complete?: (value: R) => unknown;
   error?: (error: unknown) => unknown;
 };
 
@@ -76,20 +84,21 @@ export type StatusRenderer = {
  *   }
  * }
  */
-export class Task {
-  private _previousDeps: Deps = [];
-  private _task: TaskFunction;
-  private _getDependencies: DepsFunction;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export class Task<T extends [...unknown[]] = any, R = any> {
+  private _previousDeps: T = ([] as unknown) as T;
+  private _task: TaskFunction<T, R>;
+  private _getDependencies: DepsFunction<T>;
   private _callId = 0;
   private _host: ReactiveControllerHost;
-  private _value?: unknown;
+  private _value?: R;
   private _error?: unknown;
   status: TaskStatus = TaskStatus.INITIAL;
 
   constructor(
     host: ReactiveControllerHost,
-    task: TaskFunction,
-    getDependencies: DepsFunction
+    task: TaskFunction<T, R>,
+    getDependencies: DepsFunction<T>
   ) {
     this._host = host;
     this._host.addController(this);
@@ -107,22 +116,26 @@ export class Task {
       this.status = TaskStatus.PENDING;
       this._error = undefined;
       this._value = undefined;
-      let value: unknown;
+      let result!: R | typeof initialState;
       let error: unknown;
       // Request an update to report pending state.
       this._host.requestUpdate();
       const key = ++this._callId;
       try {
-        value = await this._task(deps);
+        result = await this._task(deps);
       } catch (e) {
         error = e;
       }
       // If this is the most recent task call, process this value.
       if (this._callId === key) {
-        this.status =
-          error === undefined ? TaskStatus.COMPLETE : TaskStatus.ERROR;
-        this._value = value;
-        this._error = error;
+        if (result === initialState) {
+          this.status = TaskStatus.INITIAL;
+        } else {
+          this.status =
+            error === undefined ? TaskStatus.COMPLETE : TaskStatus.ERROR;
+          this._value = result as R;
+          this._error = error;
+        }
         // Request an update with the final value.
         this._host.requestUpdate();
       }
@@ -137,20 +150,23 @@ export class Task {
     return this._error;
   }
 
-  render(renderer: StatusRenderer) {
+  render(renderer: StatusRenderer<R>) {
     switch (this.status) {
       case TaskStatus.INITIAL:
         return renderer.initial?.();
       case TaskStatus.PENDING:
         return renderer.pending?.();
       case TaskStatus.COMPLETE:
-        return renderer.complete?.(this.value);
+        return renderer.complete?.(this.value!);
       case TaskStatus.ERROR:
         return renderer.error?.(this.error);
+      default:
+        // exhaustiveness check
+        this.status as void;
     }
   }
 
-  private _isDirty(deps: Deps) {
+  private _isDirty(deps: T) {
     let i = 0;
     const previousDeps = this._previousDeps;
     this._previousDeps = deps;

--- a/packages/labs/task/src/test/task_test.ts
+++ b/packages/labs/task/src/test/task_test.ts
@@ -284,12 +284,6 @@ suite('Task', () => {
         async ([state]) => (state === 'initial' ? initialState : 'A'),
         () => [this.state]
       );
-
-      t2 = new Task(
-        this,
-        () => new Promise(() => []),
-        () => []
-      );
     }
     customElements.define(generateElementName(), TestEl);
 
@@ -302,11 +296,15 @@ suite('Task', () => {
     await Promise.resolve();
     assert.equal(el.task.status, TaskStatus.PENDING, 'pending');
 
-    await Promise.resolve();
+    await el.task.taskComplete;
     assert.equal(el.task.status, TaskStatus.COMPLETE, 'complete');
+    assert.equal(el.task.value, 'A');
 
+    // Kick off a new task run
     el.state = 'initial';
 
+    // We need to wait for the element to update, and then the task to run,
+    // so we wait a event loop turn:
     await new Promise((r) => setTimeout(r, 0));
     assert.equal(el.task.status, TaskStatus.INITIAL, 'new initial');
   });

--- a/packages/labs/task/src/test/task_test.ts
+++ b/packages/labs/task/src/test/task_test.ts
@@ -7,7 +7,7 @@
 import {ReactiveElement, PropertyValues} from '@lit/reactive-element';
 import {ReactiveController} from '@lit/reactive-element/reactive-controller.js';
 import {property} from '@lit/reactive-element/decorators/property.js';
-import {Task, TaskStatus} from '../task.js';
+import {initialState, Task, TaskStatus} from '../task.js';
 import {generateElementName, nextFrame} from './test-helpers';
 import {assert} from '@esm-bundle/chai';
 
@@ -86,7 +86,7 @@ suite('Task', () => {
     rejectRenderedStatusTask!: () => void;
     taskValue?: unknown;
     taskControllerValue?: unknown;
-    task = new Task(
+    task = new Task<[string, string], string>(
       this,
       ([foo, bar]) =>
         new Promise((resolve, reject) => {
@@ -95,7 +95,7 @@ suite('Task', () => {
         }),
       () => [this.foo, this.bar]
     );
-    renderedStatusTask = new Task(
+    renderedStatusTask = new Task<[string?], string>(
       this,
       ([zot]) =>
         new Promise((resolve, reject) => {
@@ -272,5 +272,42 @@ suite('Task', () => {
     el.resolveRenderedStatusTask();
     await tasksUpdateComplete();
     assert.equal(el.renderedStatus, 'result: zot3');
+  });
+
+  test('task functions can return initial state', async () => {
+    class TestEl extends ReactiveElement {
+      @property()
+      state = '';
+
+      task = new Task(
+        this,
+        async ([state]) => (state === 'initial' ? initialState : 'A'),
+        () => [this.state]
+      );
+
+      t2 = new Task(
+        this,
+        () => new Promise(() => []),
+        () => []
+      );
+    }
+    customElements.define(generateElementName(), TestEl);
+
+    const el = new TestEl();
+    assert.equal(el.task.status, TaskStatus.INITIAL, 'initial');
+    container.append(el);
+
+    // After one microtask we expect the task function to have been
+    // called, but not completed
+    await Promise.resolve();
+    assert.equal(el.task.status, TaskStatus.PENDING, 'pending');
+
+    await Promise.resolve();
+    assert.equal(el.task.status, TaskStatus.COMPLETE, 'complete');
+
+    el.state = 'initial';
+
+    await new Promise((r) => setTimeout(r, 0));
+    assert.equal(el.task.status, TaskStatus.INITIAL, 'new initial');
   });
 });


### PR DESCRIPTION
Adds deps and result types to Task making `.value` and `render()` a little easier to use. Also adds a `initialState` sentinel value that a task function can return to rest the task status to INITIAL.