### PR TITLE
[lit-next] Add constructor types for LitElement & ReactiveElement

### DIFF
--- a/packages/lit-element/src/lit-element.ts
+++ b/packages/lit-element/src/lit-element.ts
@@ -141,6 +141,20 @@ export class LitElement extends ReactiveElement {
   }
 }
 
+/**
+ * Constructor type for easier definition of mixins that apply to LitElement.
+ *
+ * ```ts
+ * const MyMixin = <T extends LitElementConstructor>(superClass: T) => {
+ *   class MyMixinSubclass extends superClass {
+ *     // ...
+ *   }
+ *   return MyMixinSubclass;
+ * }
+ * ```
+ */
+export type LitElementConstructor = new (...args: unknown[]) => LitElement;
+
 // Install hydration if available
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 (globalThis as any)['litElementHydrateSupport']?.({LitElement});

--- a/packages/reactive-element/src/reactive-element.ts
+++ b/packages/reactive-element/src/reactive-element.ts
@@ -1151,6 +1151,22 @@ export abstract class ReactiveElement
   protected firstUpdated(_changedProperties: PropertyValues) {}
 }
 
+/**
+ * Constructor type for easier definition of mixins that apply to ReactiveElement.
+ *
+ * ```ts
+ * const MyMixin = <T extends ReactiveElementConstructor>(superClass: T) => {
+ *   class MyMixinSubclass extends superClass {
+ *     // ...
+ *   }
+ *   return MyMixinSubclass;
+ * }
+ * ```
+ */
+export type ReactiveElementConstructor = new (
+  ...args: unknown[]
+) => ReactiveElement;
+
 // Apply polyfills if available
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 (globalThis as any)['reactiveElementPlatformSupport']?.({ReactiveElement});


### PR DESCRIPTION
Enables easier writing of mixins.

```ts
const MyMixin = <T extends LitElementConstructor>(superClass: T) => {
  class MyMixinSubclass extends superClass {
    // ...
  }
  return MyMixinSubclass;
}
```