### PR TITLE
feat: enable forwards compat for lit1 directives

### DIFF
--- a/packages/lit-html/src/directive.ts
+++ b/packages/lit-html/src/directive.ts
@@ -97,6 +97,11 @@ export const directive = <C extends DirectiveClass>(c: C) => (
  * `directive`.
  */
 export abstract class Directive {
+  /**
+   * @nocollapse
+   * @internal
+   */
+  static readonly _$isDirectiveClass$ = true;
   //@internal
   __part: Part;
   //@internal


### PR DESCRIPTION
Allows users in lit1 land to write class directives and switch to lit2 without causing build failures. We don't actually use this property in Lit2.

SEE: #1654