### PR TITLE
[lit-html] add Lit 2 directive syntax to Lit 1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,10 @@
 /lit-html.d.ts.map
 /lit-html.js
 /lit-html.js.map
+/directive.d.ts*
+/directive.js*
+/async-directive.d.ts*
+/async-directive.js*
 /test/**/*.d.ts
 /test/**/*.d.ts.map
 /test/**/*.js

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,8 @@
 /directive.js*
 /async-directive.d.ts*
 /async-directive.js*
+/directive-helpers.d.ts*
+/directive-helpers.js*
 /test/**/*.d.ts
 /test/**/*.d.ts.map
 /test/**/*.js

--- a/src/async-directive.ts
+++ b/src/async-directive.ts
@@ -78,6 +78,13 @@ export abstract class AsyncDirective extends Directive {
   // eslint-disable-next-line @typescript-eslint/no-empty-function
   protected disconnected() {
   }
+  /**
+   * User callback to restore the working state of the directive prior to the next
+   * render. This should generally re-do the work that was undone in `disconnected`.
+   *
+   * NOTE: In lit-html 1.x, the `disconnected` and `reconnected` callbacks WILL NOT BE
+   * CALLED. The interface is provided here for forward-compatible directive authoring only.
+   */
   // eslint-disable-next-line @typescript-eslint/no-empty-function
   protected reconnected() {
   }

--- a/src/async-directive.ts
+++ b/src/async-directive.ts
@@ -66,14 +66,14 @@ export abstract class AsyncDirective extends Directive {
   }
 
   /**
-   * User callbacks for implementing logic to release any
+   * User callback for implementing logic to release any
    * resources/subscriptions that may have been retained by this directive.
    * Since directives may also be re-connected, `reconnected` should also be
    * implemented to restore the working state of the directive prior to the next
    * render.
    *
-   * In the v1 version of these APIs, we don't monitor for disconnection and
-   * reconnection.
+   * NOTE: In lit-html 1.x, the `disconnected` and `reconnected` callbacks WILL NOT BE
+   * CALLED. The interface is provided here for forward-compatible directive authoring only.
    */
   // eslint-disable-next-line @typescript-eslint/no-empty-function
   protected disconnected() {

--- a/src/async-directive.ts
+++ b/src/async-directive.ts
@@ -75,8 +75,10 @@ export abstract class AsyncDirective extends Directive {
    * In the v1 version of these APIs, we don't monitor for disconnection and
    * reconnection, we only call these methods when setValue is called.
    */
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
   protected disconnected() {
   }
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
   protected reconnected() {
   }
 }

--- a/src/async-directive.ts
+++ b/src/async-directive.ts
@@ -1,0 +1,81 @@
+/**
+ * @license
+ * Copyright (c) 2021 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+import { Directive, Part, PartInfo } from "./directive.js";
+import * as legacyLit from "./lit-html.js";
+
+/**
+ * A superclass for directives that need to asynchronously update.
+ */
+export abstract class AsyncDirective extends Directive {
+  private readonly ddPart: legacyLit.Part;
+  private renderedYet = false;
+
+  constructor(partInfo: PartInfo) {
+    super(partInfo);
+    this.ddPart = (partInfo as Part).legacyPart;
+  }
+
+  private ddGetNode(): Node | undefined {
+    if (this.ddPart instanceof legacyLit.NodePart) {
+      return this.ddPart.startNode;
+    } else if (this.ddPart instanceof legacyLit.EventPart) {
+      return this.ddPart.element;
+    } else if (this.ddPart instanceof legacyLit.BooleanAttributePart) {
+      return this.ddPart.element;
+    } else if (
+      this.ddPart instanceof legacyLit.PropertyPart ||
+      this.ddPart instanceof legacyLit.AttributePart
+    ) {
+      return this.ddPart.committer.element;
+    }
+    return undefined;
+  }
+
+  private shouldRender() {
+    if (!this.renderedYet) {
+      this.renderedYet = true;
+      return true;
+    }
+    const node = this.ddGetNode();
+    if (node != null && !node.isConnected) {
+      // node is disconnected, do not render
+      return false;
+    }
+    return true;
+  }
+
+  setValue(value: unknown) {
+    if (!this.shouldRender()) {
+      // node is disconnected, do nothing.
+      return;
+    }
+
+    this.ddPart.setValue(value);
+    this.ddPart.commit();
+  }
+
+  /**
+   * User callbacks for implementing logic to release any
+   * resources/subscriptions that may have been retained by this directive.
+   * Since directives may also be re-connected, `reconnected` should also be
+   * implemented to restore the working state of the directive prior to the next
+   * render.
+   *
+   * In the v1 version of these APIs, we don't monitor for disconnection and
+   * reconnection, we only call these methods when setValue is called.
+   */
+  protected disconnected() {}
+  protected reconnected() {}
+}

--- a/src/async-directive.ts
+++ b/src/async-directive.ts
@@ -73,7 +73,7 @@ export abstract class AsyncDirective extends Directive {
    * render.
    *
    * In the v1 version of these APIs, we don't monitor for disconnection and
-   * reconnection, we only call these methods when setValue is called.
+   * reconnection.
    */
   // eslint-disable-next-line @typescript-eslint/no-empty-function
   protected disconnected() {

--- a/src/async-directive.ts
+++ b/src/async-directive.ts
@@ -48,11 +48,7 @@ export abstract class AsyncDirective extends Directive {
       return true;
     }
     const node = this._legacyGetNode();
-    if (node != null && !node.isConnected) {
-      // node is disconnected, do not render
-      return false;
-    }
-    return true;
+    return !!(node?.isConnected);
   }
 
   setValue(value: unknown) {

--- a/src/async-directive.ts
+++ b/src/async-directive.ts
@@ -13,41 +13,41 @@
  */
 
 import {Directive, Part, PartInfo} from './directive.js';
-import * as legacyLit from './lit-html.js';
+import {AttributePart as LegacyAttributePart, BooleanAttributePart as LegacyBooleanAttributePart, EventPart as LegacyEventPart, NodePart as LegacyNodePart, Part as LegacyPart, PropertyPart as LegacyPropertyPart,} from './lit-html.js';
 
 /**
  * A superclass for directives that need to asynchronously update.
  */
 export abstract class AsyncDirective extends Directive {
-  private readonly ddPart: legacyLit.Part;
-  private renderedYet = false;
+  private readonly _legacyPart: LegacyPart;
+  private _renderedYet = false;
 
   constructor(partInfo: PartInfo) {
     super(partInfo);
-    this.ddPart = (partInfo as Part).legacyPart;
+    this._legacyPart = (partInfo as Part).legacyPart;
   }
 
-  private ddGetNode(): Node|undefined {
-    if (this.ddPart instanceof legacyLit.NodePart) {
-      return this.ddPart.startNode;
-    } else if (this.ddPart instanceof legacyLit.EventPart) {
-      return this.ddPart.element;
-    } else if (this.ddPart instanceof legacyLit.BooleanAttributePart) {
-      return this.ddPart.element;
+  private _legacyGetNode(): Node|undefined {
+    if (this._legacyPart instanceof LegacyNodePart) {
+      return this._legacyPart.startNode;
+    } else if (this._legacyPart instanceof LegacyEventPart) {
+      return this._legacyPart.element;
+    } else if (this._legacyPart instanceof LegacyBooleanAttributePart) {
+      return this._legacyPart.element;
     } else if (
-        this.ddPart instanceof legacyLit.PropertyPart ||
-        this.ddPart instanceof legacyLit.AttributePart) {
-      return this.ddPart.committer.element;
+        this._legacyPart instanceof LegacyPropertyPart ||
+        this._legacyPart instanceof LegacyAttributePart) {
+      return this._legacyPart.committer.element;
     }
     return undefined;
   }
 
-  private shouldRender() {
-    if (!this.renderedYet) {
-      this.renderedYet = true;
+  private _shouldRender() {
+    if (!this._renderedYet) {
+      this._renderedYet = true;
       return true;
     }
-    const node = this.ddGetNode();
+    const node = this._legacyGetNode();
     if (node != null && !node.isConnected) {
       // node is disconnected, do not render
       return false;
@@ -56,13 +56,13 @@ export abstract class AsyncDirective extends Directive {
   }
 
   setValue(value: unknown) {
-    if (!this.shouldRender()) {
+    if (!this._shouldRender()) {
       // node is disconnected, do nothing.
       return;
     }
 
-    this.ddPart.setValue(value);
-    this.ddPart.commit();
+    this._legacyPart.setValue(value);
+    this._legacyPart.commit();
   }
 
   /**
@@ -72,18 +72,21 @@ export abstract class AsyncDirective extends Directive {
    * implemented to restore the working state of the directive prior to the next
    * render.
    *
-   * NOTE: In lit-html 1.x, the `disconnected` and `reconnected` callbacks WILL NOT BE
-   * CALLED. The interface is provided here for forward-compatible directive authoring only.
+   * NOTE: In lit-html 1.x, the `disconnected` and `reconnected` callbacks WILL
+   * NOT BE CALLED. The interface is provided here for forward-compatible
+   * directive authoring only.
    */
   // eslint-disable-next-line @typescript-eslint/no-empty-function
   protected disconnected() {
   }
   /**
-   * User callback to restore the working state of the directive prior to the next
-   * render. This should generally re-do the work that was undone in `disconnected`.
+   * User callback to restore the working state of the directive prior to the
+   * next render. This should generally re-do the work that was undone in
+   * `disconnected`.
    *
-   * NOTE: In lit-html 1.x, the `disconnected` and `reconnected` callbacks WILL NOT BE
-   * CALLED. The interface is provided here for forward-compatible directive authoring only.
+   * NOTE: In lit-html 1.x, the `disconnected` and `reconnected` callbacks WILL
+   * NOT BE CALLED. The interface is provided here for forward-compatible
+   * directive authoring only.
    */
   // eslint-disable-next-line @typescript-eslint/no-empty-function
   protected reconnected() {

--- a/src/async-directive.ts
+++ b/src/async-directive.ts
@@ -12,8 +12,8 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import { Directive, Part, PartInfo } from "./directive.js";
-import * as legacyLit from "./lit-html.js";
+import {Directive, Part, PartInfo} from './directive.js';
+import * as legacyLit from './lit-html.js';
 
 /**
  * A superclass for directives that need to asynchronously update.
@@ -27,7 +27,7 @@ export abstract class AsyncDirective extends Directive {
     this.ddPart = (partInfo as Part).legacyPart;
   }
 
-  private ddGetNode(): Node | undefined {
+  private ddGetNode(): Node|undefined {
     if (this.ddPart instanceof legacyLit.NodePart) {
       return this.ddPart.startNode;
     } else if (this.ddPart instanceof legacyLit.EventPart) {
@@ -35,9 +35,8 @@ export abstract class AsyncDirective extends Directive {
     } else if (this.ddPart instanceof legacyLit.BooleanAttributePart) {
       return this.ddPart.element;
     } else if (
-      this.ddPart instanceof legacyLit.PropertyPart ||
-      this.ddPart instanceof legacyLit.AttributePart
-    ) {
+        this.ddPart instanceof legacyLit.PropertyPart ||
+        this.ddPart instanceof legacyLit.AttributePart) {
       return this.ddPart.committer.element;
     }
     return undefined;
@@ -76,6 +75,8 @@ export abstract class AsyncDirective extends Directive {
    * In the v1 version of these APIs, we don't monitor for disconnection and
    * reconnection, we only call these methods when setValue is called.
    */
-  protected disconnected() {}
-  protected reconnected() {}
+  protected disconnected() {
+  }
+  protected reconnected() {
+  }
 }

--- a/src/directive-helpers.ts
+++ b/src/directive-helpers.ts
@@ -1,0 +1,45 @@
+/**
+ * @license
+ * Copyright (c) 2021 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+import { ChildPart } from "./directive.js";
+import { TemplateResult } from "./lit-html.js";
+
+/**
+ * Tests if a value is a TemplateResult.
+ */
+export const isTemplateResult = (value: unknown): value is TemplateResult =>
+  value instanceof TemplateResult;
+
+/**
+ * Yields all toplevel nodes inside the dom range managed by the ChildPart.
+ *
+ * So if the ChildPart has rendered:
+ *     html`<label><input></label> <div></div>`
+ *
+ * This function will yield the label and the div, but not the input.
+ */
+export function getRenderedNodes(childPart: ChildPart) {
+  const results = [];
+  const impl = childPart;
+  const part = impl.legacyPart;
+  for (
+    let node: Node | null = part.startNode;
+    node && node !== part.endNode;
+    node = node.nextSibling
+  ) {
+    const n: Node = node;
+    results.push(n);
+  }
+  return results;
+}

--- a/src/directive-helpers.ts
+++ b/src/directive-helpers.ts
@@ -12,10 +12,10 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {TemplateResult} from "./lit-html.js";
+import {TemplateResult} from './lit-html.js';
 
 /**
  * Tests if a value is a TemplateResult.
  */
 export const isTemplateResult = (value: unknown): value is TemplateResult =>
-  value instanceof TemplateResult;
+    value instanceof TemplateResult;

--- a/src/directive-helpers.ts
+++ b/src/directive-helpers.ts
@@ -12,7 +12,7 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import { TemplateResult } from "./lit-html.js";
+import {TemplateResult} from "./lit-html.js";
 
 /**
  * Tests if a value is a TemplateResult.

--- a/src/directive-helpers.ts
+++ b/src/directive-helpers.ts
@@ -13,6 +13,7 @@
  */
 
 import {TemplateResult} from './lit-html.js';
+export {isPrimitive} from './lib/parts.js';
 
 /**
  * Tests if a value is a TemplateResult.

--- a/src/directive-helpers.ts
+++ b/src/directive-helpers.ts
@@ -12,7 +12,6 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import { ChildPart } from "./directive.js";
 import { TemplateResult } from "./lit-html.js";
 
 /**
@@ -20,26 +19,3 @@ import { TemplateResult } from "./lit-html.js";
  */
 export const isTemplateResult = (value: unknown): value is TemplateResult =>
   value instanceof TemplateResult;
-
-/**
- * Yields all toplevel nodes inside the dom range managed by the ChildPart.
- *
- * So if the ChildPart has rendered:
- *     html`<label><input></label> <div></div>`
- *
- * This function will yield the label and the div, but not the input.
- */
-export function getRenderedNodes(childPart: ChildPart) {
-  const results = [];
-  const impl = childPart;
-  const part = impl.legacyPart;
-  for (
-    let node: Node | null = part.startNode;
-    node && node !== part.endNode;
-    node = node.nextSibling
-  ) {
-    const n: Node = node;
-    results.push(n);
-  }
-  return results;
-}

--- a/src/directive.ts
+++ b/src/directive.ts
@@ -257,6 +257,10 @@ export abstract class Directive {
 /**
  * Creates a user-facing directive function from a Directive class. This
  * function has the same parameters as the directive's render() method.
+ *
+ * N.B. In Lit 2, the directive will lose state if another directive is
+ * executed on the same part as the directive instance is destroyed. This
+ * version deviates from this behavior and will keep its state.
  */
 export function directive<C extends DirectiveClass>(directiveClass: C) {
   const partToInstance =

--- a/src/directive.ts
+++ b/src/directive.ts
@@ -22,7 +22,7 @@ export const PartType = {
   BOOLEAN_ATTRIBUTE: 4,
   EVENT: 5,
   ELEMENT: 6,
-} as const;
+} as const ;
 
 export type PartType = typeof PartType[keyof typeof PartType];
 
@@ -32,10 +32,11 @@ export interface ChildPartInfo {
 
 export interface AttributePartInfo {
   readonly type:|typeof PartType.ATTRIBUTE|
-               typeof PartType.PROPERTY|
-               typeof PartType.BOOLEAN_ATTRIBUTE|typeof PartType.EVENT;
-  readonly strings?: ReadonlyArray<string>; readonly name: string; readonly tagName:
-                                                                                string;
+      typeof PartType.PROPERTY|typeof PartType.BOOLEAN_ATTRIBUTE|
+      typeof PartType.EVENT;
+  readonly strings?: ReadonlyArray<string>;
+  readonly name: string;
+  readonly tagName: string;
 }
 
 export type Part = ChildPart|AttributePart|BooleanAttributePart|EventPart;
@@ -217,7 +218,7 @@ function legacyPartToPart(part: legacyLit.Part): Part {
 export type PartInfo = ChildPartInfo|AttributePartInfo;
 
 export interface DirectiveClass {
-  new (part: PartInfo): Directive;
+  new(part: PartInfo): Directive;
 }
 
 /**
@@ -261,7 +262,7 @@ export function directive<C extends DirectiveClass>(directiveClass: C) {
       if (cached === undefined) {
         modernPart = legacyPartToPart(part);
         instance = new directiveClass(modernPart) as InstanceType<C>;
-        partToInstance.set(part, [modernPart, instance] as const);
+        partToInstance.set(part, [modernPart, instance] as const );
       } else {
         modernPart = cached[0];
         instance = cached[1];

--- a/src/directive.ts
+++ b/src/directive.ts
@@ -12,8 +12,8 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import { directive as legacyDirective } from "./lib/directive.js";
-import * as legacyLit from "./lit-html.js";
+import {directive as legacyDirective} from './lib/directive.js';
+import * as legacyLit from './lit-html.js';
 
 export const PartType = {
   ATTRIBUTE: 1,
@@ -31,17 +31,14 @@ export type ChildPartInfo = {
 };
 
 export type AttributePartInfo = {
-  readonly type:
-    | typeof PartType.ATTRIBUTE
-    | typeof PartType.PROPERTY
-    | typeof PartType.BOOLEAN_ATTRIBUTE
-    | typeof PartType.EVENT;
-  readonly strings?: ReadonlyArray<string>;
-  readonly name: string;
-  readonly tagName: string;
+  readonly type:|typeof PartType.ATTRIBUTE|
+               typeof PartType.PROPERTY|
+               typeof PartType.BOOLEAN_ATTRIBUTE|typeof PartType.EVENT;
+  readonly strings?: ReadonlyArray<string>; readonly name: string; readonly tagName:
+                                                                                string;
 };
 
-export type Part = ChildPart | AttributePart | BooleanAttributePart | EventPart;
+export type Part = ChildPart|AttributePart|BooleanAttributePart|EventPart;
 
 type Interface<T> = {
   [P in keyof T]: T[P];
@@ -50,7 +47,7 @@ type Interface<T> = {
 export type ChildPart = Interface<ChildPartImpl>;
 class ChildPartImpl {
   readonly type = PartType.CHILD;
-  readonly options: legacyLit.RenderOptions | undefined;
+  readonly options: legacyLit.RenderOptions|undefined;
   constructor(readonly legacyPart: legacyLit.NodePart) {
     this.options = legacyPart.options;
   }
@@ -72,11 +69,8 @@ export function getRenderedNodes(childPart: ChildPart) {
   const results = [];
   const impl = childPart as ChildPartImpl;
   const part = impl.legacyPart;
-  for (
-    let node: Node | null = part.startNode;
-    node && node !== part.endNode;
-    node = node.nextSibling
-  ) {
+  for (let node: Node|null = part.startNode; node && node !== part.endNode;
+       node = node.nextSibling) {
     const n: Node = node;
     results.push(n);
   }
@@ -85,9 +79,9 @@ export function getRenderedNodes(childPart: ChildPart) {
 
 export type AttributePart = Interface<AttributePartImpl>;
 class AttributePartImpl {
-  readonly type: typeof PartType.ATTRIBUTE | typeof PartType.PROPERTY;
+  readonly type: typeof PartType.ATTRIBUTE|typeof PartType.PROPERTY;
 
-  get options(): legacyLit.RenderOptions | undefined {
+  get options(): legacyLit.RenderOptions|undefined {
     return undefined;
   }
   get name(): string {
@@ -110,9 +104,8 @@ class AttributePartImpl {
     return this.element.tagName;
   }
 
-  constructor(
-    readonly legacyPart: legacyLit.AttributePart | legacyLit.PropertyPart
-  ) {
+  constructor(readonly legacyPart: legacyLit.AttributePart|
+              legacyLit.PropertyPart) {
     if (legacyPart instanceof legacyLit.PropertyPart) {
       this.type = PartType.PROPERTY;
     } else {
@@ -125,7 +118,7 @@ export type BooleanAttributePart = Interface<BooleanAttributePartImpl>;
 class BooleanAttributePartImpl {
   readonly type = PartType.BOOLEAN_ATTRIBUTE;
 
-  get options(): legacyLit.RenderOptions | undefined {
+  get options(): legacyLit.RenderOptions|undefined {
     return undefined;
   }
   get name(): string {
@@ -148,7 +141,8 @@ class BooleanAttributePartImpl {
     return this.element.tagName;
   }
 
-  constructor(readonly legacyPart: legacyLit.BooleanAttributePart) {}
+  constructor(readonly legacyPart: legacyLit.BooleanAttributePart) {
+  }
 }
 
 /**
@@ -165,9 +159,10 @@ class BooleanAttributePartImpl {
 export type EventPart = Interface<EventPartImpl>;
 class EventPartImpl {
   readonly type = PartType.EVENT;
-  constructor(readonly legacyPart: legacyLit.EventPart) {}
+  constructor(readonly legacyPart: legacyLit.EventPart) {
+  }
 
-  get options(): legacyLit.RenderOptions | undefined {
+  get options(): legacyLit.RenderOptions|undefined {
     return undefined;
   }
   get name(): string {
@@ -205,9 +200,8 @@ function legacyPartToPart(part: legacyLit.Part): Part {
   } else if (part instanceof legacyLit.BooleanAttributePart) {
     return new BooleanAttributePartImpl(part);
   } else if (
-    part instanceof legacyLit.PropertyPart ||
-    part instanceof legacyLit.AttributePart
-  ) {
+      part instanceof legacyLit.PropertyPart ||
+      part instanceof legacyLit.AttributePart) {
     return new AttributePartImpl(part);
   }
   // ElementPartInfo doesn't exist in lit-html v1
@@ -220,7 +214,7 @@ function legacyPartToPart(part: legacyLit.Part): Part {
  * This is useful for checking that a directive is attached to a valid part,
  * such as with directive that can only be used on attribute bindings.
  */
-export type PartInfo = ChildPartInfo | AttributePartInfo;
+export type PartInfo = ChildPartInfo|AttributePartInfo;
 
 export type DirectiveClass = {
   new (part: PartInfo): Directive;
@@ -230,7 +224,7 @@ export type DirectiveClass = {
  * This utility type extracts the signature of a directive class's render()
  * method so we can use it for the type of the generated directive function.
  */
-export type DirectiveParameters<C extends Directive> = Parameters<C["render"]>;
+export type DirectiveParameters<C extends Directive> = Parameters<C['render']>;
 
 /**
  * A generated directive function doesn't evaluate the directive, but just
@@ -249,7 +243,8 @@ export type DirectiveResult<C extends DirectiveClass = DirectiveClass> = {
  * `directive`.
  */
 export abstract class Directive {
-  constructor(_partInfo: PartInfo) {}
+  constructor(_partInfo: PartInfo) {
+  }
   abstract render(...props: Array<unknown>): unknown;
   update(_part: Part, props: Array<unknown>): unknown {
     return this.render(...props);
@@ -257,10 +252,8 @@ export abstract class Directive {
 }
 
 export function directive<C extends DirectiveClass>(directiveClass: C) {
-  const partToInstance = new WeakMap<
-    legacyLit.Part,
-    readonly [Part, InstanceType<C>]
-  >();
+  const partToInstance =
+      new WeakMap<legacyLit.Part, readonly[Part, InstanceType<C>]>();
   const result = legacyDirective((...props: unknown[]) => {
     return (part: legacyLit.Part) => {
       const cached = partToInstance.get(part);
@@ -278,7 +271,6 @@ export function directive<C extends DirectiveClass>(directiveClass: C) {
     };
   });
 
-  return result as (
-    ...props: DirectiveParameters<InstanceType<C>>
-  ) => (part: legacyLit.Part) => void;
+  return result as (...props: DirectiveParameters<InstanceType<C>>) =>
+             (part: legacyLit.Part) => void;
 }

--- a/src/directive.ts
+++ b/src/directive.ts
@@ -22,7 +22,7 @@ export const PartType = {
   BOOLEAN_ATTRIBUTE: 4,
   EVENT: 5,
   ELEMENT: 6,
-} as const ;
+} as const;
 
 export type PartType = typeof PartType[keyof typeof PartType];
 
@@ -145,7 +145,7 @@ class BooleanAttributePartImpl {
  * add/removeEventListener if the listener changes frequently, such as when an
  * inline function is used as a listener.
  *
- * Because event options are passed when adding listeners, we must take case
+ * Because event options are passed when adding listeners, we must take care
  * to add and remove the part as a listener when the event options change.
  */
 export type EventPart = Interface<EventPartImpl>;
@@ -258,7 +258,7 @@ export function directive<C extends DirectiveClass>(directiveClass: C) {
       if (cached === undefined) {
         modernPart = legacyPartToPart(part);
         instance = new directiveClass(modernPart) as InstanceType<C>;
-        partToInstance.set(part, [modernPart, instance] as const );
+        partToInstance.set(part, [modernPart, instance] as const);
       } else {
         modernPart = cached[0];
         instance = cached[1];

--- a/src/directive.ts
+++ b/src/directive.ts
@@ -47,7 +47,7 @@ type Interface<T> = {
 };
 
 export type ChildPart = Interface<ChildPartImpl>;
-export type {ChildPartImpl};
+export type{ChildPartImpl};
 
 class ChildPartImpl {
   readonly type = PartType.CHILD;
@@ -72,7 +72,7 @@ class ChildPartImpl {
 }
 
 export type AttributePart = Interface<AttributePartImpl>;
-export type {AttributePartImpl};
+export type{AttributePartImpl};
 
 class AttributePartImpl {
   readonly type: typeof PartType.ATTRIBUTE|typeof PartType.PROPERTY;
@@ -112,7 +112,7 @@ class AttributePartImpl {
 }
 
 export type BooleanAttributePart = Interface<BooleanAttributePartImpl>;
-export type {BooleanAttributePartImpl};
+export type{BooleanAttributePartImpl};
 
 class BooleanAttributePartImpl {
   readonly type = PartType.BOOLEAN_ATTRIBUTE;
@@ -157,7 +157,7 @@ class BooleanAttributePartImpl {
  * to add and remove the part as a listener when the event options change.
  */
 export type EventPart = Interface<EventPartImpl>;
-export type {EventPartImpl};
+export type{EventPartImpl};
 class EventPartImpl {
   readonly type = PartType.EVENT;
   constructor(readonly legacyPart: legacyLit.EventPart) {

--- a/src/directive.ts
+++ b/src/directive.ts
@@ -59,26 +59,6 @@ class ChildPartImpl {
   }
 }
 
-/**
- * Yields all toplevel nodes inside the dom range managed by the ChildPart.
- *
- * So if the ChildPart has rendered:
- *     html`<label><input></label> <div></div>`
- *
- * This function will yield the label and the div, but not the input.
- */
-export function getRenderedNodes(childPart: ChildPart) {
-  const results = [];
-  const impl = childPart as ChildPartImpl;
-  const part = impl.legacyPart;
-  for (let node: Node|null = part.startNode; node && node !== part.endNode;
-       node = node.nextSibling) {
-    const n: Node = node;
-    results.push(n);
-  }
-  return results;
-}
-
 export type AttributePart = Interface<AttributePartImpl>;
 class AttributePartImpl {
   readonly type: typeof PartType.ATTRIBUTE|typeof PartType.PROPERTY;

--- a/src/directive.ts
+++ b/src/directive.ts
@@ -249,9 +249,9 @@ export type DirectiveResult<C extends DirectiveClass = DirectiveClass> = {
  * `directive`.
  */
 export abstract class Directive {
-  constructor(partInfo: PartInfo) {}
+  constructor(_partInfo: PartInfo) {}
   abstract render(...props: Array<unknown>): unknown;
-  update(part: Part, props: Array<unknown>): unknown {
+  update(_part: Part, props: Array<unknown>): unknown {
     return this.render(...props);
   }
 }

--- a/src/directive.ts
+++ b/src/directive.ts
@@ -22,7 +22,7 @@ export const PartType = {
   BOOLEAN_ATTRIBUTE: 4,
   EVENT: 5,
   ELEMENT: 6,
-} as const;
+} as const ;
 
 export type PartType = typeof PartType[keyof typeof PartType];
 
@@ -258,7 +258,7 @@ export function directive<C extends DirectiveClass>(directiveClass: C) {
       if (cached === undefined) {
         modernPart = legacyPartToPart(part);
         instance = new directiveClass(modernPart) as InstanceType<C>;
-        partToInstance.set(part, [modernPart, instance] as const);
+        partToInstance.set(part, [modernPart, instance] as const );
       } else {
         modernPart = cached[0];
         instance = cached[1];

--- a/src/directive.ts
+++ b/src/directive.ts
@@ -58,11 +58,11 @@ class ChildPartImpl {
     return this.legacyPart.startNode.parentNode!;
   }
 
-  get startNode(): Node | null {
+  get startNode(): Node|null {
     return this.legacyPart.startNode;
   }
 
-  get endNode(): Node | null {
+  get endNode(): Node|null {
     return this.legacyPart.endNode;
   }
 }

--- a/src/directive.ts
+++ b/src/directive.ts
@@ -1,0 +1,284 @@
+/**
+ * @license
+ * Copyright (c) 2021 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+import { directive as legacyDirective } from "./lib/directive.js";
+import * as legacyLit from "./lit-html.js";
+
+export const PartType = {
+  ATTRIBUTE: 1,
+  CHILD: 2,
+  PROPERTY: 3,
+  BOOLEAN_ATTRIBUTE: 4,
+  EVENT: 5,
+  ELEMENT: 6,
+} as const;
+
+export type PartType = typeof PartType[keyof typeof PartType];
+
+export type ChildPartInfo = {
+  readonly type: typeof PartType.CHILD;
+};
+
+export type AttributePartInfo = {
+  readonly type:
+    | typeof PartType.ATTRIBUTE
+    | typeof PartType.PROPERTY
+    | typeof PartType.BOOLEAN_ATTRIBUTE
+    | typeof PartType.EVENT;
+  readonly strings?: ReadonlyArray<string>;
+  readonly name: string;
+  readonly tagName: string;
+};
+
+export type Part = ChildPart | AttributePart | BooleanAttributePart | EventPart;
+
+type Interface<T> = {
+  [P in keyof T]: T[P];
+};
+
+export type ChildPart = Interface<ChildPartImpl>;
+class ChildPartImpl {
+  readonly type = PartType.CHILD;
+  readonly options: legacyLit.RenderOptions | undefined;
+  constructor(readonly legacyPart: legacyLit.NodePart) {
+    this.options = legacyPart.options;
+  }
+
+  get parentNode(): Node {
+    return this.legacyPart.startNode.parentNode!;
+  }
+}
+
+/**
+ * Yields all toplevel nodes inside the dom range managed by the ChildPart.
+ *
+ * So if the ChildPart has rendered:
+ *     html`<label><input></label> <div></div>`
+ *
+ * This function will yield the label and the div, but not the input.
+ */
+export function getRenderedNodes(childPart: ChildPart) {
+  const results = [];
+  const impl = childPart as ChildPartImpl;
+  const part = impl.legacyPart;
+  for (
+    let node: Node | null = part.startNode;
+    node && node !== part.endNode;
+    node = node.nextSibling
+  ) {
+    const n: Node = node;
+    results.push(n);
+  }
+  return results;
+}
+
+export type AttributePart = Interface<AttributePartImpl>;
+class AttributePartImpl {
+  readonly type: typeof PartType.ATTRIBUTE | typeof PartType.PROPERTY;
+
+  get options(): legacyLit.RenderOptions | undefined {
+    return undefined;
+  }
+  get name(): string {
+    return this.legacyPart.committer.name;
+  }
+
+  get element(): Element {
+    return this.legacyPart.committer.element;
+  }
+
+  /**
+   * If this attribute part represents an interpolation, this contains the
+   * static strings of the interpolation. For single-value, complete bindings,
+   * this is undefined.
+   */
+  get strings() {
+    return this.legacyPart.committer.strings;
+  }
+  get tagName() {
+    return this.element.tagName;
+  }
+
+  constructor(
+    readonly legacyPart: legacyLit.AttributePart | legacyLit.PropertyPart
+  ) {
+    if (legacyPart instanceof legacyLit.PropertyPart) {
+      this.type = PartType.PROPERTY;
+    } else {
+      this.type = PartType.ATTRIBUTE;
+    }
+  }
+}
+
+export type BooleanAttributePart = Interface<BooleanAttributePartImpl>;
+class BooleanAttributePartImpl {
+  readonly type = PartType.BOOLEAN_ATTRIBUTE;
+
+  get options(): legacyLit.RenderOptions | undefined {
+    return undefined;
+  }
+  get name(): string {
+    return this.legacyPart.name;
+  }
+
+  get element(): Element {
+    return this.legacyPart.element;
+  }
+
+  /**
+   * If this attribute part represents an interpolation, this contains the
+   * static strings of the interpolation. For single-value, complete bindings,
+   * this is undefined.
+   */
+  get strings() {
+    return this.legacyPart.strings;
+  }
+  get tagName() {
+    return this.element.tagName;
+  }
+
+  constructor(readonly legacyPart: legacyLit.BooleanAttributePart) {}
+}
+
+/**
+ * An AttributePart that manages an event listener via add/removeEventListener.
+ *
+ * This part works by adding itself as the event listener on an element, then
+ * delegating to the value passed to it. This reduces the number of calls to
+ * add/removeEventListener if the listener changes frequently, such as when an
+ * inline function is used as a listener.
+ *
+ * Because event options are passed when adding listeners, we must take case
+ * to add and remove the part as a listener when the event options change.
+ */
+export type EventPart = Interface<EventPartImpl>;
+class EventPartImpl {
+  readonly type = PartType.EVENT;
+  constructor(readonly legacyPart: legacyLit.EventPart) {}
+
+  get options(): legacyLit.RenderOptions | undefined {
+    return undefined;
+  }
+  get name(): string {
+    return this.legacyPart.eventName;
+  }
+
+  get element(): Element {
+    return this.legacyPart.element;
+  }
+
+  /**
+   * If this attribute part represents an interpolation, this contains the
+   * static strings of the interpolation. For single-value, complete bindings,
+   * this is undefined.
+   */
+  get strings() {
+    return undefined;
+  }
+  get tagName() {
+    return this.element.tagName;
+  }
+
+  handleEvent(event: Event) {
+    this.legacyPart.handleEvent(event);
+  }
+}
+
+// no equivalent for ElementPart in v1
+
+function legacyPartToPart(part: legacyLit.Part): Part {
+  if (part instanceof legacyLit.NodePart) {
+    return new ChildPartImpl(part);
+  } else if (part instanceof legacyLit.EventPart) {
+    return new EventPartImpl(part);
+  } else if (part instanceof legacyLit.BooleanAttributePart) {
+    return new BooleanAttributePartImpl(part);
+  } else if (
+    part instanceof legacyLit.PropertyPart ||
+    part instanceof legacyLit.AttributePart
+  ) {
+    return new AttributePartImpl(part);
+  }
+  // ElementPartInfo doesn't exist in lit-html v1
+  throw new Error(`Unknown part type`);
+}
+
+/**
+ * Information about the part a directive is bound to.
+ *
+ * This is useful for checking that a directive is attached to a valid part,
+ * such as with directive that can only be used on attribute bindings.
+ */
+export type PartInfo = ChildPartInfo | AttributePartInfo;
+
+export type DirectiveClass = {
+  new (part: PartInfo): Directive;
+};
+
+/**
+ * This utility type extracts the signature of a directive class's render()
+ * method so we can use it for the type of the generated directive function.
+ */
+export type DirectiveParameters<C extends Directive> = Parameters<C["render"]>;
+
+/**
+ * A generated directive function doesn't evaluate the directive, but just
+ * returns a DirectiveResult object that captures the arguments.
+ */
+export type DirectiveResult<C extends DirectiveClass = DirectiveClass> = {
+  /** @internal */
+  _$litDirective$: C;
+  /** @internal */
+  values: DirectiveParameters<InstanceType<C>>;
+};
+
+/**
+ * Base class for creating custom directives. Users should extend this class,
+ * implement `render` and/or `update`, and then pass their subclass to
+ * `directive`.
+ */
+export abstract class Directive {
+  constructor(partInfo: PartInfo) {}
+  abstract render(...props: Array<unknown>): unknown;
+  update(part: Part, props: Array<unknown>): unknown {
+    return this.render(...props);
+  }
+}
+
+export function directive<C extends DirectiveClass>(directiveClass: C) {
+  const partToInstance = new WeakMap<
+    legacyLit.Part,
+    readonly [Part, InstanceType<C>]
+  >();
+  const result = legacyDirective((...props: unknown[]) => {
+    return (part: legacyLit.Part) => {
+      const cached = partToInstance.get(part);
+      let modernPart, instance;
+      if (cached === undefined) {
+        modernPart = legacyPartToPart(part);
+        instance = new directiveClass(modernPart) as InstanceType<C>;
+        partToInstance.set(part, [modernPart, instance] as const);
+      } else {
+        modernPart = cached[0];
+        instance = cached[1];
+      }
+      part.setValue(instance.update(modernPart, props));
+      part.commit();
+    };
+  });
+
+  return result as (
+    ...props: DirectiveParameters<InstanceType<C>>
+  ) => (part: legacyLit.Part) => void;
+}

--- a/src/directive.ts
+++ b/src/directive.ts
@@ -31,6 +31,7 @@ export interface ChildPartInfo {
 }
 
 export interface AttributePartInfo {
+  // eslint-disable-next-line @typescript-eslint/type-annotation-spacing
   readonly type:|typeof PartType.ATTRIBUTE|
       typeof PartType.PROPERTY|typeof PartType.BOOLEAN_ATTRIBUTE|
       typeof PartType.EVENT;
@@ -244,6 +245,7 @@ export type DirectiveResult<C extends DirectiveClass = DirectiveClass> = {
  * `directive`.
  */
 export abstract class Directive {
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
   constructor(_partInfo: PartInfo) {
   }
   abstract render(...props: Array<unknown>): unknown;

--- a/src/directive.ts
+++ b/src/directive.ts
@@ -57,6 +57,14 @@ class ChildPartImpl {
   get parentNode(): Node {
     return this.legacyPart.startNode.parentNode!;
   }
+
+  get startNode(): Node | null {
+    return this.legacyPart.startNode;
+  }
+
+  get endNode(): Node | null {
+    return this.legacyPart.endNode;
+  }
 }
 
 export type AttributePart = Interface<AttributePartImpl>;

--- a/src/directive.ts
+++ b/src/directive.ts
@@ -22,7 +22,7 @@ export const PartType = {
   BOOLEAN_ATTRIBUTE: 4,
   EVENT: 5,
   ELEMENT: 6,
-} as const ;
+} as const;
 
 export type PartType = typeof PartType[keyof typeof PartType];
 
@@ -50,8 +50,10 @@ export type ChildPart = Interface<ChildPartImpl>;
 class ChildPartImpl {
   readonly type = PartType.CHILD;
   readonly options: legacyLit.RenderOptions|undefined;
-  constructor(readonly legacyPart: legacyLit.NodePart) {
+  readonly legacyPart: legacyLit.NodePart;
+  constructor(legacyPart: legacyLit.NodePart) {
     this.options = legacyPart.options;
+    this.legacyPart = legacyPart;
   }
 
   get parentNode(): Node {
@@ -252,7 +254,7 @@ export function directive<C extends DirectiveClass>(directiveClass: C) {
       if (cached === undefined) {
         modernPart = legacyPartToPart(part);
         instance = new directiveClass(modernPart) as InstanceType<C>;
-        partToInstance.set(part, [modernPart, instance] as const );
+        partToInstance.set(part, [modernPart, instance] as const);
       } else {
         modernPart = cached[0];
         instance = cached[1];

--- a/src/directive.ts
+++ b/src/directive.ts
@@ -47,6 +47,8 @@ type Interface<T> = {
 };
 
 export type ChildPart = Interface<ChildPartImpl>;
+export type {ChildPartImpl};
+
 class ChildPartImpl {
   readonly type = PartType.CHILD;
   readonly options: legacyLit.RenderOptions|undefined;
@@ -70,12 +72,15 @@ class ChildPartImpl {
 }
 
 export type AttributePart = Interface<AttributePartImpl>;
+export type {AttributePartImpl};
+
 class AttributePartImpl {
   readonly type: typeof PartType.ATTRIBUTE|typeof PartType.PROPERTY;
 
   get options(): legacyLit.RenderOptions|undefined {
     return undefined;
   }
+
   get name(): string {
     return this.legacyPart.committer.name;
   }
@@ -107,12 +112,15 @@ class AttributePartImpl {
 }
 
 export type BooleanAttributePart = Interface<BooleanAttributePartImpl>;
+export type {BooleanAttributePartImpl};
+
 class BooleanAttributePartImpl {
   readonly type = PartType.BOOLEAN_ATTRIBUTE;
 
   get options(): legacyLit.RenderOptions|undefined {
     return undefined;
   }
+
   get name(): string {
     return this.legacyPart.name;
   }
@@ -149,6 +157,7 @@ class BooleanAttributePartImpl {
  * to add and remove the part as a listener when the event options change.
  */
 export type EventPart = Interface<EventPartImpl>;
+export type {EventPartImpl};
 class EventPartImpl {
   readonly type = PartType.EVENT;
   constructor(readonly legacyPart: legacyLit.EventPart) {
@@ -157,6 +166,7 @@ class EventPartImpl {
   get options(): legacyLit.RenderOptions|undefined {
     return undefined;
   }
+
   get name(): string {
     return this.legacyPart.eventName;
   }

--- a/src/directive.ts
+++ b/src/directive.ts
@@ -26,17 +26,17 @@ export const PartType = {
 
 export type PartType = typeof PartType[keyof typeof PartType];
 
-export type ChildPartInfo = {
+export interface ChildPartInfo {
   readonly type: typeof PartType.CHILD;
-};
+}
 
-export type AttributePartInfo = {
+export interface AttributePartInfo {
   readonly type:|typeof PartType.ATTRIBUTE|
                typeof PartType.PROPERTY|
                typeof PartType.BOOLEAN_ATTRIBUTE|typeof PartType.EVENT;
   readonly strings?: ReadonlyArray<string>; readonly name: string; readonly tagName:
                                                                                 string;
-};
+}
 
 export type Part = ChildPart|AttributePart|BooleanAttributePart|EventPart;
 
@@ -216,9 +216,9 @@ function legacyPartToPart(part: legacyLit.Part): Part {
  */
 export type PartInfo = ChildPartInfo|AttributePartInfo;
 
-export type DirectiveClass = {
+export interface DirectiveClass {
   new (part: PartInfo): Directive;
-};
+}
 
 /**
  * This utility type extracts the signature of a directive class's render()

--- a/src/directive.ts
+++ b/src/directive.ts
@@ -244,6 +244,10 @@ export abstract class Directive {
   }
 }
 
+/**
+ * Creates a user-facing directive function from a Directive class. This
+ * function has the same parameters as the directive's render() method.
+ */
 export function directive<C extends DirectiveClass>(directiveClass: C) {
   const partToInstance =
       new WeakMap<legacyLit.Part, readonly[Part, InstanceType<C>]>();

--- a/src/directive.ts
+++ b/src/directive.ts
@@ -22,7 +22,7 @@ export const PartType = {
   BOOLEAN_ATTRIBUTE: 4,
   EVENT: 5,
   ELEMENT: 6,
-} as const;
+} as const ;
 
 export type PartType = typeof PartType[keyof typeof PartType];
 
@@ -254,7 +254,7 @@ export function directive<C extends DirectiveClass>(directiveClass: C) {
       if (cached === undefined) {
         modernPart = legacyPartToPart(part);
         instance = new directiveClass(modernPart) as InstanceType<C>;
-        partToInstance.set(part, [modernPart, instance] as const);
+        partToInstance.set(part, [modernPart, instance] as const );
       } else {
         modernPart = cached[0];
         instance = cached[1];

--- a/src/test/directives/migration-directives_test.ts
+++ b/src/test/directives/migration-directives_test.ts
@@ -1,0 +1,208 @@
+/**
+ * @license
+ * Copyright (c) 2021 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+/// <reference path="../../../node_modules/@types/mocha/index.d.ts" />
+/// <reference path="../../../node_modules/@types/chai/index.d.ts" />
+
+import {Directive, directive, DirectiveParameters, Part, PartType} from '../../directive.js';
+import {render} from '../../lib/render.js';
+import {html} from '../../lit-html.js';
+import { stripExpressionMarkers } from '../test-utils/strip-markers.js';
+
+const assert = chai.assert;
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+/**
+ * adds the length of the parent /current node's tag name to the given value on update
+ */
+ class AddParentLengthDirective extends Directive {
+  _targetEl: Element|null = null;
+
+  render(value: number) {
+    return value.toString();
+  }
+
+  update(part: Part, [value]: DirectiveParameters<this>) {
+    const hasPrevTarget = !!this._targetEl;
+
+    if (!hasPrevTarget) {
+      switch (part.type) {
+        case PartType.ATTRIBUTE:
+        case PartType.PROPERTY:
+          this._targetEl = part.element;
+          break;
+        case PartType.CHILD:
+          this._targetEl = part.parentNode as Element;
+          break;
+        default:
+          throw new Error(`${part.name} is not supported for parent length directive`);
+      }
+    }
+
+    const parentNameLength = this._targetEl!.tagName.length;
+    return this.render(value + parentNameLength);
+  }
+}
+
+/**
+ * concats the parent / current element's tag name to the given value on update
+ */
+ class AddParentNameDirective extends Directive {
+  _targetEl: Element|null = null;
+
+  render(value: string|number) {
+    return value.toString();
+  }
+
+  update(part: Part, [value]: DirectiveParameters<this>) {
+    const hasPrevTarget = !!this._targetEl;
+
+    if (!hasPrevTarget) {
+      switch (part.type) {
+        case PartType.ATTRIBUTE:
+        case PartType.BOOLEAN_ATTRIBUTE:
+        case PartType.PROPERTY:
+          this._targetEl = part.element;
+          break;
+        case PartType.CHILD:
+          this._targetEl = part.parentNode as Element;
+          break;
+        default:
+          throw new Error(`${part.name} is not supported for parent length directive`);
+      }
+    }
+
+    const parentName = this._targetEl!.tagName.toLocaleLowerCase();
+    return this.render(`${value} ${parentName}`);
+  }
+}
+
+const addParentLength = directive(AddParentLengthDirective);
+const addParentName = directive(AddParentNameDirective);
+
+suite('migration directives', () => {
+  let container: HTMLDivElement;
+
+  setup(() => {
+    container = document.createElement('div');
+  });
+
+  suite('Each Part Type', () => {
+    test('ATTRIBUTE', () => {
+      const template = html`
+          <div
+              data-length=${addParentLength(5)}
+              data-name=${addParentName(5)}>
+          </div>`;
+      render(template, container);
+
+      const el = container.firstElementChild as HTMLDivElement;
+      const length = el.getAttribute('data-length');
+
+      assert.equal(length, '8');
+
+      const name = el.getAttribute('data-name');
+
+      assert.equal(name, '5 div');
+    });
+
+    test('BOOLEAN_ATTIBUTE', () => {
+      const template = html`
+          <article ?bool=${addParentLength(5)}></article>`;
+      const renderTemplate = () => render(template, container);
+
+      assert.throws(renderTemplate);
+    });
+
+    test('PROPERTY', () => {
+      const template = html`
+          <input .value=${addParentLength(5)}>
+          <input .value=${addParentName(5)}>`;
+      render(template, container);
+
+      const el = container.firstElementChild as HTMLInputElement;
+      const el2 = container.lastElementChild as HTMLInputElement;
+
+      const length = el.value;
+
+      assert.equal(length, '10');
+
+      const name = el2.value;
+
+      assert.equal(name, '5 input');
+    });
+
+    test('CHILD', () => {
+      const template = html`
+          <article>${addParentLength(5)}</article>
+          <article>${addParentName(5)}</article>`;
+      render(template, container);
+
+      const el = container.firstElementChild as HTMLInputElement;
+      const el2 = container.lastElementChild as HTMLInputElement;
+
+      const length = stripExpressionMarkers(el.textContent!).trim();
+
+      assert.equal(length, '12');
+
+      const name = stripExpressionMarkers(el2.textContent!).trim();
+
+      assert.equal(name, '5 article');
+    });
+
+    test('EVENT', () => {
+      const template = html`
+          <article @event=${addParentLength(5)}></article>`;
+      const renderTemplate = () => render(template, container);
+
+      assert.throws(renderTemplate);
+    });
+  });
+
+  test('part caching', () => {
+    const renderDirective = (val: number, useName = false) => {
+      let directive;
+
+      if (useName) {
+        directive = addParentName(val);
+      } else {
+        directive = addParentLength(val);
+      }
+
+      const template = html`
+          <input .value=${directive as unknown as string}></input>`;
+
+      render(template, container);
+    };
+
+    renderDirective(3);
+
+    let el = container.firstElementChild as HTMLInputElement;
+
+    assert.equal(el.value, '8');
+
+    renderDirective(4, true);
+
+    el = container.firstElementChild as HTMLInputElement;
+
+    assert.equal(el.value, '4 input');
+
+    renderDirective(5);
+
+    el = container.firstElementChild as HTMLInputElement;
+
+    assert.equal(el.value, '10');
+  });
+});

--- a/src/test/directives/migration-directives_test.ts
+++ b/src/test/directives/migration-directives_test.ts
@@ -12,9 +12,6 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-/// <reference path="../../../node_modules/@types/mocha/index.d.ts" />
-/// <reference path="../../../node_modules/@types/chai/index.d.ts" />
-
 import {Directive, directive, DirectiveParameters, Part, PartInfo, PartType,} from '../../directive.js';
 import {render} from '../../lib/render.js';
 import {html} from '../../lit-html.js';
@@ -25,14 +22,17 @@ const assert = chai.assert;
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 /**
- * adds the length of the parent /current node's tag name to the given value on
- * update. e.g. <span>${addParentLength(3)}</span> => <span>7</span>
+ * Adds the length of the parent or current node's tag name to the given value
+ * on update.
+ *
+ * @example
+ * html`<span>${addParentLength(3)}</span>` => <span>7</span>
  */
 class AddParentLengthDirective extends Directive {
   _targetEl: Element|null = null;
 
   render(value: number) {
-    return value.toString();
+    return value;
   }
 
   update(part: Part, [value]: DirectiveParameters<this>) {
@@ -59,40 +59,11 @@ class AddParentLengthDirective extends Directive {
 }
 
 /**
- * concats the parent / current element's tag name to the given value on update.
- * e.g. <span>${addParentName(3)}</span> => <span>3 span</span>
+ * Returns the given string plus number of updates.
+ *
+ * @example
+ * updateCounter('foo') // foo:0
  */
-class AddParentNameDirective extends Directive {
-  _targetEl: Element|null = null;
-
-  render(value: string|number) {
-    return value.toString();
-  }
-
-  update(part: Part, [value]: DirectiveParameters<this>) {
-    const hasPrevTarget = !!this._targetEl;
-
-    if (!hasPrevTarget) {
-      switch (part.type) {
-        case PartType.ATTRIBUTE:
-        case PartType.BOOLEAN_ATTRIBUTE:
-        case PartType.PROPERTY:
-          this._targetEl = part.element;
-          break;
-        case PartType.CHILD:
-          this._targetEl = part.parentNode as Element;
-          break;
-        default:
-          throw new Error(
-              `${part.name} is not supported for parent length directive`);
-      }
-    }
-
-    const parentName = this._targetEl!.tagName.toLocaleLowerCase();
-    return this.render(`${value} ${parentName}`);
-  }
-}
-
 class UpdateCounterDirective extends Directive {
   _numUpdates = 0;
 
@@ -104,19 +75,22 @@ class UpdateCounterDirective extends Directive {
     }
   }
 
-  update(_part: Part, [str]: DirectiveParameters<this>) {
-    this._numUpdates++;
-    return this.render(`updates: ${this._numUpdates} input: ${str}`);
-  }
-
   render(str: string) {
-    return str;
+    return `${str}:${this._numUpdates++}`;
   }
 }
 
 const addParentLength = directive(AddParentLengthDirective);
-const addParentName = directive(AddParentNameDirective);
 const updateCounter = directive(UpdateCounterDirective);
+
+/**
+ * Fetches the textContent of a node, srips out lit comments and trims it.
+ *
+ * @param node Node of which to normalize text content
+ */
+const getAndNormalizeTextContent = (node: Node) => {
+  return stripExpressionMarkers(node.textContent!).trim();
+};
 
 suite('migration directives', () => {
   let container: HTMLDivElement;
@@ -125,66 +99,43 @@ suite('migration directives', () => {
     container = document.createElement('div');
   });
 
-  suite('Each Part Type', () => {
-    test('ATTRIBUTE', () => {
+  suite('Works on:', () => {
+    test('Attribute part bindings', () => {
       const template = html` <div
         data-length=${addParentLength(5)}
-        data-name=${addParentName(5)}
       ></div>`;
       render(template, container);
 
       const el = container.firstElementChild as HTMLDivElement;
       const length = el.getAttribute('data-length');
-
       assert.equal(length, '8');
-
-      const name = el.getAttribute('data-name');
-
-      assert.equal(name, '5 div');
     });
 
-    test('BOOLEAN_ATTIBUTE', () => {
+    test('boolean attribute part bindings', () => {
       const template = html` <article ?bool=${addParentLength(5)}></article>`;
       const renderTemplate = () => render(template, container);
 
       assert.throws(renderTemplate);
     });
 
-    test('PROPERTY', () => {
-      const template = html` <input .value=${addParentLength(5)} />
-        <input .value=${addParentName(5)} />`;
+    test('property part bindings', () => {
+      const template = html` <input .value=${addParentLength(5)} >`;
       render(template, container);
 
       const el = container.firstElementChild as HTMLInputElement;
-      const el2 = container.lastElementChild as HTMLInputElement;
-
-      const length = el.value;
-
-      assert.equal(length, '10');
-
-      const name = el2.value;
-
-      assert.equal(name, '5 input');
+      assert.equal(el.value, '10');
     });
 
-    test('CHILD', () => {
-      const template = html` <article>${addParentLength(5)}</article>
-        <article>${addParentName(5)}</article>`;
+    test('child part bindings', () => {
+      const template = html` <article>${addParentLength(5)}</article>`;
       render(template, container);
 
       const el = container.firstElementChild as HTMLInputElement;
-      const el2 = container.lastElementChild as HTMLInputElement;
-
-      const length = stripExpressionMarkers(el.textContent!).trim();
-
+      const length = getAndNormalizeTextContent(el);
       assert.equal(length, '12');
-
-      const name = stripExpressionMarkers(el2.textContent!).trim();
-
-      assert.equal(name, '5 article');
     });
 
-    test('EVENT', () => {
+    test('event part bindings', () => {
       const template = html` <article @event=${addParentLength(5)}></article>`;
       const renderTemplate = () => render(template, container);
 
@@ -192,57 +143,56 @@ suite('migration directives', () => {
     });
   });
 
-  test('part caching', () => {
-    const renderDirective = (val: number, useName = false) => {
+  test('part cache is not cleared by other directives', () => {
+    const renderDirective = (val: number|string) => {
       let directive;
 
-      if (useName) {
-        directive = addParentName(val);
+      if ((val as string)?.length !== undefined) {
+        directive = updateCounter(val as string);
       } else {
-        directive = addParentLength(val);
+        directive = addParentLength(val as number);
       }
 
       const template = html`
-          <input .value=${(directive as unknown) as string}></input>`;
+          <my-el>${directive}</my-el>`;
 
       render(template, container);
     };
 
-    renderDirective(3);
-
+    // Render with updateCounter directive
+    renderDirective('foo');
     let el = container.firstElementChild as HTMLInputElement;
+    assert.equal(getAndNormalizeTextContent(el), 'foo:0');
 
-    assert.equal(el.value, '8');
-
-    renderDirective(4, true);
-
+    // Render with addParentName directive
+    renderDirective(3);
     el = container.firstElementChild as HTMLInputElement;
+    assert.equal(getAndNormalizeTextContent(el), '8');
 
-    assert.equal(el.value, '4 input');
-
-    renderDirective(5);
-
+    // Render with the first updateCounter see no fresh state vs Lit 2
+    renderDirective('bar');
     el = container.firstElementChild as HTMLInputElement;
-
-    assert.equal(el.value, '10');
+    assert.equal(getAndNormalizeTextContent(el), 'bar:1');
   });
 
   test('state preseved across renders', () => {
     const renderDirective = (str: string) =>
         render(html`<div>${updateCounter(str)}</div>`, container);
 
-
+    // Initial render with updateCounter
     renderDirective('hello');
     const el = container.firstElementChild as HTMLInputElement;
-    let content = stripExpressionMarkers(el.textContent!).trim();
-    assert.equal(content, 'updates: 1 input: hello');
+    let content = getAndNormalizeTextContent(el);
+    assert.equal(content, 'hello:0');
 
+    // Internal directive state is preserved
     renderDirective('world');
-    content = stripExpressionMarkers(el.textContent!).trim();
-    assert.equal(content, 'updates: 2 input: world');
+    content = getAndNormalizeTextContent(el);
+    assert.equal(content, 'world:1');
 
+    // Ensure update is triggered with no change in argument
     renderDirective('world');
-    content = stripExpressionMarkers(el.textContent!).trim();
-    assert.equal(content, 'updates: 3 input: world');
+    content = getAndNormalizeTextContent(el);
+    assert.equal(content, 'world:2');
   });
 });

--- a/src/test/directives/migration-directives_test.ts
+++ b/src/test/directives/migration-directives_test.ts
@@ -15,19 +15,20 @@
 /// <reference path="../../../node_modules/@types/mocha/index.d.ts" />
 /// <reference path="../../../node_modules/@types/chai/index.d.ts" />
 
-import {Directive, directive, DirectiveParameters, Part, PartType} from '../../directive.js';
+import {Directive, directive, DirectiveParameters, Part, PartType,} from '../../directive.js';
 import {render} from '../../lib/render.js';
 import {html} from '../../lit-html.js';
-import { stripExpressionMarkers } from '../test-utils/strip-markers.js';
+import {stripExpressionMarkers} from '../test-utils/strip-markers.js';
 
 const assert = chai.assert;
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 /**
- * adds the length of the parent /current node's tag name to the given value on update
+ * adds the length of the parent /current node's tag name to the given value on
+ * update
  */
- class AddParentLengthDirective extends Directive {
+class AddParentLengthDirective extends Directive {
   _targetEl: Element|null = null;
 
   render(value: number) {
@@ -47,7 +48,8 @@ const assert = chai.assert;
           this._targetEl = part.parentNode as Element;
           break;
         default:
-          throw new Error(`${part.name} is not supported for parent length directive`);
+          throw new Error(
+              `${part.name} is not supported for parent length directive`);
       }
     }
 
@@ -59,7 +61,7 @@ const assert = chai.assert;
 /**
  * concats the parent / current element's tag name to the given value on update
  */
- class AddParentNameDirective extends Directive {
+class AddParentNameDirective extends Directive {
   _targetEl: Element|null = null;
 
   render(value: string|number) {
@@ -80,7 +82,8 @@ const assert = chai.assert;
           this._targetEl = part.parentNode as Element;
           break;
         default:
-          throw new Error(`${part.name} is not supported for parent length directive`);
+          throw new Error(
+              `${part.name} is not supported for parent length directive`);
       }
     }
 
@@ -101,11 +104,10 @@ suite('migration directives', () => {
 
   suite('Each Part Type', () => {
     test('ATTRIBUTE', () => {
-      const template = html`
-          <div
-              data-length=${addParentLength(5)}
-              data-name=${addParentName(5)}>
-          </div>`;
+      const template = html` <div
+        data-length=${addParentLength(5)}
+        data-name=${addParentName(5)}
+      ></div>`;
       render(template, container);
 
       const el = container.firstElementChild as HTMLDivElement;
@@ -119,17 +121,15 @@ suite('migration directives', () => {
     });
 
     test('BOOLEAN_ATTIBUTE', () => {
-      const template = html`
-          <article ?bool=${addParentLength(5)}></article>`;
+      const template = html` <article ?bool=${addParentLength(5)}></article>`;
       const renderTemplate = () => render(template, container);
 
       assert.throws(renderTemplate);
     });
 
     test('PROPERTY', () => {
-      const template = html`
-          <input .value=${addParentLength(5)}>
-          <input .value=${addParentName(5)}>`;
+      const template = html` <input .value=${addParentLength(5)} />
+        <input .value=${addParentName(5)} />`;
       render(template, container);
 
       const el = container.firstElementChild as HTMLInputElement;
@@ -145,9 +145,8 @@ suite('migration directives', () => {
     });
 
     test('CHILD', () => {
-      const template = html`
-          <article>${addParentLength(5)}</article>
-          <article>${addParentName(5)}</article>`;
+      const template = html` <article>${addParentLength(5)}</article>
+        <article>${addParentName(5)}</article>`;
       render(template, container);
 
       const el = container.firstElementChild as HTMLInputElement;
@@ -163,8 +162,7 @@ suite('migration directives', () => {
     });
 
     test('EVENT', () => {
-      const template = html`
-          <article @event=${addParentLength(5)}></article>`;
+      const template = html` <article @event=${addParentLength(5)}></article>`;
       const renderTemplate = () => render(template, container);
 
       assert.throws(renderTemplate);
@@ -182,7 +180,7 @@ suite('migration directives', () => {
       }
 
       const template = html`
-          <input .value=${directive as unknown as string}></input>`;
+          <input .value=${(directive as unknown) as string}></input>`;
 
       render(template, container);
     };

--- a/test/index.html
+++ b/test/index.html
@@ -28,6 +28,7 @@
     <script type="module" src="./directives/unsafe-svg_test.js"></script>
     <script type="module" src="./directives/class-map_test.js"></script>
     <script type="module" src="./directives/style-map_test.js"></script>
+    <script type="module" src="./directives/migration-directives_test.js"></script>
     <script>
       WCT.loadSuites([
         'shady.html',


### PR DESCRIPTION
Add forwards compatibility for Lit 1 directives. This will allow users to write with the Lit 2 directive class syntax and also adds some files so that the we can migrate users to the new import targets and then switch them to Lit 2 rather than those changes being atomic.

Notable changes:
* `directive` can now take a `DirectiveClass` as an argument in `lit-html/directives`
* The API of the lit 2 `[a-zA-Z]+Part`s have added to `lit-html/directives`
* creation of root level:
  * `async-directive.ts`
  * `directive.ts`
* creation of `ChildPart`

Note: this seems to have broken lit-analyzer 1.1.9 internally, but i could not reproduce those errors externally. This seems to work just fine in lit-analyzer 1.2.0.

Additionally, usage of `ChildPart` in a directive may cause lit-analyzer to not detect that a directive is a directive, but this should not cause any failures because `NodePart` (Lit 1 equivalent) is never bound to anything that needs type checking.

Related #1653