### PR TITLE
chore: npm run install isn't a valid command, update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Initialize repo:
 ```sh
 git clone https://github.com/Polymer/lit-html.git -b lit-next
 cd lit-html
-npm run install
+npm install
 npm run bootstrap
 ```
 


### PR DESCRIPTION
when running `npm run install` you'll get the following error:

```
npm ERR! missing script: install

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/anthonymittaz/.npm/_logs/2021-03-08T02_05_41_926Z-debug.log
```