### PR TITLE
[reactive-element] Make JSCompiler_renameProperty block scoped

### DIFF
--- a/packages/reactive-element/CHANGELOG.md
+++ b/packages/reactive-element/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - (Since 1.0.0-pre.1) Removed `willUpdate` from `ReactiveController`.
 - (Since 1.0.0-pre.1) Renamed `Controller`'s `dis/connectedCallback` methods.
 - (Since 1.0.0-pre.1) Renamed `Controller` to `ReactiveController`.
+- Made JSCompiler_renameProperty block scoped so that it's inlined in the Terser prod build. Closure should compile from the development build, or after a custom TypeScript compilation.
 
 ## [1.0.0-pre.1] - 2020-12-16
 

--- a/packages/reactive-element/src/reactive-element.ts
+++ b/packages/reactive-element/src/reactive-element.ts
@@ -75,21 +75,11 @@ if (DEV_MODE) {
  * alias this function, so we have to use a small shim that has the same
  * behavior when not compiling.
  */
-window.JSCompiler_renameProperty = <P extends PropertyKey>(
+/*@__INLINE__*/
+const JSCompiler_renameProperty = <P extends PropertyKey>(
   prop: P,
   _obj: unknown
 ): P => prop;
-
-declare global {
-  const JSCompiler_renameProperty: <P extends PropertyKey>(
-    prop: P,
-    _obj: unknown
-  ) => P;
-
-  interface Window {
-    JSCompiler_renameProperty: typeof JSCompiler_renameProperty;
-  }
-}
 
 /**
  * Converts property values to and from attribute values.
@@ -1160,7 +1150,9 @@ if (DEV_MODE) {
   // Default warning set.
   ReactiveElement.enabledWarnings = ['change-in-update'];
   const ensureOwnWarnings = function (ctor: typeof ReactiveElement) {
-    if (!ctor.hasOwnProperty('enabledWarnings')) {
+    if (
+      !ctor.hasOwnProperty(JSCompiler_renameProperty('enabledWarnings', ctor))
+    ) {
       ctor.enabledWarnings = ctor.enabledWarnings!.slice();
     }
   };


### PR DESCRIPTION
This makes Terser inline JSCompiler_renameProperty, removing it's cost completely.

Closure will have to compile form the development build, or after a custom TypeScript build.

Also added `JSCompiler_renameProperty()` to wrap `enabledWarnings`.

Fixes #1655 by not introducing a redeclared _global_ block-scoped variable.