### PR TITLE
Update to released template-shadow-root

### DIFF
--- a/packages/lit-ssr/package-lock.json
+++ b/packages/lit-ssr/package-lock.json
@@ -2006,6 +2006,11 @@
       "integrity": "sha512-XEVDA7oH6o4Au9apyRDucjcIzvP44Ur4sqTMGRKCcE6sCAeKiOkRE03TCYNJAFkzckMWWT8Xx3IxG3iwjAcsRQ==",
       "dev": true
     },
+    "@webcomponents/template-shadowroot": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@webcomponents/template-shadowroot/-/template-shadowroot-0.1.0.tgz",
+      "integrity": "sha512-ry84Vft6xtRBbd4M/ptRodbOLodV5AD15TYhyRghCRgIcJJKmYmJ2v2BaaWxygENwh6Uq3zTfGPmlckKT/GXsQ=="
+    },
     "@webcomponents/webcomponentsjs": {
       "version": "2.4.4",
       "resolved": "https://registry.npmjs.org/@webcomponents/webcomponentsjs/-/webcomponentsjs-2.4.4.tgz",

--- a/packages/lit-ssr/package.json
+++ b/packages/lit-ssr/package.json
@@ -54,6 +54,7 @@
     "typescript": "^4.1.3"
   },
   "dependencies": {
+    "@webcomponents/template-shadowroot": "^0.1.0",
     "escape-html": "^1.0.3",
     "koa": "^2.7.0",
     "koa-node-resolve": "^1.0.0-pre.5",

--- a/packages/lit-ssr/src/demo/app-server.ts
+++ b/packages/lit-ssr/src/demo/app-server.ts
@@ -33,10 +33,7 @@ export function* renderApp(data: typeof initialData) {
             import('/demo/app-client.js');
           });
         </script>
-        <script type="module">
-          import {hydrateShadowRoots} from './node_modules/template-shadowroot/template-shadowroot.js';
-          hydrateShadowRoots(document.body);
-        </script>
+        <script src="./node_modules/@webcomponents/template-shadowroot/template-shadowroot.min.js"></script>
         `;
   yield `
       </head>
@@ -49,6 +46,7 @@ export function* renderApp(data: typeof initialData) {
 
   yield `
         </div>
+        <script>TemplateShadowRoot.hydrateShadowRoots(document.body);</script>
       </body>
-    </html>`;
+</html>`;
 }

--- a/packages/lit-ssr/src/test/integration/client/basic_test.ts
+++ b/packages/lit-ssr/src/test/integration/client/basic_test.ts
@@ -9,7 +9,7 @@ import '@open-wc/testing';
 import {tests} from '../tests/basic.js';
 import {render} from 'lit';
 import {hydrate} from 'lit/hydrate.js';
-import {hydrateShadowRoots} from 'template-shadowroot/template-shadowroot.js';
+import {hydrateShadowRoots} from '@webcomponents/template-shadowroot/template-shadowroot.js';
 import {SSRExpectedHTML} from '../tests/ssr-test.js';
 
 const assert = chai.assert;


### PR DESCRIPTION
The tests still use the module version, but switched the demo to use the minified / legacy script version to sanity check (worked fine).