### PR TITLE
[lit-html] Add `_$litPart$` to reservedProperties and match convention

### DIFF
--- a/packages/lit-html/src/hydrate.ts
+++ b/packages/lit-html/src/hydrate.ts
@@ -123,9 +123,9 @@ export const hydrate = (
   container: Element | DocumentFragment,
   options: Partial<RenderOptions> = {}
 ) => {
-  // TODO(kschaaf): Do we need a helper for _$litPart ("part for node")?
+  // TODO(kschaaf): Do we need a helper for _$litPart$ ("part for node")?
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  if ((container as any)._$litPart !== undefined) {
+  if ((container as any)._$litPart$ !== undefined) {
     throw new Error('container already contains a live render');
   }
 
@@ -178,7 +178,7 @@ export const hydrate = (
     'there should be exactly one root part in a render container'
   );
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  (container as any)._$litPart = rootPart;
+  (container as any)._$litPart$ = rootPart;
 };
 
 const openChildPart = (

--- a/packages/lit-html/src/lit-html.ts
+++ b/packages/lit-html/src/lit-html.ts
@@ -303,11 +303,11 @@ export const render = (
 ): ChildPart => {
   const partOwnerNode = options?.renderBefore ?? container;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  let part: ChildPart = (partOwnerNode as any)._$litPart;
+  let part: ChildPart = (partOwnerNode as any)._$litPart$;
   if (part === undefined) {
     const endNode = options?.renderBefore ?? null;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (partOwnerNode as any)._$litPart = part = new ChildPartImpl(
+    (partOwnerNode as any)._$litPart$ = part = new ChildPartImpl(
       container.insertBefore(createMarker(), endNode),
       endNode,
       undefined,

--- a/rollup-common.js
+++ b/rollup-common.js
@@ -35,7 +35,7 @@ const skipBundleOutput = {
 // to avoid collisions since they are used to brand values in positions that
 // accept any value. We don't use a Symbol for these to support mixing and
 // matching values from different versions.
-const reservedProperties = ['_$litType$', '_$litDirective$'];
+const reservedProperties = ['_$litType$', '_$litDirective$', '_$litPart$'];
 
 // Private properties which should be stable between versions but are used on
 // unambiguous objects and thus are safe to mangle. These include properties on


### PR DESCRIPTION
The expando put on the reference node was changed from `$lit$` to `_$litPart` in https://github.com/Polymer/lit-html/commit/e587a130b0bb395e6a688baaa4f64ba22b295497, causing it to be renamed to a short letter. We need to make sure that expando doesn't easily collide with user properties, so it should go in `reservedProperties`.

I added the trailing `$` to match the existing convention of reserved properties.

Fixes #1615 