### PR TITLE
[reactive-element] The `createRenderRoot` method is now called only once.

### DIFF
--- a/packages/reactive-element/CHANGELOG.md
+++ b/packages/reactive-element/CHANGELOG.md
@@ -17,6 +17,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 <!-- ### Removed -->
 <!-- ### Fixed -->
 
+## Unreleased
+
+### Fixed
+
+- (Since 1.0.0-pre.2) The `createRenderRoot` method is now called only once [#1679](https://github.com/Polymer/lit-html/issues/1679).
+
 ## [1.0.0-pre.2] - 2021-02-11
 
 ### Added

--- a/packages/reactive-element/src/reactive-element.ts
+++ b/packages/reactive-element/src/reactive-element.ts
@@ -732,7 +732,7 @@ export abstract class ReactiveElement
    */
   connectedCallback() {
     // create renderRoot before first update.
-    if (!this.hasUpdated) {
+    if (this.renderRoot === undefined) {
       (this as {
         renderRoot: Element | DocumentFragment;
       }).renderRoot = this.createRenderRoot();

--- a/packages/reactive-element/src/test/reactive-element_test.ts
+++ b/packages/reactive-element/src/test/reactive-element_test.ts
@@ -51,6 +51,24 @@ suite('ReactiveElement', () => {
     assert.isTrue(el.hasRenderRoot);
   });
 
+  test(`createRenderRoot is called only once`, async () => {
+    class E extends ReactiveElement {
+      renderRootCalls = 0;
+      createRenderRoot() {
+        this.renderRootCalls++;
+        return this;
+      }
+    }
+    customElements.define(generateElementName(), E);
+    const el = new E();
+    container.appendChild(el);
+    container.removeChild(el);
+    container.appendChild(el);
+    container.removeChild(el);
+    container.appendChild(el);
+    assert.equal(el.renderRootCalls, 1);
+  });
+
   test('`updateComplete` waits for `requestUpdate` but does not trigger update, async', async () => {
     class E extends ReactiveElement {
       updateCount = 0;


### PR DESCRIPTION
Fixes #1679.