### PR TITLE
Fixes for styleMap tests on IE11

### DIFF
--- a/packages/lit-html/src/directives/style-map.ts
+++ b/packages/lit-html/src/directives/style-map.ts
@@ -82,8 +82,10 @@ class StyleMap extends Directive {
         if (name.includes('-')) {
           style.removeProperty(name);
         } else {
+          // Note reset using empty string (vs null) as IE11 does not always
+          // reset via null (https://developer.mozilla.org/en-US/docs/Web/API/ElementCSSInlineStyle/style#setting_styles)
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          (style as any)[name] = null;
+          (style as any)[name] = '';
         }
       }
     });

--- a/packages/lit-html/src/test/directives/style-map_test.ts
+++ b/packages/lit-html/src/test/directives/style-map_test.ts
@@ -67,7 +67,9 @@ suite('styleMap', () => {
   test('first render skips undefined properties', () => {
     renderStyleMap({marginTop: undefined, marginBottom: null});
     const el = container.firstElementChild as HTMLElement;
-    assert.equal(el.getAttribute('style'), '');
+    // Note calling `setAttribute('style', '') does results in
+    // `getAttribute('style') === null` on IE11; test cssText instead
+    assert.equal(el.style.cssText, '');
     assert.equal(el.style.marginTop, '');
     assert.equal(el.style.marginBottom, '');
   });


### PR DESCRIPTION
Fixes some test regressions on IE11 that snuck in with https://github.com/Polymer/lit-html/pull/1665:
* Assert `style.cssText === ''` rather than `style.getAttribute('style') === ''` since IE doesn't serialize an empty string to `style` when calling `setAttribute('style', '')`
* Reset css properties using empty string `''` rather than `null`, due to differing behavior on IE: https://developer.mozilla.org/en-US/docs/Web/API/ElementCSSInlineStyle/style#setting_styles