### PR TITLE
Make `isDefined` generic, rather than using `unknown`.

### DIFF
--- a/packages/lit-html/src/directives/if-defined.ts
+++ b/packages/lit-html/src/directives/if-defined.ts
@@ -12,4 +12,4 @@ import {nothing} from '../lit-html.js';
  *
  * For other part types, this directive is a no-op.
  */
-export const ifDefined = (value: unknown) => value ?? nothing;
+export const ifDefined = <T>(value: T) => value ?? nothing;


### PR DESCRIPTION
This change allows the input type to propagate through to the return type. I noticed this because one our internal linters (probably lit-analyzer?) was complaining about binding `unknown` to an attribute, in a situation that looked like this:
```javascript
html`<example-element some-attribute="${ifDefined(someBoolean)}"></example-element>`
```