### PR TITLE
[lit-html] Use export type instead of Impl/Ctors

### DIFF
--- a/packages/lit-html/src/hydrate.ts
+++ b/packages/lit-html/src/hydrate.ts
@@ -6,15 +6,7 @@
 
 import type {TemplateResult} from './lit-html.js';
 
-import {
-  noChange,
-  EventPart,
-  ChildPart,
-  PropertyPart,
-  ElementPart,
-  RenderOptions,
-  _Σ,
-} from './lit-html.js';
+import {noChange, RenderOptions, _Σ} from './lit-html.js';
 import {AttributePartInfo, PartType} from './directive.js';
 import {
   isPrimitive,
@@ -32,6 +24,10 @@ const {
   _ElementPart: ElementPart,
 } = _Σ;
 
+type ChildPart = InstanceType<typeof ChildPart>;
+type EventPart = InstanceType<typeof EventPart>;
+type PropertyPart = InstanceType<typeof PropertyPart>;
+type ElementPart = InstanceType<typeof ElementPart>;
 type TemplateInstance = InstanceType<typeof TemplateInstance>;
 
 /**

--- a/packages/lit-html/src/lit-html.ts
+++ b/packages/lit-html/src/lit-html.ts
@@ -814,15 +814,6 @@ class TemplateInstance {
 /*
  * Parts
  */
-type AttributePartConstructor<T = AttributePart> = {
-  new (
-    element: HTMLElement,
-    name: string,
-    strings: ReadonlyArray<string>,
-    parent: Disconnectable | undefined,
-    options: RenderOptions | undefined
-  ): T;
-};
 type AttributeTemplatePart = {
   readonly type: typeof ATTRIBUTE_PART;
   readonly index: number;
@@ -835,13 +826,6 @@ type AttributeTemplatePart = {
 type NodeTemplatePart = {
   readonly type: typeof CHILD_PART;
   readonly index: number;
-};
-type ElementPartConstructor = {
-  new (
-    element: HTMLElement,
-    parent: Disconnectable | undefined,
-    options: RenderOptions | undefined
-  ): ElementPart;
 };
 type ElementTemplatePart = {
   readonly type: typeof ELEMENT_PART;
@@ -1508,11 +1492,11 @@ export const _Σ = {
   _resolveDirective: resolveDirective,
   // Used in tests and private-ssr-support
   _ChildPart: ChildPart,
-  _AttributePart: AttributePart as AttributePartConstructor,
-  _BooleanAttributePart: BooleanAttributePart as AttributePartConstructor<BooleanAttributePart>,
-  _EventPart: EventPart as AttributePartConstructor<EventPart>,
-  _PropertyPart: PropertyPart as AttributePartConstructor<PropertyPart>,
-  _ElementPart: ElementPart as ElementPartConstructor,
+  _AttributePart: AttributePart,
+  _BooleanAttributePart: BooleanAttributePart,
+  _EventPart: EventPart,
+  _PropertyPart: PropertyPart,
+  _ElementPart: ElementPart,
 };
 
 // Apply polyfills if available

--- a/packages/lit-html/src/test/lit-html_test.ts
+++ b/packages/lit-html/src/test/lit-html_test.ts
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 import {
-  AttributePart,
   ChildPart,
   CompiledTemplateResult,
   html,
@@ -33,6 +32,7 @@ import {createRef, ref} from '../directives/ref.js';
 // For compiled template tests
 import {_Σ} from '../private-ssr-support.js';
 const {AttributePart} = _Σ;
+type AttributePart = InstanceType<typeof AttributePart>;
 
 const ua = window.navigator.userAgent;
 const isIe = ua.indexOf('Trident/') > 0;


### PR DESCRIPTION
This mostly cleans up the code around exporting just the types for parts.

When the values and types of a class are exported separately like this, it doesn't seem like you can import both the value and the type as the same name, although you can declare a type of the same name locally (which is odd). So I think using the `type ImportedClass = InstanceType<typeof importedClass>` pattern seems better than what we had?