### PR TITLE
[lit-html] Add version-stability test

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -59,6 +59,7 @@ packages/lit-element/polyfill-support.*
 packages/lit-element/private-ssr-support.*
 
 packages/lit-html/development/
+packages/lit-html/version-stability-build/
 packages/lit-html/directives/
 packages/lit-html/node_modules/
 packages/lit-html/test/

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -43,6 +43,12 @@
       }
     },
     {
+      "files": ["packages/lit-html/src/test/version-stability_test.js"],
+      "env": {
+        "mocha": true
+      }
+    },
+    {
       "files": [
         "*_test.ts",
         "**/custom_typings/*.ts",

--- a/.prettierignore
+++ b/.prettierignore
@@ -59,6 +59,7 @@ packages/lit-element/polyfill-support.*
 packages/lit-element/private-ssr-support.*
 
 packages/lit-html/development/
+packages/lit-html/version-stability-build/
 packages/lit-html/directives/
 packages/lit-html/node_modules/
 packages/lit-html/test/

--- a/packages/lit-html/.gitignore
+++ b/packages/lit-html/.gitignore
@@ -1,4 +1,5 @@
 /development/
+/version-stability-build/
 /directives/
 /node_modules/
 /test/

--- a/packages/lit-html/package.json
+++ b/packages/lit-html/package.json
@@ -47,18 +47,19 @@
     }
   },
   "scripts": {
-    "build": "npm run clean && npm run build:ts && rollup -c",
+    "build": "npm run clean && npm run build:ts && npm run build:version-stability-test && rollup -c",
     "build:watch": "rollup -c --watch",
     "build:ts": "tsc --build && treemirror development . '**/*.d.ts{,.map}'",
     "build:ts:watch": "tsc --build --watch",
+    "build:version-stability-test": "rollup -c rollup-version-stability-test.config.js",
     "check-version": "node scripts/check-version-tracker.js",
     "checksize": "rollup -c --environment=CHECKSIZE",
-    "clean": "rm -rf {async-directive,directive-helpers,directive,hydrate,lit-html,polyfill-support,private-ssr-support,static}.{js,js.map,d.ts} test/ directives/ development/ *.tsbuildinfo",
+    "clean": "rm -rf {async-directive,directive-helpers,directive,hydrate,lit-html,polyfill-support,private-ssr-support,static}.{js,js.map,d.ts} test/ directives/ development/ version-stability-test/ *.tsbuildinfo",
     "dev": "scripts/dev.sh",
     "prepublishOnly": "npm run check-version",
     "test": "npm run test:dev && npm run test:prod",
     "test:dev": "cd ../tests && npx wtr '../lit-html/development/**/*_test.(js|html)'",
-    "test:prod": "MODE=prod npm run test:dev",
+    "test:prod": "MODE=prod npm run test:dev -- '../lit-html/src/test/version-stability_test.js'",
     "test:watch": "npm run test:dev -- --watch"
   },
   "files": [

--- a/packages/lit-html/rollup-version-stability-test.config.js
+++ b/packages/lit-html/rollup-version-stability-test.config.js
@@ -1,0 +1,12 @@
+/**
+ * @license
+ * Copyright 2018 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import {defaultConfig} from './rollup.config.js';
+
+export default defaultConfig({
+  outputDir: './version-stability-build/',
+  testPropertyPrefix: 'VERSION_TEST_',
+});

--- a/packages/lit-html/rollup.config.js
+++ b/packages/lit-html/rollup.config.js
@@ -6,35 +6,39 @@
 
 import {litProdConfig} from '../../rollup-common.js';
 
-export default litProdConfig({
-  classPropertyPrefix: 'Σ',
-  entryPoints: [
-    'directives/async-append',
-    'directives/async-replace',
-    'directives/cache',
-    'directives/class-map',
-    'directives/guard',
-    'directives/if-defined',
-    'directives/live',
-    'directives/ref',
-    'directives/repeat',
-    'directives/style-map',
-    'directives/template-content',
-    'directives/unsafe-html',
-    'directives/unsafe-svg',
-    'directives/until',
-    'lit-html',
-    'directive',
-    'directive-helpers',
-    'async-directive',
-    'static',
-    'hydrate',
-    'private-ssr-support',
-    'polyfill-support',
-  ],
-  bundled: [
-    {
-      file: 'polyfill-support',
-    },
-  ],
-});
+export const defaultConfig = (options = {}) =>
+  litProdConfig({
+    classPropertyPrefix: 'Σ',
+    entryPoints: [
+      'directives/async-append',
+      'directives/async-replace',
+      'directives/cache',
+      'directives/class-map',
+      'directives/guard',
+      'directives/if-defined',
+      'directives/live',
+      'directives/ref',
+      'directives/repeat',
+      'directives/style-map',
+      'directives/template-content',
+      'directives/unsafe-html',
+      'directives/unsafe-svg',
+      'directives/until',
+      'lit-html',
+      'directive',
+      'directive-helpers',
+      'async-directive',
+      'static',
+      'hydrate',
+      'private-ssr-support',
+      'polyfill-support',
+    ],
+    bundled: [
+      {
+        file: 'polyfill-support',
+      },
+    ],
+    ...options,
+  });
+
+export default defaultConfig();

--- a/packages/lit-html/src/test/version-stability_test.js
+++ b/packages/lit-html/src/test/version-stability_test.js
@@ -4,325 +4,245 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-import {
-  html as htmlA,
-  render as renderA,
-  nothing as nothingA,
-  noChange as noChangeA,
-} from '../../lit-html.js';
-import {
-  directive as directiveA,
-  Directive as DirectiveA,
-  PartType as PartTypeA,
-} from '../../directive.js';
-import {AsyncDirective as AsyncDirectiveA} from '../../async-directive.js';
-import {repeat as repeatA} from '../../directives/repeat.js';
+import * as litHtml1 from '../../lit-html.js';
+import * as directive1 from '../../directive.js';
+import * as asyncDirective1 from '../../async-directive.js';
+import * as repeat1 from '../../directives/repeat.js';
 
-import {
-  html as htmlB,
-  render as renderB,
-  nothing as nothingB,
-  noChange as noChangeB,
-} from '../../version-stability-build/lit-html.js';
-import {
-  directive as directiveB,
-  Directive as DirectiveB,
-  PartType as PartTypeB,
-} from '../../version-stability-build/directive.js';
-import {AsyncDirective as AsyncDirectiveB} from '../../version-stability-build/async-directive.js';
-import {repeat as repeatB} from '../../version-stability-build/directives/repeat.js';
+import * as litHtml2 from '../../version-stability-build/lit-html.js';
+import * as directive2 from '../../version-stability-build/directive.js';
+import * as asyncDirective2 from '../../version-stability-build/async-directive.js';
+import * as repeat2 from '../../version-stability-build/directives/repeat.js';
 
 import {stripExpressionComments} from '../../development/test/test-utils/strip-markers.js';
 import {assert} from '@esm-bundle/chai';
 
 const nextFrame = () => new Promise((r) => requestAnimationFrame(() => r()));
 
-const dirA = directiveA(
-  class extends DirectiveA {
-    constructor(partInfo) {
-      super(partInfo);
-      this.partInfo = partInfo;
-    }
-    render(v) {
-      if (this.partInfo.type !== PartTypeA.ATTRIBUTE) {
-        throw new Error('expected PartType.ATTRIBUTE');
-      }
-      const {tagName, name, strings} = this.partInfo;
-      return `[${v}:${tagName}:${name}:${strings.join(':')}]`;
-    }
+// {
+//   html as htmlA,
+//   render as renderA,
+//   nothing as nothingA,
+//   noChange as noChangeA,
+// }
+
+// {
+//   directive as directiveA,
+//   Directive as DirectiveA,
+//   PartType as PartTypeA,
+// }
+
+// {AsyncDirective as AsyncDirectiveA}
+
+// {repeat as repeatA}
+
+const version1 = [litHtml1, directive1, asyncDirective1, repeat1];
+const version2 = [litHtml2, directive2, asyncDirective2, repeat2];
+
+[
+  [version1, version2],
+  [version2, version1],
+].forEach(
+  ([
+    [
+      {html: htmlA, render: renderA, nothing: nothingA},
+      {directive: directiveA, Directive: DirectiveA, PartType: PartTypeA},
+      {AsyncDirective: AsyncDirectiveA},
+    ],
+    [
+      {html: htmlB, nothing: nothingB, noChange: noChangeB},
+      {directive: directiveB, Directive: DirectiveB, PartType: PartTypeB},
+      {AsyncDirective: AsyncDirectiveB},
+      {repeat: repeatB},
+    ],
+  ]) => {
+    suite('version-stability', () => {
+      let container;
+
+      const dirA = directiveA(
+        class extends DirectiveA {
+          constructor(partInfo) {
+            super(partInfo);
+            this.partInfo = partInfo;
+          }
+          render(v) {
+            if (this.partInfo.type !== PartTypeA.ATTRIBUTE) {
+              throw new Error('expected PartType.ATTRIBUTE');
+            }
+            const {tagName, name, strings} = this.partInfo;
+            return `[${v}:${tagName}:${name}:${strings.join(':')}]`;
+          }
+        }
+      );
+
+      const dirB = directiveB(
+        class extends DirectiveB {
+          constructor(partInfo) {
+            super(partInfo);
+            this.partInfo = partInfo;
+          }
+          render(v) {
+            if (this.partInfo.type !== PartTypeB.ATTRIBUTE) {
+              throw new Error('expected PartType.ATTRIBUTE');
+            }
+            const {tagName, name, strings} = this.partInfo;
+            return `[${v}:${tagName}:${name}:${strings.join(':')}]`;
+          }
+        }
+      );
+
+      const passthruB = directiveB(
+        class extends DirectiveB {
+          render(v) {
+            return v;
+          }
+        }
+      );
+
+      const asyncA = directiveA(
+        class extends AsyncDirectiveA {
+          render(v, cb) {
+            this.cb = cb;
+            this.cb(true);
+            Promise.resolve().then(() => this.setValue(v));
+          }
+          disconnected() {
+            this.cb(false);
+          }
+          reconnected() {
+            this.cb(true);
+          }
+        }
+      );
+
+      const asyncB = directiveB(
+        class extends AsyncDirectiveB {
+          render(v, cb) {
+            this.cb = cb;
+            this.cb(true);
+            Promise.resolve().then(() => this.setValue(v));
+          }
+          disconnected() {
+            this.cb(false);
+          }
+          reconnected() {
+            this.cb(true);
+          }
+        }
+      );
+
+      setup(() => {
+        container = document.createElement('div');
+      });
+
+      const assertContent = (expected) => {
+        assert.equal(stripExpressionComments(container.innerHTML), expected);
+      };
+
+      test('renderA with htmlB', () => {
+        renderA(htmlB`<div>${'test'}</div>`, container);
+        assertContent('<div>test</div>');
+      });
+
+      test('renderA with nothingB and noChangeB', () => {
+        const template = (v) => htmlA`<div>${v}</div>`;
+        renderA(template('test'), container);
+        assertContent('<div>test</div>');
+        renderA(template(nothingB), container);
+        assertContent('<div></div>');
+        renderA(template('test'), container);
+        assertContent('<div>test</div>');
+        renderA(template(noChangeB), container);
+        assertContent('<div>test</div>');
+      });
+
+      test('renderA with directiveB', () => {
+        renderA(htmlB`<div title="a${dirB('B')}b"></div>`, container);
+        assertContent('<div title="a[B:DIV:title:a:b]b"></div>');
+      });
+
+      test('renderA with directiveA nested in passthruB', () => {
+        renderA(
+          htmlB`<div title="a${passthruB(dirA('A'))}b"></div>`,
+          container
+        );
+        assertContent('<div title="a[A:DIV:title:a:b]b"></div>');
+      });
+
+      test('renderA with asyncB', async () => {
+        let connected = true;
+        const cb = (c) => (connected = c);
+        const template = (bool) =>
+          htmlA`<div>${bool ? asyncB('B', cb) : nothingA}</div>`;
+        renderA(template(true), container);
+        assertContent('<div></div>');
+        assert.isTrue(connected);
+        // Wait until directive updates value.
+        await nextFrame();
+        assertContent('<div>B</div>');
+        renderA(template(false), container);
+        assert.isFalse(connected);
+        assertContent('<div></div>');
+        const part = renderA(template(true), container);
+        assert.isTrue(connected);
+        // Wait until directive updates value.
+        await nextFrame();
+        assertContent('<div>B</div>');
+        part.setConnected(false);
+        assert.isFalse(connected);
+        assertContent('<div>B</div>');
+        part.setConnected(true);
+        assert.isTrue(connected);
+        assertContent('<div>B</div>');
+      });
+
+      test('renderA with repeatB rendering htmlA and passthruB', () => {
+        const items = [0, 1, 2];
+        renderA(
+          htmlA`<div>${repeatB(
+            items,
+            (item) => htmlA`<p>${passthruB(`B${item}`)}</p>`
+          )}</div>`,
+          container
+        );
+        assertContent('<div><p>B0</p><p>B1</p><p>B2</p></div>');
+      });
+
+      test('renderA with repeatB rendering asyncA', async () => {
+        const items = [0];
+        let connected = false;
+        const cb = (c) => (connected = c);
+        const template = (bool) =>
+          htmlA`<div>${
+            bool
+              ? repeatB(
+                  items,
+                  (item) => htmlA`<p>${asyncA(`A${item}`, cb)}</p>`
+                )
+              : nothingB
+          }</div>`;
+        renderA(template(true, cb), container);
+        assert.isTrue(connected);
+        assertContent('<div><p></p></div>');
+        // Wait until directive updates value.
+        await nextFrame();
+        assertContent('<div><p>A0</p></div>');
+        renderA(template(false, cb), container);
+        assert.isFalse(connected);
+        assertContent('<div></div>');
+        const part = renderA(template(true, cb), container);
+        assert.isTrue(connected);
+        assertContent('<div><p></p></div>');
+        // Wait until directive updates value.
+        await nextFrame();
+        assertContent('<div><p>A0</p></div>');
+        part.setConnected(false);
+        assert.isFalse(connected);
+        assertContent('<div><p>A0</p></div>');
+        part.setConnected(true);
+        assert.isTrue(connected);
+        assertContent('<div><p>A0</p></div>');
+      });
+    });
   }
 );
-
-const dirB = directiveB(
-  class extends DirectiveB {
-    constructor(partInfo) {
-      super(partInfo);
-      this.partInfo = partInfo;
-    }
-    render(v) {
-      if (this.partInfo.type !== PartTypeB.ATTRIBUTE) {
-        throw new Error('expected PartType.ATTRIBUTE');
-      }
-      const {tagName, name, strings} = this.partInfo;
-      return `[${v}:${tagName}:${name}:${strings.join(':')}]`;
-    }
-  }
-);
-
-const passthruA = directiveA(
-  class extends DirectiveA {
-    render(v) {
-      return v;
-    }
-  }
-);
-
-const passthruB = directiveB(
-  class extends DirectiveB {
-    render(v) {
-      return v;
-    }
-  }
-);
-
-const asyncA = directiveA(
-  class extends AsyncDirectiveA {
-    render(v, cb) {
-      this.cb = cb;
-      this.cb(true);
-      Promise.resolve().then(() => this.setValue(v));
-    }
-    disconnected() {
-      this.cb(false);
-    }
-    reconnected() {
-      this.cb(true);
-    }
-  }
-);
-
-const asyncB = directiveB(
-  class extends AsyncDirectiveB {
-    render(v, cb) {
-      this.cb = cb;
-      this.cb(true);
-      Promise.resolve().then(() => this.setValue(v));
-    }
-    disconnected() {
-      this.cb(false);
-    }
-    reconnected() {
-      this.cb(true);
-    }
-  }
-);
-
-suite('version-stability', () => {
-  let container;
-
-  setup(() => {
-    container = document.createElement('div');
-  });
-
-  const assertContent = (expected) => {
-    assert.equal(stripExpressionComments(container.innerHTML), expected);
-  };
-
-  test('renderA with htmlB', () => {
-    renderA(htmlB`<div>${'test'}</div>`, container);
-    assertContent('<div>test</div>');
-  });
-
-  test('renderB with htmlA', () => {
-    renderB(htmlA`<div>${'test'}</div>`, container);
-    assertContent('<div>test</div>');
-  });
-
-  test('renderA with nothingB and noChangeB', () => {
-    const template = (v) => htmlA`<div>${v}</div>`;
-    renderA(template('test'), container);
-    assertContent('<div>test</div>');
-    renderA(template(nothingB), container);
-    assertContent('<div></div>');
-    renderA(template('test'), container);
-    assertContent('<div>test</div>');
-    renderA(template(noChangeB), container);
-    assertContent('<div>test</div>');
-  });
-
-  test('renderB with nothingA and noChangeA', () => {
-    const template = (v) => htmlA`<div>${v}</div>`;
-    renderB(template('test'), container);
-    assertContent('<div>test</div>');
-    renderB(template(nothingA), container);
-    assertContent('<div></div>');
-    renderB(template('test'), container);
-    assertContent('<div>test</div>');
-    renderB(template(noChangeA), container);
-    assertContent('<div>test</div>');
-  });
-
-  test('renderA with directiveB', () => {
-    renderA(htmlB`<div title="a${dirB('B')}b"></div>`, container);
-    assertContent('<div title="a[B:DIV:title:a:b]b"></div>');
-  });
-
-  test('renderB with directiveA', () => {
-    renderB(htmlA`<div title="a${dirA('A')}b"></div>`, container);
-    assertContent('<div title="a[A:DIV:title:a:b]b"></div>');
-  });
-
-  test('renderA with directiveA nested in passthruB', () => {
-    renderA(htmlB`<div title="a${passthruB(dirA('A'))}b"></div>`, container);
-    assertContent('<div title="a[A:DIV:title:a:b]b"></div>');
-  });
-
-  test('renderB with directiveB nested in passthruA', () => {
-    renderB(htmlA`<div title="a${passthruA(dirB('B'))}b"></div>`, container);
-    assertContent('<div title="a[B:DIV:title:a:b]b"></div>');
-  });
-
-  test('renderA with asyncB', async () => {
-    let connected = true;
-    const cb = (c) => (connected = c);
-    const template = (bool) =>
-      htmlA`<div>${bool ? asyncB('B', cb) : nothingA}</div>`;
-    renderA(template(true), container);
-    assertContent('<div></div>');
-    assert.isTrue(connected);
-    // Wait until directive updates value.
-    await nextFrame();
-    assertContent('<div>B</div>');
-    renderA(template(false), container);
-    assert.isFalse(connected);
-    assertContent('<div></div>');
-    const part = renderA(template(true), container);
-    assert.isTrue(connected);
-    // Wait until directive updates value.
-    await nextFrame();
-    assertContent('<div>B</div>');
-    part.setConnected(false);
-    assert.isFalse(connected);
-    assertContent('<div>B</div>');
-    part.setConnected(true);
-    assert.isTrue(connected);
-    assertContent('<div>B</div>');
-  });
-
-  test('renderB with asyncA', async () => {
-    let connected = false;
-    const cb = (c) => (connected = c);
-    const template = (bool) =>
-      htmlB`<div>${bool ? asyncA('A', cb) : nothingB}</div>`;
-    renderB(template(true), container);
-    assertContent('<div></div>');
-    assert.isTrue(connected);
-    // Wait until directive updates value.
-    await nextFrame();
-    assertContent('<div>A</div>');
-    renderB(template(false), container);
-    assert.isFalse(connected);
-    assertContent('<div></div>');
-    const part = renderB(template(true), container);
-    assert.isTrue(connected);
-    // Wait until directive updates value.
-    await nextFrame();
-    assertContent('<div>A</div>');
-    part.setConnected(false);
-    assert.isFalse(connected);
-    assertContent('<div>A</div>');
-    part.setConnected(true);
-    assert.isTrue(connected);
-    assertContent('<div>A</div>');
-  });
-
-  test('renderA with repeatB rendering htmlA and passthruB', () => {
-    const items = [0, 1, 2];
-    renderA(
-      htmlA`<div>${repeatB(
-        items,
-        (item) => htmlA`<p>${passthruB(`B${item}`)}</p>`
-      )}</div>`,
-      container
-    );
-    assertContent('<div><p>B0</p><p>B1</p><p>B2</p></div>');
-  });
-
-  test('renderB with repeatA rendering htmlB and passthruA', () => {
-    const items = [0, 1, 2];
-    renderB(
-      htmlB`<div>${repeatA(
-        items,
-        (item) => htmlB`<p>${passthruA(`A${item}`)}</p>`
-      )}</div>`,
-      container
-    );
-    assertContent('<div><p>A0</p><p>A1</p><p>A2</p></div>');
-  });
-
-  test('renderA with repeatB rendering asyncA', async () => {
-    const items = [0];
-    let connected = false;
-    const cb = (c) => (connected = c);
-    const template = (bool) =>
-      htmlA`<div>${
-        bool
-          ? repeatB(items, (item) => htmlA`<p>${asyncA(`A${item}`, cb)}</p>`)
-          : nothingB
-      }</div>`;
-    renderA(template(true, cb), container);
-    assert.isTrue(connected);
-    assertContent('<div><p></p></div>');
-    // Wait until directive updates value.
-    await nextFrame();
-    assertContent('<div><p>A0</p></div>');
-    renderA(template(false, cb), container);
-    assert.isFalse(connected);
-    assertContent('<div></div>');
-    const part = renderA(template(true, cb), container);
-    assert.isTrue(connected);
-    assertContent('<div><p></p></div>');
-    // Wait until directive updates value.
-    await nextFrame();
-    assertContent('<div><p>A0</p></div>');
-    part.setConnected(false);
-    assert.isFalse(connected);
-    assertContent('<div><p>A0</p></div>');
-    part.setConnected(true);
-    assert.isTrue(connected);
-    assertContent('<div><p>A0</p></div>');
-  });
-
-  test('renderB with repeatA rendering asyncB', async () => {
-    const items = [0];
-    let connected = false;
-    const cb = (c) => (connected = c);
-    const template = (bool) =>
-      htmlB`<div>${
-        bool
-          ? repeatA(items, (item) => htmlB`<p>${asyncB(`B${item}`, cb)}</p>`)
-          : nothingA
-      }</div>`;
-    renderB(template(true, cb), container);
-    assert.isTrue(connected);
-    assertContent('<div><p></p></div>');
-    // Wait until directive updates value.
-    await nextFrame();
-    assertContent('<div><p>B0</p></div>');
-    renderA(template(false, cb), container);
-    assert.isFalse(connected);
-    assertContent('<div></div>');
-    const part = renderA(template(true, cb), container);
-    assert.isTrue(connected);
-    assertContent('<div><p></p></div>');
-    // Wait until directive updates value.
-    await nextFrame();
-    assertContent('<div><p>B0</p></div>');
-    part.setConnected(false);
-    assert.isFalse(connected);
-    assertContent('<div><p>B0</p></div>');
-    part.setConnected(true);
-    assert.isTrue(connected);
-    assertContent('<div><p>B0</p></div>');
-  });
-});

--- a/packages/lit-html/src/test/version-stability_test.js
+++ b/packages/lit-html/src/test/version-stability_test.js
@@ -1,0 +1,320 @@
+/**
+ * @license
+ * Copyright 2020 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import {
+  html as htmlA,
+  render as renderA,
+  nothing as nothingA,
+  noChange as noChangeA,
+} from '../../lit-html.js';
+import {
+  directive as directiveA,
+  Directive as DirectiveA,
+  PartType as PartTypeA,
+} from '../../directive.js';
+import {AsyncDirective as AsyncDirectiveA} from '../../async-directive.js';
+import {repeat as repeatA} from '../../directives/repeat.js';
+
+import {
+  html as htmlB,
+  render as renderB,
+  nothing as nothingB,
+  noChange as noChangeB,
+} from '../../version-stability-build/lit-html.js';
+import {
+  directive as directiveB,
+  Directive as DirectiveB,
+  PartType as PartTypeB,
+} from '../../version-stability-build/directive.js';
+import {AsyncDirective as AsyncDirectiveB} from '../../version-stability-build/async-directive.js';
+import {repeat as repeatB} from '../../version-stability-build/directives/repeat.js';
+
+import {stripExpressionComments} from '../../development/test/test-utils/strip-markers.js';
+import {assert} from '@esm-bundle/chai';
+
+const nextFrame = () => new Promise((r) => requestAnimationFrame(() => r()));
+
+const dirA = directiveA(
+  class extends DirectiveA {
+    constructor(partInfo) {
+      super(partInfo);
+      this.partInfo = partInfo;
+    }
+    render(v) {
+      if (this.partInfo.type !== PartTypeA.ATTRIBUTE) {
+        throw new Error('expected PartType.ATTRIBUTE');
+      }
+      const {tagName, name, strings} = this.partInfo;
+      return `[${v}:${tagName}:${name}:${strings.join(':')}]`;
+    }
+  }
+);
+
+const dirB = directiveB(
+  class extends DirectiveB {
+    constructor(partInfo) {
+      super(partInfo);
+      this.partInfo = partInfo;
+    }
+    render(v) {
+      if (this.partInfo.type !== PartTypeB.ATTRIBUTE) {
+        throw new Error('expected PartType.ATTRIBUTE');
+      }
+      const {tagName, name, strings} = this.partInfo;
+      return `[${v}:${tagName}:${name}:${strings.join(':')}]`;
+    }
+  }
+);
+
+const passthruA = directiveA(
+  class extends DirectiveA {
+    render(v) {
+      return v;
+    }
+  }
+);
+
+const passthruB = directiveA(
+  class extends DirectiveB {
+    render(v) {
+      return v;
+    }
+  }
+);
+
+const asyncA = directiveA(
+  class extends AsyncDirectiveA {
+    render(v, cb) {
+      this.cb = cb;
+      this.cb(true);
+      Promise.resolve().then(() => this.setValue(v));
+    }
+    disconnected() {
+      this.cb(false);
+    }
+    reconnected() {
+      this.cb(true);
+    }
+  }
+);
+
+const asyncB = directiveA(
+  class extends AsyncDirectiveB {
+    render(v, cb) {
+      this.cb = cb;
+      this.cb(true);
+      Promise.resolve().then(() => this.setValue(v));
+    }
+    disconnected() {
+      this.cb(false);
+    }
+    reconnected() {
+      this.cb(true);
+    }
+  }
+);
+
+suite('version-stability', () => {
+  let container;
+
+  setup(() => {
+    container = document.createElement('div');
+  });
+
+  const assertContent = (expected) => {
+    assert.equal(stripExpressionComments(container.innerHTML), expected);
+  };
+
+  test('renderA with htmlB', () => {
+    renderA(htmlB`<div>${'test'}</div>`, container);
+    assertContent('<div>test</div>');
+  });
+
+  test('renderB with htmlA', () => {
+    renderB(htmlA`<div>${'test'}</div>`, container);
+    assertContent('<div>test</div>');
+  });
+
+  test('renderA with nothingB and noChangeB', () => {
+    const template = (v) => htmlA`<div>${v}</div>`;
+    renderA(template('test'), container);
+    assertContent('<div>test</div>');
+    renderA(template(nothingB), container);
+    assertContent('<div></div>');
+    renderA(template('test'), container);
+    assertContent('<div>test</div>');
+    renderA(template(noChangeB), container);
+    assertContent('<div>test</div>');
+  });
+
+  test('renderB with nothingA and noChangeA', () => {
+    const template = (v) => htmlA`<div>${v}</div>`;
+    renderB(template('test'), container);
+    assertContent('<div>test</div>');
+    renderB(template(nothingA), container);
+    assertContent('<div></div>');
+    renderB(template('test'), container);
+    assertContent('<div>test</div>');
+    renderB(template(noChangeA), container);
+    assertContent('<div>test</div>');
+  });
+
+  test('renderA with directiveB', () => {
+    renderA(htmlB`<div title="a${dirB('B')}b"></div>`, container);
+    assertContent('<div title="a[B:DIV:title:a:b]b"></div>');
+  });
+
+  test('renderB with directiveA', () => {
+    renderB(htmlA`<div title="a${dirA('A')}b"></div>`, container);
+    assertContent('<div title="a[A:DIV:title:a:b]b"></div>');
+  });
+
+  test('renderA with directiveA nested in passthruB', () => {
+    renderA(htmlB`<div title="a${passthruB(dirA('A'))}b"></div>`, container);
+    assertContent('<div title="a[A:DIV:title:a:b]b"></div>');
+  });
+
+  test('renderB with directiveB nested in passthruA', () => {
+    renderB(htmlA`<div title="a${passthruA(dirB('B'))}b"></div>`, container);
+    assertContent('<div title="a[B:DIV:title:a:b]b"></div>');
+  });
+
+  test('renderA with asyncB', async () => {
+    let connected = true;
+    const cb = (c) => (connected = c);
+    const template = (bool) =>
+      htmlA`<div>${bool ? asyncB('B', cb) : nothingA}</div>`;
+    renderA(template(true), container);
+    assertContent('<div></div>');
+    assert.isTrue(connected);
+    await nextFrame();
+    assertContent('<div>B</div>');
+    renderA(template(false), container);
+    assert.isFalse(connected);
+    assertContent('<div></div>');
+    const part = renderA(template(true), container);
+    assert.isTrue(connected);
+    await nextFrame();
+    assertContent('<div>B</div>');
+    part.setConnected(false);
+    assert.isFalse(connected);
+    assertContent('<div>B</div>');
+    part.setConnected(true);
+    assert.isTrue(connected);
+    assertContent('<div>B</div>');
+  });
+
+  test('renderB with asyncA', async () => {
+    let connected = false;
+    const cb = (c) => (connected = c);
+    const template = (bool) =>
+      htmlB`<div>${bool ? asyncA('A', cb) : nothingB}</div>`;
+    renderB(template(true), container);
+    assertContent('<div></div>');
+    assert.isTrue(connected);
+    await nextFrame();
+    assertContent('<div>A</div>');
+    renderB(template(false), container);
+    assert.isFalse(connected);
+    assertContent('<div></div>');
+    const part = renderB(template(true), container);
+    assert.isTrue(connected);
+    await nextFrame();
+    assertContent('<div>A</div>');
+    part.setConnected(false);
+    assert.isFalse(connected);
+    assertContent('<div>A</div>');
+    part.setConnected(true);
+    assert.isTrue(connected);
+    assertContent('<div>A</div>');
+  });
+
+  test('renderA with repeatB rendering htmlA and passthruB', () => {
+    const items = [0, 1, 2];
+    renderA(
+      htmlA`<div>${repeatB(
+        items,
+        (item) => htmlA`<p>${passthruB(`B${item}`)}</p>`
+      )}</div>`,
+      container
+    );
+    assertContent('<div><p>B0</p><p>B1</p><p>B2</p></div>');
+  });
+
+  test('renderB with repeatA rendering htmlB and passthruA', () => {
+    const items = [0, 1, 2];
+    renderB(
+      htmlB`<div>${repeatA(
+        items,
+        (item) => htmlB`<p>${passthruA(`A${item}`)}</p>`
+      )}</div>`,
+      container
+    );
+    assertContent('<div><p>A0</p><p>A1</p><p>A2</p></div>');
+  });
+
+  test('renderA with repeatB rendering asyncA', async () => {
+    const items = [0];
+    let connected = false;
+    const cb = (c) => (connected = c);
+    const template = (bool) =>
+      htmlA`<div>${
+        bool
+          ? repeatB(items, (item) => htmlA`<p>${asyncA(`A${item}`, cb)}</p>`)
+          : nothingB
+      }</div>`;
+    renderA(template(true, cb), container);
+    assert.isTrue(connected);
+    assertContent('<div><p></p></div>');
+    await nextFrame();
+    assertContent('<div><p>A0</p></div>');
+    renderA(template(false, cb), container);
+    assert.isFalse(connected);
+    assertContent('<div></div>');
+    const part = renderA(template(true, cb), container);
+    assert.isTrue(connected);
+    assertContent('<div><p></p></div>');
+    await nextFrame();
+    assertContent('<div><p>A0</p></div>');
+    part.setConnected(false);
+    assert.isFalse(connected);
+    assertContent('<div><p>A0</p></div>');
+    part.setConnected(true);
+    assert.isTrue(connected);
+    assertContent('<div><p>A0</p></div>');
+  });
+
+  test('renderB with repeatA rendering asyncB', async () => {
+    const items = [0];
+    let connected = false;
+    const cb = (c) => (connected = c);
+    const template = (bool) =>
+      htmlB`<div>${
+        bool
+          ? repeatA(items, (item) => htmlB`<p>${asyncB(`B${item}`, cb)}</p>`)
+          : nothingA
+      }</div>`;
+    renderB(template(true, cb), container);
+    assert.isTrue(connected);
+    assertContent('<div><p></p></div>');
+    await nextFrame();
+    assertContent('<div><p>B0</p></div>');
+    renderA(template(false, cb), container);
+    assert.isFalse(connected);
+    assertContent('<div></div>');
+    const part = renderA(template(true, cb), container);
+    assert.isTrue(connected);
+    assertContent('<div><p></p></div>');
+    await nextFrame();
+    assertContent('<div><p>B0</p></div>');
+    part.setConnected(false);
+    assert.isFalse(connected);
+    assertContent('<div><p>B0</p></div>');
+    part.setConnected(true);
+    assert.isTrue(connected);
+    assertContent('<div><p>B0</p></div>');
+  });
+});

--- a/packages/lit-html/src/test/version-stability_test.js
+++ b/packages/lit-html/src/test/version-stability_test.js
@@ -19,23 +19,6 @@ import {assert} from '@esm-bundle/chai';
 
 const nextFrame = () => new Promise((r) => requestAnimationFrame(() => r()));
 
-// {
-//   html as htmlA,
-//   render as renderA,
-//   nothing as nothingA,
-//   noChange as noChangeA,
-// }
-
-// {
-//   directive as directiveA,
-//   Directive as DirectiveA,
-//   PartType as PartTypeA,
-// }
-
-// {AsyncDirective as AsyncDirectiveA}
-
-// {repeat as repeatA}
-
 const version1 = [litHtml1, directive1, asyncDirective1, repeat1];
 const version2 = [litHtml2, directive2, asyncDirective2, repeat2];
 

--- a/packages/lit-html/src/test/version-stability_test.js
+++ b/packages/lit-html/src/test/version-stability_test.js
@@ -77,7 +77,7 @@ const passthruA = directiveA(
   }
 );
 
-const passthruB = directiveA(
+const passthruB = directiveB(
   class extends DirectiveB {
     render(v) {
       return v;
@@ -101,7 +101,7 @@ const asyncA = directiveA(
   }
 );
 
-const asyncB = directiveA(
+const asyncB = directiveB(
   class extends AsyncDirectiveB {
     render(v, cb) {
       this.cb = cb;
@@ -198,6 +198,7 @@ suite('version-stability', () => {
     assertContent('<div></div>');
     const part = renderA(template(true), container);
     assert.isTrue(connected);
+    // Wait until directive updates value.
     await nextFrame();
     assertContent('<div>B</div>');
     part.setConnected(false);
@@ -216,6 +217,7 @@ suite('version-stability', () => {
     renderB(template(true), container);
     assertContent('<div></div>');
     assert.isTrue(connected);
+    // Wait until directive updates value.
     await nextFrame();
     assertContent('<div>A</div>');
     renderB(template(false), container);
@@ -223,6 +225,7 @@ suite('version-stability', () => {
     assertContent('<div></div>');
     const part = renderB(template(true), container);
     assert.isTrue(connected);
+    // Wait until directive updates value.
     await nextFrame();
     assertContent('<div>A</div>');
     part.setConnected(false);
@@ -270,6 +273,7 @@ suite('version-stability', () => {
     renderA(template(true, cb), container);
     assert.isTrue(connected);
     assertContent('<div><p></p></div>');
+    // Wait until directive updates value.
     await nextFrame();
     assertContent('<div><p>A0</p></div>');
     renderA(template(false, cb), container);
@@ -278,6 +282,7 @@ suite('version-stability', () => {
     const part = renderA(template(true, cb), container);
     assert.isTrue(connected);
     assertContent('<div><p></p></div>');
+    // Wait until directive updates value.
     await nextFrame();
     assertContent('<div><p>A0</p></div>');
     part.setConnected(false);
@@ -301,6 +306,7 @@ suite('version-stability', () => {
     renderB(template(true, cb), container);
     assert.isTrue(connected);
     assertContent('<div><p></p></div>');
+    // Wait until directive updates value.
     await nextFrame();
     assertContent('<div><p>B0</p></div>');
     renderA(template(false, cb), container);
@@ -309,6 +315,7 @@ suite('version-stability', () => {
     const part = renderA(template(true, cb), container);
     assert.isTrue(connected);
     assertContent('<div><p></p></div>');
+    // Wait until directive updates value.
     await nextFrame();
     assertContent('<div><p>B0</p></div>');
     part.setConnected(false);

--- a/packages/lit-html/src/test/version-stability_test.js
+++ b/packages/lit-html/src/test/version-stability_test.js
@@ -190,6 +190,7 @@ suite('version-stability', () => {
     renderA(template(true), container);
     assertContent('<div></div>');
     assert.isTrue(connected);
+    // Wait until directive updates value.
     await nextFrame();
     assertContent('<div>B</div>');
     renderA(template(false), container);

--- a/rollup-common.js
+++ b/rollup-common.js
@@ -155,7 +155,7 @@ const prefixProperties = (
       // `prefixClassProperties` is called twice on the same `nameCache`.
       if (p.startsWith('$__') && !props[p].startsWith(classPropertyPrefix)) {
         props[p] = classPropertyPrefix + props[p];
-      } else if (!p.startsWith('$_$')) {
+      } else if (testPropertyPrefix && !(p.slice(1) in stableProperties)) {
         // Only change the names of non-stable properties when testing
         props[p] = testPropertyPrefix + props[p];
       }


### PR DESCRIPTION
Adds a `version-stability-build` using a special rollup config that adds a `VERSION_TEST_` prefix to all non-stable mangled properties, and adds a `version-stability_test.js` that imports the normal `prod` build as well as the `version-stability-build` into the same test file, and tests various known stability-sensitive operations:
* `TemplateResult` passed to different-version `render`
* `nothing` & `noChange` passed to different-version `render`
* `Directive` passed to different-version `render`
* `Directive` passed to different version `Directive` (nested directives)
* `AsyncDirective` (with `disconnect`/`reconnect`) passed into a different-version `render`
* `repeat` directive (which makes its own parts using `directive-helpers`) passed into different-version `render`
* `AsyncDirective` passed to different version `repeat`

Note the test file is in JS not TS, as I found it exceedingly difficult to get a TS setup to build a test file in this package that works with builds in the same package like this.