### PR TITLE
[lit-next] scoped registries typings (wrong path)

### DIFF
--- a/packages/labs/scoped-registry-mixin/package.json
+++ b/packages/labs/scoped-registry-mixin/package.json
@@ -12,7 +12,7 @@
   "type": "module",
   "main": "scoped-registry-mixin.js",
   "module": "scoped-registry-mixin.js",
-  "typings": "index.d.ts",
+  "typings": "scoped-registry-mixin.d.ts",
   "directories": {
     "test": "test"
   },


### PR DESCRIPTION
Was trying to use this new package from typescript and I wasn't able to find typings for it and had a look at what was published on npm for `@lit-labs/scoped-registry-mixin` and `index.d.ts` is definitely not there. The good news is that we are publishing the `.d.ts` but under a different file name.