### PR TITLE
[labs] When publishing we also need to include some files form the development folder

### DIFF
--- a/packages/labs/scoped-registry-mixin/package.json
+++ b/packages/labs/scoped-registry-mixin/package.json
@@ -25,6 +25,7 @@
   "files": [
     "/src/",
     "!/src/test/",
+    "/development/scoped-registry-mixin.{d.ts,d.ts.map,js,js.map}",
     "/scoped-registry-mixin.{d.ts,d.ts.map,js,js.map}"
   ],
   "scripts": {

--- a/packages/labs/scoped-registry-mixin/package.json
+++ b/packages/labs/scoped-registry-mixin/package.json
@@ -25,7 +25,8 @@
   "files": [
     "/src/",
     "!/src/test/",
-    "/development/scoped-registry-mixin.{d.ts,d.ts.map,js,js.map}",
+    "/development/",
+    "!/development/test/",
     "/scoped-registry-mixin.{d.ts,d.ts.map,js,js.map}"
   ],
   "scripts": {


### PR DESCRIPTION
As per the exports map

see https://github.com/Polymer/lit-html/issues/1728

# Description
Exports points to a development scoped-registry-mixin.js but it's missing from published npm package.

```
"exports": {
    ".": {
      "development": "./development/scoped-registry-mixin.js",
      "default": "./scoped-registry-mixin.js"
    }
  },
````

# @lit-labs/scoped-registry-mixin
1.0.0-pre.1

# Compilation error

Could not load /Users/anthonymittaz/Projects/DesignSystems/mono/node_modules/@lit-labs/scoped-registry-mixin/development/scoped-registry-mixin.j
