### PR TITLE
Ensures `hostConnected` is called only once for element upgrade or late added controllers

### DIFF
--- a/packages/reactive-element/CHANGELOG.md
+++ b/packages/reactive-element/CHANGELOG.md
@@ -17,6 +17,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 <!-- ### Removed -->
 <!-- ### Fixed -->
 
+## Unreleased
+
+### Fixed
+
+- (Since 1.0.0-pre.3) A controller's `hostConnected` is called only once if an element is upgraded to a custom element [#1731](https://github.com/Polymer/lit-html/issues/1731).
+
 ## 1.0.0-pre.3 - 2021-03-31
 
 ### Fixed

--- a/packages/reactive-element/src/reactive-element.ts
+++ b/packages/reactive-element/src/reactive-element.ts
@@ -717,7 +717,11 @@ export abstract class ReactiveElement
    */
   addController(controller: ReactiveController) {
     (this.__controllers ??= []).push(controller);
-    if (this.isConnected) {
+    // If a controller is added after the element has been connected,
+    // call hostConnected. Note, re-using existence of `renderRoot` here
+    // (which is set in connectedCallback) to avoid the need to track a
+    // first connected state.
+    if (this.renderRoot !== undefined && this.isConnected) {
       controller.hostConnected?.();
     }
   }

--- a/packages/reactive-element/src/test/reactive-element-controllers_test.ts
+++ b/packages/reactive-element/src/test/reactive-element-controllers_test.ts
@@ -120,18 +120,6 @@ suite('Reactive controllers', () => {
     assert.equal(el.controller.disconnectedCount, 1);
   });
 
-  test('controllers added after an element is connected call `hostConnected`', () => {
-    const controller = new MyController(el);
-    el.addController(controller);
-    assert.equal(el.controller.connectedCount, 1);
-    assert.equal(el.controller.disconnectedCount, 0);
-    container.removeChild(el);
-    assert.equal(el.controller.disconnectedCount, 1);
-    container.appendChild(el);
-    assert.equal(el.controller.connectedCount, 2);
-    assert.equal(el.controller.disconnectedCount, 1);
-  });
-
   test('controllers can implement hostUpdate/hostUpdated', async () => {
     assert.equal(el.updateCount, 1);
     assert.equal(el.updatedCount, 1);
@@ -185,5 +173,32 @@ suite('Reactive controllers', () => {
       'hostDisconnected',
       'disconnectedCallback',
     ]);
+  });
+
+  test('controllers added after an element is first connected call `hostConnected`', () => {
+    const controller = new MyController(el);
+    assert.equal(controller.connectedCount, 1);
+    assert.equal(controller.disconnectedCount, 0);
+    container.removeChild(el);
+    assert.equal(controller.disconnectedCount, 1);
+    container.appendChild(el);
+    assert.equal(controller.connectedCount, 2);
+    assert.equal(controller.disconnectedCount, 1);
+  });
+
+  test('controllers added on an upgraded element call `hostConnected` once', async () => {
+    const name = generateElementName();
+    class B extends A {}
+    const el = document.createElement(name) as B;
+    container.appendChild(el);
+    customElements.define(name, B);
+    await el.updateComplete;
+    assert.equal(el.controller.connectedCount, 1);
+    assert.equal(el.controller.disconnectedCount, 0);
+    container.removeChild(el);
+    assert.equal(el.controller.disconnectedCount, 1);
+    container.appendChild(el);
+    assert.equal(el.controller.connectedCount, 2);
+    assert.equal(el.controller.disconnectedCount, 1);
   });
 });


### PR DESCRIPTION
* Fixes #1731. Previously if an element adding a controller in its constructor was upgraded, the controller's `hostConnected` would be called 2x. This was because `addController` called `hostConnected` if `isConnected` was true. Now it does so only if the element `isConnected` and the `connectedCallback` has already run (noted by checking existence of `renderRoot`).
* Also fixes test for adding a controller after element boot up.