### PR TITLE
[reactive-element] Add '@lit/reactive-element/decorators/base.js' to the grouped decorator exports.

### DIFF
--- a/packages/lit-element/src/decorators.ts
+++ b/packages/lit-element/src/decorators.ts
@@ -11,6 +11,7 @@
  * not an arrow function.
  */
 
+export * from '@lit/reactive-element/decorators/base.js';
 export * from '@lit/reactive-element/decorators/custom-element.js';
 export * from '@lit/reactive-element/decorators/property.js';
 export * from '@lit/reactive-element/decorators/state.js';

--- a/packages/reactive-element/src/decorators.ts
+++ b/packages/reactive-element/src/decorators.ts
@@ -11,6 +11,7 @@
  * not an arrow function.
  */
 
+export * from './decorators/base.js';
 export * from './decorators/custom-element.js';
 export * from './decorators/property.js';
 export * from './decorators/state.js';


### PR DESCRIPTION
I ran into this because one internal user had `import {Constructor} from 'lit-element';`. ~I also made the lit-element decorators.ts a proxy to the one in reactive-element, since they seem to be exporting the same things.~ _(Reverted. I'd rather just propose the minimal change, but could add this back in if requested.)_