### PR TITLE
[lit-html] Add and export type HTMLTemplateResult

### DIFF
--- a/packages/lit-html/src/lit-html.ts
+++ b/packages/lit-html/src/lit-html.ts
@@ -225,6 +225,8 @@ export type TemplateResult<T extends ResultType = ResultType> = {
   values: unknown[];
 };
 
+export type HTMLTemplateResult = TemplateResult<typeof HTML_RESULT>;
+                           
 export type SVGTemplateResult = TemplateResult<typeof SVG_RESULT>;
 
 export interface CompiledTemplateResult {


### PR DESCRIPTION
As there is a matching one for SVGTemplateResult, it wouldn't hurt consistency to add one for HTMLTemplateResult

This would prevent having to define types like `export declare const html: (strings: TemplateStringsArray, ...values: unknown[]) => TemplateResult<1>;`