### PR TITLE
[scoped-registry-mixin] adopt styles

### DIFF
--- a/packages/labs/scoped-registry-mixin/package.json
+++ b/packages/labs/scoped-registry-mixin/package.json
@@ -45,6 +45,7 @@
   },
   "author": "The Polymer Authors",
   "dependencies": {
+    "@lit/reactive-element": "1.0.0-pre.3",
     "lit": "^2.0.0-pre.2"
   },
   "devDependencies": {

--- a/packages/labs/scoped-registry-mixin/src/scoped-registry-mixin.ts
+++ b/packages/labs/scoped-registry-mixin/src/scoped-registry-mixin.ts
@@ -13,6 +13,7 @@
  */
 
 import type {LitElement} from 'lit';
+import {adoptStyles} from '@lit/reactive-element/css-tag.js';
 
 // Proposed interface changes
 declare global {
@@ -55,10 +56,17 @@ export function ScopedRegistryHost<SuperClass extends LitElementConstructor>(
         );
       }
 
-      return (this.renderOptions.creationScope = this.attachShadow({
+      const renderRoot = (this.renderOptions.creationScope = this.attachShadow({
         ...shadowRootOptions,
         customElements: constructor.registry,
       }));
+
+      adoptStyles(
+        renderRoot,
+        (this.constructor as typeof LitElement).elementStyles!
+      );
+
+      return renderRoot;
     }
   };
 }

--- a/packages/labs/scoped-registry-mixin/src/test/scoped-registry-mixin_test.ts
+++ b/packages/labs/scoped-registry-mixin/src/test/scoped-registry-mixin_test.ts
@@ -13,11 +13,11 @@
  */
 
 import '@webcomponents/scoped-custom-element-registry/scoped-custom-element-registry.min.js';
-import {LitElement, html} from 'lit';
+import {LitElement, html, css} from 'lit';
 import {ScopedRegistryHost} from '../scoped-registry-mixin';
 import {assert} from '@esm-bundle/chai';
 
-class SimpleGreeting extends ScopedRegistryHost(LitElement) {
+class SimpleGreeting extends LitElement {
   private name: String;
 
   static get properties() {
@@ -40,6 +40,14 @@ class ScopedComponent extends ScopedRegistryHost(LitElement) {
     'simple-greeting': SimpleGreeting,
   };
 
+  static get styles() {
+    return css`
+      :host {
+        color: #ff0000;
+      }
+    `;
+  }
+
   render() {
     return html` <simple-greeting
       id="greeting"
@@ -51,61 +59,77 @@ class ScopedComponent extends ScopedRegistryHost(LitElement) {
 customElements.define('scoped-component', ScopedComponent);
 
 suite('scoped-registry-mixin', () => {
-  test(`scoped-component should have a registry`, async () => {
-    const $container = document.createElement('div');
-    $container.innerHTML = `<scoped-component></scoped-component>`;
+  test(`host element should have a registry`, async () => {
+    const container = document.createElement('div');
+    container.innerHTML = `<scoped-component></scoped-component>`;
 
-    document.body.appendChild($container);
+    document.body.appendChild(container);
 
-    const $scopedComponent = $container.firstChild as LitElement;
-    await $scopedComponent.updateComplete;
+    const scopedComponent = container.firstChild as LitElement;
+    await scopedComponent.updateComplete;
     // @ts-expect-error: customElements not yet in ShadowRoot type
-    const registry = $scopedComponent?.shadowRoot?.customElements;
+    const registry = scopedComponent?.shadowRoot?.customElements;
 
     assert.exists(registry);
   });
 
-  test(`simple-greeting should not have a registry`, async () => {
-    const $container = document.createElement('div');
-    $container.innerHTML = `<scoped-component></scoped-component>`;
+  test(`hosted element should not have a registry`, async () => {
+    const container = document.createElement('div');
+    container.innerHTML = `<scoped-component></scoped-component>`;
 
-    document.body.appendChild($container);
+    document.body.appendChild(container);
 
-    const $scopedComponent = $container.firstChild as LitElement;
-    await $scopedComponent.updateComplete;
-    const $simpleGreeting = $scopedComponent?.shadowRoot?.getElementById(
+    const scopedComponent = container.firstChild as LitElement;
+    await scopedComponent.updateComplete;
+    const simpleGreeting = scopedComponent?.shadowRoot?.getElementById(
       'greeting'
     ) as LitElement;
     // @ts-expect-error: customElements not yet in ShadowRoot type
-    const registry = $simpleGreeting?.shadowRoot?.customElements;
+    const registry = simpleGreeting?.shadowRoot?.customElements;
 
     assert.notExists(registry);
   });
 
-  test(`simple-greeting should be defined inside the ScopedComponent registry`, async () => {
-    const $container = document.createElement('div');
-    $container.innerHTML = `<scoped-component></scoped-component>`;
+  test(`hosted element should be defined inside the host element registry`, async () => {
+    const container = document.createElement('div');
+    container.innerHTML = `<scoped-component></scoped-component>`;
 
-    document.body.appendChild($container);
+    document.body.appendChild(container);
 
-    const $scopedComponent = $container.firstChild as LitElement;
-    await $scopedComponent.updateComplete;
-    const $simpleGreeting = $scopedComponent?.shadowRoot?.getElementById(
+    const scopedComponent = container.firstChild as LitElement;
+    await scopedComponent.updateComplete;
+    const simpleGreeting = scopedComponent?.shadowRoot?.getElementById(
       'greeting'
     ) as LitElement;
 
-    assert.isTrue($simpleGreeting instanceof SimpleGreeting);
+    assert.isTrue(simpleGreeting instanceof SimpleGreeting);
   });
 
-  test(`simple-greeting should not be able in the global registry`, async () => {
-    const $container = document.createElement('div');
-    $container.innerHTML = `<simple-greeting id="global-greeting"></simple-greeting>`;
+  test(`hosted element should not be defined in the global registry`, async () => {
+    const container = document.createElement('div');
+    container.innerHTML = `<simple-greeting id="global-greeting"></simple-greeting>`;
 
-    document.body.appendChild($container);
+    document.body.appendChild(container);
 
-    const $simpleGreeting = document.getElementById('global-greeting');
+    const simpleGreeting = document.getElementById('global-greeting');
 
-    assert.isFalse($simpleGreeting instanceof SimpleGreeting);
-    assert.isTrue($simpleGreeting instanceof HTMLElement);
+    assert.isFalse(simpleGreeting instanceof SimpleGreeting);
+    assert.isTrue(simpleGreeting instanceof HTMLElement);
+  });
+
+  test(`host element should apply static styles`, async () => {
+    const container = document.createElement('div');
+    container.innerHTML = `<scoped-component></scoped-component>`;
+
+    document.body.appendChild(container);
+
+    const scopedComponent = container.firstChild as LitElement;
+    await scopedComponent.updateComplete;
+    const simpleGreeting = scopedComponent?.shadowRoot?.getElementById(
+      'greeting'
+    );
+    const {color} = getComputedStyle(simpleGreeting!);
+
+    assert.equal(color, 'rgb(255, 0, 0)');
   });
 });


### PR DESCRIPTION
As the adoption of styles is done by the method createShadowRoot of ReactiveElement, we must also adopt them inside the method createShadowRoot of ScopedRegistryMixin. Otherwise, components using this mixin are not going to have the styles adopted.