### PR TITLE
Add TrustedTypes support to lit-next

### DIFF
--- a/packages/labs/ssr/src/lib/render-lit-html.ts
+++ b/packages/labs/ssr/src/lib/render-lit-html.ts
@@ -279,7 +279,7 @@ const getTemplateOpcodes = (result: TemplateResult) => {
    * on; this lets us skip over certain ast nodes by string character position
    * while walking the AST.
    */
-  const ast = parseFragment(html, {
+  const ast = parseFragment(String(html), {
     sourceCodeLocationInfo: true,
   }) as DefaultTreeDocumentFragment;
 
@@ -336,7 +336,7 @@ const getTemplateOpcodes = (result: TemplateResult) => {
     }
     const previousLastOffset = lastOffset;
     lastOffset = offset;
-    const value = html.substring(previousLastOffset, offset);
+    const value = String(html).substring(previousLastOffset, offset);
     flush(value);
   };
 

--- a/packages/lit-html/CHANGELOG.md
+++ b/packages/lit-html/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Added `defer-hydration` attribute handling to `experimental-hydrate`, which helps
   coordinate ordered wakeup of custom elements during hydration.
+- Added support for running with [Trusted Types](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/trusted-types) enforced.
 
 ### Changed
 

--- a/packages/lit-html/src/lit-html.ts
+++ b/packages/lit-html/src/lit-html.ts
@@ -36,7 +36,7 @@ const policy = trustedTypes
   ? trustedTypes.createPolicy('lit-html', {
       createHTML: (s) => s,
     })
-  : null;
+  : undefined;
 
 /**
  * Used to sanitize any value before it is written into the DOM. This can be
@@ -544,7 +544,7 @@ const getTemplateHtml = (
 
   // Returned as an array for terseness
   return [
-    policy
+    policy !== undefined
       ? policy.createHTML(htmlResult)
       : ((htmlResult as unknown) as TrustedHTML),
     attrNames,

--- a/packages/lit-html/src/test/lit-html_test.ts
+++ b/packages/lit-html/src/test/lit-html_test.ts
@@ -1509,10 +1509,15 @@ suite('lit-html', () => {
   });
 
   suite('compiled', () => {
+    const trustedTypes =
+        (globalThis as unknown as Partial<Window>).trustedTypes;
+    const policy = trustedTypes?.createPolicy(
+      'lit-html', { createHTML: (s) => s }) ?? {createHTML:(s) => s as unknown as TrustedHTML};
+
     test('only text', () => {
       // A compiled template for html`${'A'}`
       const _$lit_template_1: CompiledTemplate = {
-        h: '<!---->',
+        h: policy.createHTML('<!---->'),
         parts: [{type: 2, index: 0}],
       };
       assertRender(
@@ -1527,7 +1532,7 @@ suite('lit-html', () => {
     test('text expression', () => {
       // A compiled template for html`<div>${'A'}</div>`
       const _$lit_template_1: CompiledTemplate = {
-        h: `<div><!----></div>`,
+        h: policy.createHTML(`<div><!----></div>`),
         parts: [{type: 2, index: 1}],
       };
       const result = {
@@ -1540,7 +1545,7 @@ suite('lit-html', () => {
     test('attribute expression', () => {
       // A compiled template for html`<div foo=${'A'}></div>`
       const _$lit_template_1: CompiledTemplate = {
-        h: '<div></div>',
+        h: policy.createHTML('<div></div>'),
         parts: [
           {
             type: 1,
@@ -1562,7 +1567,7 @@ suite('lit-html', () => {
       const r = createRef();
       // A compiled template for html`<div ${ref(r)}></div>`
       const _$lit_template_1: CompiledTemplate = {
-        h: '<div></div>',
+        h: policy.createHTML('<div></div>'),
         parts: [{type: 6, index: 0}],
       };
       const result = {


### PR DESCRIPTION
When running in a browser that supports [TrustedTypes](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/trusted-types) this will create a lit-html policy and use it for blessing the content of tagged template literals before we hand it off to HTMLTemplateElement#innerHTML for parsing.