### PR TITLE
README tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 Lit is a simple library for building fast, lightweight web components.
 
-At its core is a boilerplate-killing component base class that provides reactive state, scoped styles, and a declarative template system that leads the pack in size, speed, and expressiveness.
+At Lit's core is a boilerplate-killing component base class that provides reactive state, scoped styles, and a declarative template system that's tiny, fast and expressive.
 
 ### Documentation
 

--- a/packages/lit/README.md
+++ b/packages/lit/README.md
@@ -1,14 +1,18 @@
-# Lit 2.0
+# Lit
 
-Fast, lightweight web components
+## Simple. Fast. Web Components.
+
+Lit is a simple library for building fast, lightweight web components.
+
+At its core is a boilerplate-killing component base class that provides reactive state, scoped styles, and a declarative template system that leads the pack in size, speed, and expressiveness.
 
 ## About this package
 
-The `lit` package contains everything needed to build Lit components with the LitElement base class, lit-html templates, and all first-party lit-html directives.
+The `lit` package contains everything needed to build Lit components: the LitElement base class, Lit templates, and all first-party Lit directives.
 
 Modules:
 
-- `lit`: The main module exports the core pieces needed for component development: `LitElement`, `html`, `css`, and the most
+- `lit`: The main module exports the core pieces needed for component development, including `LitElement`, `html`, and `css`
 - `lit/decorators.js`: Exports all the TypeScript/Babel decorators from one module.
 - `lit/decorators/...`: The `decorators/` folder contains a module for each decorator (`@customElement()`, `@property()`, etc.) for optimal pay-as-you-go module loading.
 - `lit/html.js`: Just the exports needed for standalone `lit-html` usage: `render()`, `html`, `svg`, etc.

--- a/packages/lit/README.md
+++ b/packages/lit/README.md
@@ -4,7 +4,7 @@
 
 Lit is a simple library for building fast, lightweight web components.
 
-At its core is a boilerplate-killing component base class that provides reactive state, scoped styles, and a declarative template system that leads the pack in size, speed, and expressiveness.
+At Lit's core is a boilerplate-killing component base class that provides reactive state, scoped styles, and a declarative template system that's tiny, fast and expressive.
 
 ## About this package
 


### PR DESCRIPTION
Slight messaging / presentation tweaks in preparation for launch, since this will be what people see when they look up `lit` on npm.

* Removed version number from heading (I couldn't find any comparable packages that included a version number)
* Grabbed the more official tagline and 1-phrase description from the monorepo
* Lightly edited intro text to de-emphasize the identity of `lit-html` as a separate thing, though resisted the temptation to make more edits further down for now