### PR TITLE
[lit] Include lit logo in lit NPM package

### DIFF
--- a/.changeset/lemon-clouds-melt.md
+++ b/.changeset/lemon-clouds-melt.md
@@ -1,0 +1,5 @@
+---
+'lit': patch
+---
+
+Add lit logo to NPM package

--- a/packages/lit/package.json
+++ b/packages/lit/package.json
@@ -135,7 +135,8 @@
     "/polyfill-support.{d.ts.map,d.ts,js.map,js}",
     "/static-html.{d.ts.map,d.ts,js.map,js}",
     "/decorators/",
-    "/directives/"
+    "/directives/",
+    "/logo.svg"
   ],
   "dependencies": {
     "@lit/reactive-element": "^1.0.0",


### PR DESCRIPTION
This way it should show up at https://www.npmjs.com/package/lit instead of the missing image we currently see.

Tested by running `npm pack` and seeing `logo.svg` listed.