### PR TITLE
Add Lit to changeset for #2635

### DIFF
--- a/.changeset/weak-feet-invent.md
+++ b/.changeset/weak-feet-invent.md
@@ -1,4 +1,5 @@
 ---
+'lit': patch
 'lit-html': patch
 '@lit/reactive-element': patch
 ---


### PR DESCRIPTION
We forgot to include `lit` in the list of packages affected by https://github.com/lit/lit/pull/2635.

(We should probably make an action that checks this).