### PR TITLE
Fix typo in API doc.

### DIFF
--- a/src/directives/live.ts
+++ b/src/directives/live.ts
@@ -30,7 +30,7 @@ import {AttributePart, BooleanAttributePart, directive, EventPart, NodePart, Pro
  *
  *     html`<input .value=${live(x)}>`
  *
- * `live()` performs a strict equality check agains the live DOM value, and if
+ * `live()` performs a strict equality check against the live DOM value, and if
  * the new value is equal to the live value, does nothing. This means that
  * `live()` should not be used when the binding will cause a type conversion. If
  * you use `live()` with an attribute binding, make sure that only strings are


### PR DESCRIPTION
Fix is API doc only, error originally reported in https://github.com/lit/lit.dev/pull/769.