### PR TITLE
[labs/router] Add support to Router with none of its own routes.

### DIFF
--- a/packages/labs/router/README.md
+++ b/packages/labs/router/README.md
@@ -67,7 +67,7 @@ class MyElement extends LitElement {
   ]);
 
   render() {
-    return router.outlet;
+    return router.outlet();
   }
 }
 ```

--- a/packages/labs/router/src/test/router_test.ts
+++ b/packages/labs/router/src/test/router_test.ts
@@ -5,7 +5,7 @@
  */
 
 import {assert} from '@esm-bundle/chai';
-import type {Test1, Child1, Child2} from './router_test_code.js';
+import type {Test1, Test2, Child1, Child2} from './router_test_code.js';
 import type {RouteConfig, PathRouteConfig} from '../routes.js';
 
 const isPathRouteConfig = (route: RouteConfig): route is PathRouteConfig =>
@@ -103,7 +103,7 @@ const canTest =
     // Initial location
     //
 
-    // Set the iframe URL to / before appending the element
+    // Set the iframe URL before appending the element
     contentWindow!.history.pushState({}, '', '/child1/def');
     contentDocument!.body.append(el);
     await el.updateComplete;
@@ -143,6 +143,35 @@ const canTest =
     assert.include(
       stripExpressionComments(child2.shadowRoot!.innerHTML),
       '<h3>Child 2: xyz</h3>'
+    );
+  });
+
+  test('Nested routing where the parent contains no routes', async () => {
+    await loadTestModule('./router_test.html');
+    const el = container.contentDocument!.createElement(
+      'router-test-2'
+    ) as Test2;
+    const {contentWindow, contentDocument} = container;
+
+    // Set the iframe URL to / before appending the element
+    contentWindow!.history.pushState({}, '', '/def');
+    contentDocument!.body.append(el);
+    await el.updateComplete;
+
+    const child1 = el.shadowRoot!.querySelector('child-1') as Child1;
+    await child1.updateComplete;
+
+    const child2 = el.shadowRoot!.querySelector('child-2') as Child2;
+    await child2.updateComplete;
+
+    // Verify the child route rendered
+    assert.include(
+      stripExpressionComments(child1.shadowRoot!.innerHTML),
+      '<h3>Child 1: def</h3>'
+    );
+    assert.include(
+      stripExpressionComments(child2.shadowRoot!.innerHTML),
+      '<h3>Child 2: def</h3>'
     );
   });
 

--- a/packages/labs/router/src/test/router_test_code.ts
+++ b/packages/labs/router/src/test/router_test_code.ts
@@ -68,6 +68,21 @@ export class Test1 extends LitElement {
   }
 }
 
+@customElement('router-test-2')
+export class Test2 extends LitElement {
+  _router = new Router(this, [
+    {path: '/*'}, // TODO: Note this should be implicit if `new Router(this)` was created.
+  ]);
+
+  override render() {
+    return html`
+      <h1>Test: no top level routes</h1>
+      <child-1></child-1>
+      <child-2></child-2>
+    `;
+  }
+}
+
 @customElement('child-1')
 export class Child1 extends LitElement {
   _routes = new Routes(this, [


### PR DESCRIPTION
### Why

We document that a top level Router does not need routes, however this is not supported currently. This draft adds a test to "mimic" what I think the behavior should be of a Router with no routes. It should treat all routes as `/*` and forward routing to the children.

Added a test with this behavior but no API changes have been made.