### PR TITLE
[infra] Temporarily ignore virtualizer in changesets

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -6,5 +6,5 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "minor",
-  "ignore": []
+  "ignore": ["@lit-labs/virtualizer"]
 }


### PR DESCRIPTION
Temporarily skip publishing of `@lit-labs/virtualizer` via changesets. This should be removed when the package is in a good state for a new release.
cc: @usergenic @graynorton 