### PR TITLE
fix: Set lit component properties before rendering to the DOM when using @lit/react createComponent

### DIFF
--- a/.changeset/tall-tools-pay.md
+++ b/.changeset/tall-tools-pay.md
@@ -1,0 +1,6 @@
+---
+'@lit-labs/ssr-react': patch
+'@lit/react': patch
+---
+
+Set lit component properties before rendering to the DOM when using @lit/react createComponent

--- a/packages/labs/ssr-react/src/test/integration/enable-lit-ssr_test.tsx
+++ b/packages/labs/ssr-react/src/test/integration/enable-lit-ssr_test.tsx
@@ -250,7 +250,7 @@ wrappedCEtest('wrapped element without prop', () => {
 wrappedCEtest('wrapped element with prop', () => {
   assert.equal(
     ReactDOMServer.renderToString(<ReactTestElement name="React" />),
-    `<test-element defer-hydration=""><template shadowroot="open" shadowrootmode="open"><style>
+    `<test-element name="React" defer-hydration=""><template shadowroot="open" shadowrootmode="open"><style>
     p {
       color: blue;
     }
@@ -264,7 +264,7 @@ wrappedCEtest('wrapped element with prop and attribute', () => {
     ReactDOMServer.renderToString(
       <ReactTestElement name="React" id="react-test-element" />
     ),
-    `<test-element id="react-test-element" defer-hydration=""><template shadowroot="open" shadowrootmode="open"><style>
+    `<test-element name="React" id="react-test-element" defer-hydration=""><template shadowroot="open" shadowrootmode="open"><style>
     p {
       color: blue;
     }
@@ -284,7 +284,7 @@ wrappedCEtest('wrapped element with object prop', () => {
     ReactDOMServer.renderToString(
       <ReactObjectTestElement user={{name: 'React'}} />
     ),
-    `<object-test-element defer-hydration=""><template shadowroot="open" shadowrootmode="open"><!--lit-part EvGichL14uw=--><p>Hello, <!--lit-part-->React<!--/lit-part-->!</p><!--/lit-part--></template></object-test-element>`
+    `<object-test-element user="[object Object]" defer-hydration=""><template shadowroot="open" shadowrootmode="open"><!--lit-part EvGichL14uw=--><p>Hello, <!--lit-part-->React<!--/lit-part-->!</p><!--/lit-part--></template></object-test-element>`
   );
 });
 

--- a/packages/react/src/create-component.ts
+++ b/packages/react/src/create-component.ts
@@ -314,6 +314,7 @@ export const createComponent = <
     }
 
     return React.createElement(tagName, {
+      ...elementProps,
       ...reactProps,
       ref: React.useCallback(
         (node: I) => {

--- a/packages/react/src/test/create-component_test.tsx
+++ b/packages/react/src/test/create-component_test.tsx
@@ -82,6 +82,16 @@ class BasicElement extends ReactiveElement {
   @property({type: Array, reflect: true})
   rarr: unknown[] | null | undefined = null;
 
+  @property({type: Boolean})
+  testPropertyAvailableBeforeConnected = false
+  public propertyAvailableBeforeConnected = false
+
+  override connectedCallback(){
+    super.connectedCallback();
+
+    this.propertyAvailableBeforeConnected = this.testPropertyAvailableBeforeConnected
+  }
+
   @property({type: Object})
   set customAccessors(customAccessors: Foo) {
     const oldValue = this._customAccessors;
@@ -551,5 +561,11 @@ suite('createComponent', () => {
     const el = document.querySelector(tagName)!;
     assert.equal(el.style.display, 'block');
     assert.equal(el.getAttribute('class'), 'foo bar');
+  });
+
+  test('Properties have their value set before connectedCallback runs', async () => {
+    render(<BasicElementComponent testPropertyAvailableBeforeConnected={true} />);
+    const el = document.querySelector(tagName)!;
+    assert.equal(el.propertyAvailableBeforeConnected, true);
   });
 });


### PR DESCRIPTION
[#4435](https://github.com/lit/lit/issues/4435)

**Solution:**
Adding the elementProps when using React.createElement makes sure that the properties are set before the connectedCallback runs.

**Notes:**
By adding this change, tests in @lit/labs/ssr-react were breaking because now the user inputted properties will show up on the element when you call ReactDOMServer.renderToString.

If you have any questions or suggestions please let me know.