### PR TITLE
Allow specific props to be forced to reactProps rather than elementProps

### DIFF
--- a/.changeset/empty-cars-cry.md
+++ b/.changeset/empty-cars-cry.md
@@ -1,0 +1,5 @@
+---
+'@lit/react': minor
+---
+
+Allow specific props to be forced to reactProps rather than elementProps

--- a/packages/react/src/test/create-component_test.tsx
+++ b/packages/react/src/test/create-component_test.tsx
@@ -25,6 +25,7 @@ const DEV_MODE = !!ReactiveElement.enableWarning;
 declare global {
   interface HTMLElementTagNameMap {
     [tagName]: BasicElement;
+    'basic-button': BasicButton,
     'x-foo': XFoo;
   }
 }
@@ -112,6 +113,22 @@ const BasicElementComponent = createComponent({
   events: basicElementEvents,
   tagName,
 });
+
+class BasicButton extends HTMLButtonElement {
+
+}
+const BasicButtonComponent = createComponent<BasicButton, {
+  onClick: EventName<MouseEvent>,
+}, {
+  form?: string,
+  id?: never,
+}>({
+  react: React,
+  elementClass: BasicButton,
+  tagName: 'basic-button',
+  reactProps: ['form']
+})
+
 
 const render = (children: React.ReactNode) => {
   act(() => {
@@ -559,4 +576,21 @@ suite('createComponent', () => {
     assert.equal(el.style.display, 'block');
     assert.equal(el.getAttribute('class'), 'foo bar');
   });
+
+  test('can force "form" to be a property', async () => {
+    render(
+      <BasicButtonComponent form="the-form-id" />
+    );
+    const el = document.querySelector('basic-button')!;
+    assert.equal(el.outerHTML, '<basic-button form="the-form-id"></basic-button>')
+  })
+
+  test('forbid the use of a specific attribute', async () => {
+    render(
+      // @ts-expect-error Usage of the id property is explicitly forbidden
+      <BasicButtonComponent id="the-form-id" />
+    );
+    const el = document.querySelector('basic-button')!;
+    assert.equal(el.tagName, 'BASIC-BUTTON');
+  })
 });


### PR DESCRIPTION
At times, the HTML attribute of an element can have a type or purpose different from it's instance property. This is the case for the HTMLButtonElement (and any WCs exending from that) and the "form" property. As HTML attribute, it indicates the id of the form this button submits or cancels, while the property on the instance gets an instance of the form with that id.

To support this, this PR adds a "reactProps" option to "createComponent" that can force React props to stay React props. 

As a side-effect, this also makes it possible to forbid passing specific props at the type level

Fixes #4668 