### PR TITLE
[labs/observers] Make ResizeController.disconnect() public. It permanently unobserves all targets.

### DIFF
--- a/packages/labs/observers/src/resize-controller.ts
+++ b/packages/labs/observers/src/resize-controller.ts
@@ -140,7 +140,7 @@ export class ResizeController<T = unknown> implements ReactiveController {
 
   hostDisconnected() {
     this._isConnected = false;
-    this.disconnect();
+    this._observer.disconnect();
   }
 
   /**
@@ -172,11 +172,13 @@ export class ResizeController<T = unknown> implements ReactiveController {
   }
 
   /**
-   * Disconnects the observer. This is done automatically when the host
-   * disconnects. Note that the observer is automatically reconnected when the
-   * host reconnects.
+   * Disconnects the observer, unobserving all previously-observed elements.
+   *
+   * You typically do not need to call this method yourself, as we automatically
+   * disconnect the observer when the host component is disconnected.
    */
-  protected disconnect() {
+  disconnect() {
     this._observer.disconnect();
+    this._targets.clear();
   }
 }

--- a/packages/labs/observers/src/test/resize-controller_test.ts
+++ b/packages/labs/observers/src/test/resize-controller_test.ts
@@ -534,10 +534,35 @@ if (DEV_MODE) {
     await resizeComplete();
     assert.isTrue(el.observerValue);
     el.resetObserverValue();
-    await resizeComplete();
 
     // Does not report change when unobserved
     el.observer.unobserve(d1);
+    resizeElement(d1);
+    await resizeComplete();
+    assert.isUndefined(el.observerValue);
+
+    el.remove();
+    container.appendChild(el);
+
+    // Does not report changes when re-connected
+    resizeElement(d1);
+    await resizeComplete();
+    assert.isUndefined(el.observerValue);
+  });
+
+  test('observer can be disconnected', async () => {
+    const el = await getTestElement(() => ({target: null}));
+    const d1 = document.createElement('div');
+
+    // Reports initial changes when observe called.
+    el.observer.observe(d1);
+    el.renderRoot.appendChild(d1);
+    await resizeComplete();
+    assert.isTrue(el.observerValue);
+    el.resetObserverValue();
+
+    // Does not report change when unobserved
+    el.observer.disconnect();
     resizeElement(d1);
     await resizeComplete();
     assert.isUndefined(el.observerValue);


### PR DESCRIPTION
Our `ResizeController` implementation automatically disconnects and reconnects
its native `ResizeObserver` object whenever the host component is disconnected
and reconnected. However, this behavior is generally transparent to the user.
This change makes `resizeController.disconnect()` stop observing *permanently*,
rather than until the next reconnect, which makes its user-visible behavior
identical to calling `.disconnect()` on a native `ResizeObserver`. This should
make the behavior much less surprising.

With this change, it also makes sense to make the `disconnect` method public, so
that we expose the same `observe`/`unobserve`/`disconnect` interface as the
native `ResizeObserver`.

-------------

This is a follow-up PR on top of #4850, and it includes the #4850 commit. I recommend you merge #4850 first, and use the "Commits" tab to review the changes added by this PR.