### PR TITLE
[labs/nextjs] skip patching when bundling for next edge runtime

### DIFF
--- a/.changeset/early-poets-boil.md
+++ b/.changeset/early-poets-boil.md
@@ -1,0 +1,5 @@
+---
+'@lit-labs/nextjs': patch
+---
+
+skip patching when bundling for next edge runtime

--- a/packages/labs/nextjs/src/index.ts
+++ b/packages/labs/nextjs/src/index.ts
@@ -30,7 +30,17 @@ export = (
   (nextConfig: NextConfig = {}) => {
     return Object.assign({}, nextConfig, {
       webpack: (config, options) => {
-        const {isServer} = options;
+        const {isServer, nextRuntime} = options;
+
+        // Skip patching when bundling for next's edge runtime
+        if (nextRuntime === 'edge') {
+          // Apply user provided custom webpack config function if it exists.
+          if (typeof nextConfig.webpack === 'function') {
+            return nextConfig.webpack(config, options);
+          }
+
+          return config;
+        }
 
         const {
           addDeclarativeShadowDomPolyfill = true,


### PR DESCRIPTION
Added an early return to skip any webpack config modification when bundling for next's edge runtime. 

Addresses an issue we experienced when bundling in "node:22.11.0-alpine" where otherwise lit patches were applied to e.g. `.next/server/edge-instrumentation.js`.

This should not have any side-effects as the edge runtime is not used for any SSR processes.