### PR TITLE
[lit-html] Allow the template cache to be customized when using the withStatic() tag generator

### DIFF
--- a/.changeset/free-words-hear.md
+++ b/.changeset/free-words-hear.md
@@ -1,0 +1,5 @@
+---
+'lit-html': minor
+---
+
+Allow the template cache to be customized when using the withStatic() tag generator


### PR DESCRIPTION
This adds an options object with a `getCache(strings)` option on it to `withStatic()`.

Authors can now customize the caching of static templates, including:
- Disabling caching completely (return `undefined`)
- Having separate caches per template callsite
- Use an LRU cache
- Use caches that collect hit rate metrics

This is done via `withStatic()` so that the caching strategy doesn't affect other static templates, and so that caching can be tailored to the specific template. A highly dynamic template could have caching disabled, for instance.

When combine with an `isServer` check, the cache can be customized per environment too.