### PR TITLE
[labs/ssr] Experiment with ShadowRealm

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -349,6 +349,7 @@ packages/labs/ssr/test/**/*.js.map
 packages/labs/ssr/test/**/*.d.ts
 packages/labs/ssr/test/**/*.d.ts.map
 packages/labs/ssr/index.*
+packages/labs/ssr/shadow-realm.*
 !packages/labs/ssr/custom_typings/*.d.ts
 
 packages/labs/ssr-client/development/

--- a/.prettierignore
+++ b/.prettierignore
@@ -337,6 +337,7 @@ packages/labs/ssr/test/**/*.js.map
 packages/labs/ssr/test/**/*.d.ts
 packages/labs/ssr/test/**/*.d.ts.map
 packages/labs/ssr/index.*
+packages/labs/ssr/shadow-realm.*
 !packages/labs/ssr/custom_typings/*.d.ts
 
 packages/labs/ssr-client/development/

--- a/packages/labs/ssr/.gitignore
+++ b/packages/labs/ssr/.gitignore
@@ -6,4 +6,5 @@
 /test/**/*.d.ts
 /test/**/*.d.ts.map
 /index.*
+/shadow-realm.*
 !/custom_typings/*.d.ts

--- a/packages/labs/ssr/package.json
+++ b/packages/labs/ssr/package.json
@@ -76,7 +76,7 @@
       ]
     },
     "test:unit": {
-      "command": "NODE_OPTIONS=\"--experimental-vm-modules --enable-source-maps\" uvu test \"lib/.*_test\\.js$\"",
+      "command": "NODE_OPTIONS=\"--experimental-vm-modules --experimental-shadow-realm --enable-source-maps\" uvu test \"lib/.*_test\\.js$\"",
       "#comment": [
         "These unit tests use the default export condition, so they require a",
         "full build of all dependencies."

--- a/packages/labs/ssr/src/env.d.ts
+++ b/packages/labs/ssr/src/env.d.ts
@@ -9,3 +9,23 @@ declare var litSsrCallConnectedCallback: undefined | boolean;
 
 // eslint-disable-next-line no-var
 declare var litServerRoot: HTMLElement;
+
+/**
+ * https://github.com/tc39/proposal-shadowrealm
+ */
+declare class ShadowRealm {
+  constructor();
+  importValue<T extends PrimitiveValueOrCallable>(
+    specifier: string,
+    bindingName: string
+  ): Promise<T>;
+  evaluate<T extends PrimitiveValueOrCallable>(sourceText: string): T;
+}
+
+declare type PrimitiveValueOrCallable =
+  | string
+  | number
+  | boolean
+  | null
+  | undefined
+  | Function;

--- a/packages/labs/ssr/src/lib/shadow-realm/dom-shim.ts
+++ b/packages/labs/ssr/src/lib/shadow-realm/dom-shim.ts
@@ -1,0 +1,72 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+// Buffer is not (yet) exposed as a global symbol in a ShadowRealm,
+// so we need to import it.
+import {Buffer} from 'buffer';
+import {
+  HTMLElement,
+  Element,
+  Event,
+  CustomEvent,
+  EventTarget,
+  CSSStyleSheet,
+  CustomElementRegistry,
+} from '@lit-labs/ssr-dom-shim';
+
+/**
+ * Install the DOM shim symbols on globalThis.
+ * https://github.com/tc39/proposal-shadowrealm
+ * https://github.com/nodejs/node/issues/42528
+ */
+
+class ShadowRoot {}
+
+class Document {
+  get adoptedStyleSheets() {
+    return [];
+  }
+  createTreeWalker() {
+    return {};
+  }
+  createTextNode() {
+    return {};
+  }
+  createElement() {
+    return {};
+  }
+}
+
+// This module is expected to be imported in a ShadowRealm
+// and should polyfill a browser environment inside that
+// ShadowRealm.
+Object.assign(globalThis, {
+  EventTarget,
+  Event: globalThis.Event ?? Event,
+  CustomEvent: globalThis.CustomEvent ?? CustomEvent,
+  Element,
+  HTMLElement,
+  Document,
+  document: new Document(),
+  CSSStyleSheet,
+  ShadowRoot,
+  CustomElementRegistry,
+  customElements: new CustomElementRegistry(),
+  atob(s: string) {
+    return Buffer.from(s, 'base64').toString('binary');
+  },
+  btoa(s: string) {
+    return Buffer.from(s, 'binary').toString('base64');
+  },
+  location: new URL('http://localhost'),
+  MutationObserver: class {
+    observe() {}
+  },
+
+  // No-op any async tasks
+  requestAnimationFrame() {},
+  window: globalThis,
+});

--- a/packages/labs/ssr/src/lib/shadow-realm/render-internal.ts
+++ b/packages/labs/ssr/src/lib/shadow-realm/render-internal.ts
@@ -1,0 +1,112 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import {TemplateResult} from 'lit-html';
+import {isTemplateResult} from 'lit-html/directive-helpers.js';
+import type {
+  RenderResult,
+  Thunk,
+  ThunkedRenderResult,
+} from '../render-result.js';
+import {renderThunked} from '../render.js';
+
+export function renderThunkedInShadowRealm(value: string) {
+  const deserializedValue: TemplateResult = JSON.parse(value);
+  patchLitTemplate(deserializedValue);
+  return toArrayResult(renderThunked(deserializedValue));
+}
+
+function patchLitTemplate(template: TemplateResult) {
+  if (!isTemplateResult(template)) {
+    return;
+  }
+
+  Object.assign(template.strings, {raw: template.strings});
+  for (const value of template.values) {
+    if (isTemplateResult(value)) {
+      patchLitTemplate(value as TemplateResult);
+    }
+  }
+}
+
+function toArrayResult(result: ThunkedRenderResult) {
+  let index = 0;
+  return function _$litRenderArray() {
+    if (index >= result.length) {
+      return null;
+    }
+
+    let value:
+      | string
+      | Thunk
+      | Promise<string | RenderResult | ThunkedRenderResult>
+      | RenderResult
+      | ReturnType<Thunk> = result[index++];
+    while (typeof value === 'function') {
+      value = value();
+    }
+
+    if (value == null) {
+      // We must not return null/undefined, as this implies
+      // the end of the array.
+      return '';
+    } else if (typeof value === 'string') {
+      return value;
+    } else if (
+      Array.isArray(value) ||
+      typeof (value as RenderResult)[Symbol.iterator] === 'function'
+    ) {
+      return toArrayResult(
+        Array.isArray(value)
+          ? value
+          : (Array.from(value as RenderResult) as ThunkedRenderResult)
+      );
+    }
+    // Must be a Promise
+    if (typeof (value as Promise<unknown>).then !== 'function') {
+      throw new Error(
+        `Unexpected value in RenderResult: ${value} (${typeof value})`
+      );
+    }
+    return toPromiseResult(
+      value as Promise<string | ThunkedRenderResult | RenderResult>
+    );
+  };
+}
+
+function toPromiseResult(
+  result: Promise<string | ThunkedRenderResult | RenderResult>
+) {
+  return function _$litRenderPromise(
+    resolve: (value: string | Thunk) => void,
+    reject: (reason: string) => void
+  ) {
+    result.then(
+      (value) => {
+        if (value == null) {
+          resolve('');
+        } else if (typeof value === 'string') {
+          resolve(value);
+        } else if (
+          Array.isArray(value) ||
+          typeof (value as RenderResult)[Symbol.iterator] === 'function'
+        ) {
+          const arrayResult = toArrayResult(
+            Array.isArray(value)
+              ? value
+              : (Array.from(value as RenderResult) as ThunkedRenderResult)
+          );
+          resolve(arrayResult as unknown as Thunk);
+        } else {
+          reject(
+            `Unexpected value in RenderResult: ${value} (${typeof value})`
+          );
+        }
+      },
+      (err) => reject(String(err))
+    );
+  };
+}

--- a/packages/labs/ssr/src/lib/shadow-realm/render.ts
+++ b/packages/labs/ssr/src/lib/shadow-realm/render.ts
@@ -1,0 +1,31 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import {ThunkedRenderResult} from '../render-result.js';
+import {shadowRealmRenders} from './shadow-realm.js';
+
+/**
+ * Renders a lit-html template (or any renderable lit-html value) to a thunk
+ * array. Any custom elements encountered will be rendered if a matching
+ * ElementRenderer is found.
+ *
+ * This method is suitable for streaming the contents of the element.
+ *
+ * When consuming the result, thunks *must* be called in order to obtain their
+ * values. If thunks are not called, or not called in the correct order, the
+ * output will be incorrect.
+ *
+ * @param value Value to render
+ * @param renderInfo Optional render context object that should be passed to any
+ *   reentrant calls to `render`, e.g. from a `renderShadow` callback on an
+ *   ElementRenderer.
+ */
+export function renderThunked(
+  value: unknown,
+  shadowRealm: ShadowRealm
+): ThunkedRenderResult {
+  return shadowRealmRenders.get(shadowRealm)!(JSON.stringify(value));
+}

--- a/packages/labs/ssr/src/lib/shadow-realm/shadow-realm.ts
+++ b/packages/labs/ssr/src/lib/shadow-realm/shadow-realm.ts
@@ -1,0 +1,62 @@
+import {pathToFileURL} from 'url';
+import {join} from 'path';
+import type {ThunkedRenderResult} from '../render-result.js';
+
+type ImportCallback = (
+  specifier: string,
+  callback: (error: string | null) => void
+) => void;
+
+export const shadowRealmRenders = new WeakMap<
+  ShadowRealm,
+  (value: string) => ThunkedRenderResult
+>();
+
+export async function createShadowRealm(options?: {
+  modules?: string[];
+}): Promise<ShadowRealm> {
+  const modules = options?.modules ?? [];
+
+  const shadowRealm = new ShadowRealm();
+
+  const importModuleCallback = shadowRealm.evaluate<ImportCallback>(`
+      (specifier, callback) => {
+        import(specifier).then(
+          () => callback(null),
+          (error) => callback(String(error))
+        );
+      }
+    `);
+  const importModule = (specifier: string) =>
+    new Promise<void>((resolve, reject) => {
+      const resolvedSpecifier = specifier.startsWith('.')
+        ? pathToFileURL(join(process.cwd(), specifier)).href
+        : specifier;
+      importModuleCallback(resolvedSpecifier, (error) => {
+        if (error) {
+          reject(
+            new Error(
+              `Error importing module ${specifier} into ShadowRealm: ${error}`
+            )
+          );
+        } else {
+          resolve();
+        }
+      });
+    });
+
+  await importModule(new URL('./dom-shim.js', import.meta.url).href);
+
+  const renderThunked = (await shadowRealm.importValue(
+    new URL('./render-internal.js', import.meta.url).href,
+    'renderThunkedInShadowRealm'
+  )) as unknown as (value: string) => ThunkedRenderResult;
+
+  shadowRealmRenders.set(shadowRealm, renderThunked);
+
+  for (const specifier of modules) {
+    await importModule(specifier);
+  }
+
+  return shadowRealm;
+}

--- a/packages/labs/ssr/src/shadow-realm.ts
+++ b/packages/labs/ssr/src/shadow-realm.ts
@@ -1,0 +1,2 @@
+export {createShadowRealm} from './lib/shadow-realm/shadow-realm.js';
+export {renderThunked} from './lib/shadow-realm/render.js';

--- a/packages/labs/ssr/src/test/lib/render-inside-shadow-realm_test.ts
+++ b/packages/labs/ssr/src/test/lib/render-inside-shadow-realm_test.ts
@@ -1,0 +1,130 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import {test} from 'uvu';
+// eslint-disable-next-line import/extensions
+import * as assert from 'uvu/assert';
+import {relative} from 'path';
+import {fileURLToPath} from 'url';
+import {createShadowRealm} from '../../lib/shadow-realm/shadow-realm.js';
+
+function toSpecifier(specifier: string) {
+  return `./${relative(process.cwd(), fileURLToPath(new URL(specifier, import.meta.url)))}`;
+}
+
+test.before.each((context) => {
+  console.time(context.__test__);
+});
+
+test.after.each((context) => {
+  console.timeEnd(context.__test__);
+});
+
+test('create ShadowRealm', () => {
+  const shadowRealm = new ShadowRealm();
+  assert.instance(shadowRealm, ShadowRealm);
+});
+
+test('create shimmed ShadowRealm', async () => {
+  const shadowRealm = await createShadowRealm();
+  assert.instance(shadowRealm, ShadowRealm);
+});
+
+test('ShadowRealm render simple greeting', async () => {
+  const shadowRealm = await createShadowRealm();
+  const render = (await shadowRealm.importValue(
+    toSpecifier('../test-files/shadowrealm/render.js'),
+    'render'
+  )) as (data: string) => string;
+  const result = render(JSON.stringify({name: 'World!'}));
+  assert.equal(
+    result,
+    `<!--lit-part JV/ph7+UdTw=-->
+      <div>
+        <!--lit-node 1--><simple-greeting  name="World!"><template shadowroot="open" shadowrootmode="open"><style>
+    p {
+      color: blue;
+    }
+  </style><!--lit-part EvGichL14uw=--><p>Hello, <!--lit-part-->World!<!--/lit-part-->!</p><!--/lit-part--></template></simple-greeting>
+      </div>
+    <!--/lit-part-->`
+  );
+});
+
+test('ShadowRealm render simple greeting async', async () => {
+  const shadowRealm = await createShadowRealm();
+  const renderAsync = (await shadowRealm.importValue(
+    toSpecifier('../test-files/shadowrealm/render.js'),
+    'renderAsync'
+  )) as (
+    data: string,
+    callback: (error: string | null, value: string) => void
+  ) => void;
+
+  const result = await new Promise((resolve, reject) => {
+    renderAsync(JSON.stringify({name: 'async World!'}), (error, value) => {
+      if (error !== null) {
+        reject(error);
+      } else {
+        resolve(value);
+      }
+    });
+  });
+
+  assert.equal(
+    result,
+    `<!--lit-part JV/ph7+UdTw=-->
+      <div>
+        <!--lit-node 1--><simple-greeting  name="async World!"><template shadowroot="open" shadowrootmode="open"><style>
+    p {
+      color: blue;
+    }
+  </style><!--lit-part EvGichL14uw=--><p>Hello, <!--lit-part-->async World!<!--/lit-part-->!</p><!--/lit-part--></template></simple-greeting>
+      </div>
+    <!--/lit-part-->`
+  );
+});
+
+test('ShadowRealm render simple greeting iterator', async () => {
+  const shadowRealm = await createShadowRealm();
+  const renderIterator = (await shadowRealm.importValue(
+    toSpecifier('../test-files/shadowrealm/render.js'),
+    'renderIterator'
+  )) as (
+    data: string,
+    callback: (error: string | null, value: string | null) => void
+  ) => void;
+
+  const result = await new Promise((resolve, reject) => {
+    let result = '';
+    const callback = (error: string | null, value: string | null) => {
+      if (error !== null) {
+        reject(error);
+      } else if (value !== null) {
+        result += value;
+      } else {
+        resolve(result);
+      }
+    };
+
+    renderIterator(JSON.stringify({name: 'iterator World!'}), callback);
+  });
+
+  assert.equal(
+    result,
+    `<!--lit-part pXlNvZ9gkcE=-->
+    <div>
+      <!--lit-node 1--><simple-greeting  name="iterator World!"><template shadowroot="open" shadowrootmode="open"><style>
+    p {
+      color: blue;
+    }
+  </style><!--lit-part EvGichL14uw=--><p>Hello, <!--lit-part-->iterator World!<!--/lit-part-->!</p><!--/lit-part--></template></simple-greeting>
+    </div>
+  <!--/lit-part-->`
+  );
+});
+
+test.run();

--- a/packages/labs/ssr/src/test/lib/render-via-shadow-realm_test.ts
+++ b/packages/labs/ssr/src/test/lib/render-via-shadow-realm_test.ts
@@ -1,0 +1,61 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import {test} from 'uvu';
+// eslint-disable-next-line import/extensions
+import * as assert from 'uvu/assert';
+import {collectResultSync} from '../../lib/render-result.js';
+import {createShadowRealm, renderThunked} from '../../shadow-realm.js';
+import {html} from 'lit';
+
+test.before.each((context) => {
+  console.time(context.__test__);
+});
+
+test.after.each((context) => {
+  console.timeEnd(context.__test__);
+});
+
+test('ShadowRealm render simple greeting', async () => {
+  const shadowRealm = await createShadowRealm({
+    modules: [
+      new URL('../test-files/shadowrealm/simple-greeting.js', import.meta.url)
+        .href,
+    ],
+  });
+  console.log(
+    (
+      shadowRealm as unknown as {
+        renderThunked: (value: string) => unknown;
+      }
+    ).renderThunked
+  );
+  const payload = {name: 'World!'};
+  const result = collectResultSync(
+    renderThunked(
+      html`
+        <div>
+          <simple-greeting name="${payload.name}"></simple-greeting>
+        </div>
+      `,
+      shadowRealm
+    )
+  );
+  assert.equal(
+    result,
+    `<!--lit-part pcttL59/lIs=-->
+        <div>
+          <!--lit-node 1--><simple-greeting  name="World!"><template shadowroot="open" shadowrootmode="open"><style>
+    p {
+      color: blue;
+    }
+  </style><!--lit-part EvGichL14uw=--><p>Hello, <!--lit-part-->World!<!--/lit-part-->!</p><!--/lit-part--></template></simple-greeting>
+        </div>
+      <!--/lit-part-->`
+  );
+});
+
+test.run();

--- a/packages/labs/ssr/src/test/test-files/shadowrealm/render.ts
+++ b/packages/labs/ssr/src/test/test-files/shadowrealm/render.ts
@@ -1,0 +1,66 @@
+import {html} from 'lit';
+import {renderThunked, render as _render} from '../../../lib/render.js';
+import {collectResult, collectResultSync} from '../../../lib/render-result.js';
+
+import './simple-greeting.js';
+
+export interface RenderData {
+  name: string;
+}
+
+export function render(data: string): string {
+  const payload = JSON.parse(data) as RenderData;
+  return collectResultSync(
+    renderThunked(html`
+      <div>
+        <simple-greeting name="${payload.name}"></simple-greeting>
+      </div>
+    `)
+  );
+}
+
+async function renderAsyncInternal(data: RenderData): Promise<string> {
+  return await collectResult(
+    renderThunked(html`
+      <div>
+        <simple-greeting name="${data.name}"></simple-greeting>
+      </div>
+    `)
+  );
+}
+
+export function renderAsync(
+  data: string,
+  callback: (error: string | null, value: string) => void
+) {
+  const payload = JSON.parse(data) as RenderData;
+  renderAsyncInternal(payload).then(
+    (result) => callback(null, result),
+    (error: unknown) => callback(String(error), '')
+  );
+}
+
+async function renderIteratorInternal(
+  data: RenderData,
+  callback: (error: string | null, value: string | null) => void
+) {
+  const iterator = _render(html`
+    <div>
+      <simple-greeting name="${data.name}"></simple-greeting>
+    </div>
+  `);
+  for await (const chunk of iterator) {
+    callback(null, chunk as string);
+  }
+  callback(null, null);
+}
+
+export function renderIterator(
+  data: string,
+  callback: (error: string | null, value: string | null) => void
+) {
+  const payload = JSON.parse(data) as RenderData;
+  renderIteratorInternal(payload, callback).catch((error: unknown) =>
+    callback(String(error), null)
+  );
+}

--- a/packages/labs/ssr/src/test/test-files/shadowrealm/simple-greeting.ts
+++ b/packages/labs/ssr/src/test/test-files/shadowrealm/simple-greeting.ts
@@ -1,0 +1,18 @@
+import {html, css, LitElement} from 'lit';
+import {customElement, property} from 'lit/decorators.js';
+
+@customElement('simple-greeting')
+export class SimpleGreeting extends LitElement {
+  static override styles = css`
+    p {
+      color: blue;
+    }
+  `;
+
+  @property()
+  name = 'Somebody';
+
+  override render() {
+    return html`<p>Hello, ${this.name}!</p>`;
+  }
+}


### PR DESCRIPTION
This is a draft pull request to experiment with ShadowRealms.

Findings:

- The current implementation in Node.js is still experimental behind a flag `--experimental-shadow-realm`: nodejs/node#42528
  - Memory leaks are possible: nodejs/node#47353
  - `node:module` is not (yet?) available, meaning hooks (like CSS support) are not supported
- Only primitive values and functions can be transferred between global context and ShadowRealm. Meaning only e.g. string, number, boolean, null, undefined and Function, but not an object, Promise or Array.

Questions:

- Should lit provide utility for using ShadowRealms?
- If yes, should the rendering be done fully inside the ShadowRealm (like `render-inside-shadow-realm_test.ts`) or via tranfer (like `render-via-shadow-realm_test.ts`)?