### PR TITLE
fix: export SignalWatcherApi interface

### DIFF
--- a/.changeset/true-ads-strive.md
+++ b/.changeset/true-ads-strive.md
@@ -1,0 +1,5 @@
+---
+'@lit-labs/signals': minor
+---
+
+export `SignalWatcherApi` interface which is used in the return type of the `SignalWatcher` mixin

--- a/packages/labs/signals/src/lib/signal-watcher.ts
+++ b/packages/labs/signals/src/lib/signal-watcher.ts
@@ -41,7 +41,7 @@ const effectWatcher = new Signal.subtle.Watcher(() => {
   });
 });
 
-interface SignalWatcherApi {
+export interface SignalWatcherApi {
   updateEffect(fn: () => void, options?: EffectOptions): () => void;
 }
 


### PR DESCRIPTION
Export `SignalWatcherApi` interface which is used in the return type of the `SignalWatcher` mixin.

fix #5192 