### PR TITLE
Publicize SignalWatcherApi so class extensions are happy in TS

### DIFF
--- a/packages/labs/signals/src/lib/signal-watcher.ts
+++ b/packages/labs/signals/src/lib/signal-watcher.ts
@@ -41,7 +41,7 @@ const effectWatcher = new Signal.subtle.Watcher(() => {
   });
 });
 
-interface SignalWatcherApi {
+export interface SignalWatcherApi {
   updateEffect(fn: () => void, options?: EffectOptions): () => void;
 }
 


### PR DESCRIPTION
TS throws the following without this `export`...

> 'extends' clause of exported class 'ReveElement' has or is using private name 'SignalWatcherApi'.ts(4020)

<img width="835" height="246" alt="image" src="https://github.com/user-attachments/assets/6bb8e5f6-4148-4960-a6e6-6eb1cb646209" />
