### PR TITLE
[labs/ssr-dom-shim] Add register css hook file to publishable files

### DIFF
--- a/.changeset/eager-icons-bathe.md
+++ b/.changeset/eager-icons-bathe.md
@@ -1,0 +1,5 @@
+---
+'@lit-labs/ssr-dom-shim': patch
+---
+
+Add register css hook file to publishable files

--- a/packages/labs/ssr-dom-shim/package.json
+++ b/packages/labs/ssr-dom-shim/package.json
@@ -28,6 +28,7 @@
   },
   "files": [
     "index.{d.ts,d.ts.map,js,js.map}",
+    "register-css-hook.{d.ts,d.ts.map,js,js.map}",
     "lib/"
   ],
   "scripts": {


### PR DESCRIPTION
Currently the compilation result from `register-css-hook.ts` is not included in the package.json `files` list, which means these files will not be published.
This PR fixes this.