### PR TITLE
Add repository details to package.json

### DIFF
--- a/packages/labs/vscode-extension/package.json
+++ b/packages/labs/vscode-extension/package.json
@@ -7,6 +7,12 @@
   "engines": {
     "vscode": "^1.103.0"
   },
+  "private": true,
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/lit/lit.git",
+    "directory": "packages/labs/vscode-extension"
+  },
   "categories": [
     "Programming Languages",
     "Snippets",


### PR DESCRIPTION
- Mark package private for now, discussed during Lit Eng Meeting Jan 29
- Add missing repository field