### PR TITLE
[lit-html] Fix ref directive crash when passed undefined during lifec…

### DIFF
--- a/packages/lit-html/src/async-directive.ts
+++ b/packages/lit-html/src/async-directive.ts
@@ -301,7 +301,7 @@ export abstract class AsyncDirective extends Directive {
   /**
    * The connection state for this Directive.
    */
-  isConnected!: boolean;
+  isConnected = false;
 
   // @internal
   override _$disconnectableChildren?: Set<Disconnectable> = undefined;

--- a/packages/lit-html/src/directive.ts
+++ b/packages/lit-html/src/directive.ts
@@ -117,7 +117,7 @@ export abstract class Directive implements Disconnectable {
 
   // See comment in Disconnectable interface for why this is a getter
   get _$isConnected() {
-    return this._$parent._$isConnected;
+    return this._$parent?._$isConnected ?? false;
   }
 
   /** @internal */

--- a/packages/lit-html/src/directives/ref.ts
+++ b/packages/lit-html/src/directives/ref.ts
@@ -95,8 +95,8 @@ class RefDirective extends AsyncDirective {
       if (element !== undefined) {
         this._ref.call(this._context, element);
       }
-    } else {
-      (this._ref as RefInternal)!.value = element;
+    } else if (this._ref !== undefined) {
+      (this._ref as RefInternal).value = element;
     }
   }
 
@@ -109,6 +109,10 @@ class RefDirective extends AsyncDirective {
   }
 
   override disconnected() {
+    // Nothing to do if there is no ref
+    if (this._ref === undefined) {
+      return;
+    }
     // Only clear the box if our element is still the one in it (i.e. another
     // directive instance hasn't rendered its element to it before us); that
     // only happens in the event of the directive being cleared (not via manual
@@ -119,6 +123,10 @@ class RefDirective extends AsyncDirective {
   }
 
   override reconnected() {
+    // Nothing to do if there is no ref
+    if (this._ref === undefined) {
+      return;
+    }
     // If we were manually disconnected, we can safely put our element back in
     // the box, since no rendering could have occurred to change its state
     this._updateRefValue(this._element);


### PR DESCRIPTION
## Summary
- Guard `_updateRefValue` else branch with `else if (this._ref !== undefined)` to prevent TypeError when setting `.value` on `undefined`
- Add early returns in `disconnected()` and `reconnected()` when `this._ref` is `undefined`
- Change `AsyncDirective.isConnected` from `!` definite assignment (`isConnected!: boolean`) to safe default (`isConnected = false`) so it is never `undefined` at runtime
- Change `Directive._$isConnected` getter to use optional chaining (`this._$parent?._$isConnected ?? false`) to handle uninitialized parent references

## Test plan
- [x] Added 6 new tests covering `ref(undefined)` during disconnect, reconnect, multiple cycles, ref switching, and re-render while disconnected
- [x] All 23 ref tests pass on Chromium and Firefox (dev + prod)
- [x] Existing tests unaffected

Fixes #5217