### PR TITLE
[labs/virtualizer] Guard custom element registration for multi-bundle…

### DIFF
--- a/packages/labs/virtualizer/src/LitVirtualizer.ts
+++ b/packages/labs/virtualizer/src/LitVirtualizer.ts
@@ -18,6 +18,17 @@ import {
 } from './virtualize.js';
 
 export class LitVirtualizer<T = unknown> extends LitElement {
+  /**
+   * Safely defines the custom element if it has not already been registered.
+   * This is idempotent and safe to call multiple times, e.g. across
+   * microfrontends or multiple bundles sharing the same page.
+   */
+  static define(tagName = 'lit-virtualizer') {
+    if (!customElements.get(tagName)) {
+      customElements.define(tagName, this);
+    }
+  }
+
   @property({attribute: false})
   items: T[] = [];
 

--- a/packages/labs/virtualizer/src/Virtualizer.ts
+++ b/packages/labs/virtualizer/src/Virtualizer.ts
@@ -45,7 +45,12 @@ export function provideResizeObserver(Ctor: typeof ResizeObserver) {
   _ResizeObserver = Ctor;
 }
 
-export const virtualizerRef = Symbol('virtualizerRef');
+// Use Symbol.for so that multiple copies of this module (e.g. across
+// microfrontends or independently built bundles) share the same key
+// when accessing the virtualizer instance on a host element.
+export const virtualizerRef = Symbol.for(
+  '@lit-labs/virtualizer/virtualizerRef'
+);
 const SIZER_ATTRIBUTE = 'virtualizer-sizer';
 
 declare global {

--- a/packages/labs/virtualizer/src/lit-virtualizer.ts
+++ b/packages/labs/virtualizer/src/lit-virtualizer.ts
@@ -10,8 +10,9 @@ export {RangeChangedEvent, VisibilityChangedEvent} from './events.js';
 
 /**
  * Import this module to declare the lit-virtualizer custom element.
+ * Safe to import multiple times; the element is only registered once.
  */
-customElements.define('lit-virtualizer', LitVirtualizer);
+LitVirtualizer.define();
 
 declare global {
   interface HTMLElementTagNameMap {

--- a/packages/labs/virtualizer/src/test/scenarios/multi-import-safety.test.ts
+++ b/packages/labs/virtualizer/src/test/scenarios/multi-import-safety.test.ts
@@ -1,0 +1,87 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import {expect} from '@open-wc/testing';
+
+describe('multi-import safety', () => {
+  it('does not throw when lit-virtualizer is imported after already being defined', async () => {
+    // First import — registers the element
+    const {LitVirtualizer} = await import('../../lit-virtualizer.js');
+    expect(customElements.get('lit-virtualizer')).to.equal(LitVirtualizer);
+
+    // Simulate a second bundle calling define with the same tag name.
+    // Before the fix, this would throw:
+    //   NotSupportedError: the name "lit-virtualizer" has already been used
+    expect(() => {
+      LitVirtualizer.define();
+    }).not.to.throw();
+  });
+
+  it('registers the element exactly once across multiple define calls', async () => {
+    const {LitVirtualizer} = await import('../../lit-virtualizer.js');
+    const registered = customElements.get('lit-virtualizer');
+    expect(registered).to.equal(LitVirtualizer);
+
+    // Call define again — should be a no-op
+    LitVirtualizer.define();
+
+    // The registered constructor must still be the same
+    expect(customElements.get('lit-virtualizer')).to.equal(registered);
+  });
+
+  it('is safe to call define many times in succession', async () => {
+    const {LitVirtualizer} = await import('../../lit-virtualizer.js');
+
+    expect(() => {
+      for (let i = 0; i < 10; i++) {
+        LitVirtualizer.define();
+      }
+    }).not.to.throw();
+
+    expect(customElements.get('lit-virtualizer')).to.equal(LitVirtualizer);
+  });
+
+  it('bare customElements.define would throw without the guard', async () => {
+    const {LitVirtualizer} = await import('../../lit-virtualizer.js');
+
+    // Confirm the element is registered
+    expect(customElements.get('lit-virtualizer')).to.equal(LitVirtualizer);
+
+    // A bare customElements.define (without a guard) throws — this is the
+    // original bug. Our fix prevents this by checking before defining.
+    expect(() => {
+      customElements.define('lit-virtualizer', LitVirtualizer);
+    }).to.throw();
+  });
+
+  it('simulates multi-bundle scenario with direct customElements.define guard', async () => {
+    // This test simulates what a second bundle would do:
+    // check-then-define, matching the pattern in lit-virtualizer.ts
+    const {LitVirtualizer} = await import('../../lit-virtualizer.js');
+
+    // The element is already defined from the import
+    expect(customElements.get('lit-virtualizer')).to.equal(LitVirtualizer);
+
+    // A second bundle would do the same guard check
+    const alreadyDefined = customElements.get('lit-virtualizer');
+    if (!alreadyDefined) {
+      // This branch should NOT execute since it's already defined
+      customElements.define('lit-virtualizer', LitVirtualizer);
+    }
+
+    // Confirm element is still properly registered
+    expect(customElements.get('lit-virtualizer')).to.equal(LitVirtualizer);
+  });
+
+  it('virtualizerRef symbol is shared across module loads via Symbol.for', async () => {
+    const {virtualizerRef} = await import('../../Virtualizer.js');
+
+    // The symbol should be the global Symbol.for key, meaning any
+    // other bundle using the same key gets the same symbol
+    const expectedSymbol = Symbol.for('@lit-labs/virtualizer/virtualizerRef');
+    expect(virtualizerRef).to.equal(expectedSymbol);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `customElements.get()` guard before `customElements.define()` to prevent `NotSupportedError` when the virtualizer module is imported multiple times
- Centralize registration logic into a static `LitVirtualizer.define()` method, providing an idempotent API for both internal and external use
- Change `virtualizerRef` from `Symbol()` to `Symbol.for()` so multiple bundles share the same host element reference key

## Test plan
- [x] Added 6 new tests covering repeated define calls, multi-bundle simulation, guard verification, and cross-bundle symbol identity
- [x] All 120 existing + new tests pass with zero regressions
- [x] Verified bare `customElements.define` still throws (proving the original bug) while `LitVirtualizer.define()` is safe

Fixes #5212
