### PR TITLE
[labs/observers] Add lit-html as runtime dependency for pnpm hoist=fa…

### DIFF
--- a/packages/labs/observers/package.json
+++ b/packages/labs/observers/package.json
@@ -168,11 +168,11 @@
   "devDependencies": {
     "@lit-internal/scripts": "^1.0.1",
     "@types/trusted-types": "^2.0.2",
-    "lit": "^3.3.1",
-    "lit-html": "^3.3.1"
+    "lit": "^3.3.1"
   },
   "dependencies": {
-    "@lit/reactive-element": "^1.0.0 || ^2.0.0"
+    "@lit/reactive-element": "^1.0.0 || ^2.0.0",
+    "lit-html": "^3.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/labs/observers/rollup.config.js
+++ b/packages/labs/observers/rollup.config.js
@@ -16,5 +16,5 @@ export default litProdConfig({
     'intersection-controller',
     'performance-controller',
   ],
-  external: ['@lit/reactive-element'],
+  external: ['@lit/reactive-element', 'lit-html'],
 });

--- a/packages/labs/observers/src/index.ts
+++ b/packages/labs/observers/src/index.ts
@@ -3,3 +3,24 @@
  * Copyright 2021 Google LLC
  * SPDX-License-Identifier: BSD-3-Clause
  */
+
+export {IntersectionController} from './intersection-controller.js';
+export type {
+  IntersectionControllerConfig,
+  IntersectionValueCallback,
+} from './intersection-controller.js';
+export {MutationController} from './mutation-controller.js';
+export type {
+  MutationControllerConfig,
+  MutationValueCallback,
+} from './mutation-controller.js';
+export {PerformanceController} from './performance-controller.js';
+export type {
+  PerformanceControllerConfig,
+  PerformanceValueCallback,
+} from './performance-controller.js';
+export {ResizeController} from './resize-controller.js';
+export type {
+  ResizeControllerConfig,
+  ResizeValueCallback,
+} from './resize-controller.js';

--- a/packages/labs/observers/src/test/module-resolution_test.ts
+++ b/packages/labs/observers/src/test/module-resolution_test.ts
@@ -1,0 +1,63 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import {assert} from 'chai';
+
+suite('module resolution', () => {
+  test('ResizeController can be imported from its individual entry point', async () => {
+    const module = await import('@lit-labs/observers/resize-controller.js');
+    assert.isFunction(module.ResizeController);
+  });
+
+  test('IntersectionController can be imported from its individual entry point', async () => {
+    const module = await import(
+      '@lit-labs/observers/intersection-controller.js'
+    );
+    assert.isFunction(module.IntersectionController);
+  });
+
+  test('MutationController can be imported from its individual entry point', async () => {
+    const module = await import('@lit-labs/observers/mutation-controller.js');
+    assert.isFunction(module.MutationController);
+  });
+
+  test('PerformanceController can be imported from its individual entry point', async () => {
+    const module = await import(
+      '@lit-labs/observers/performance-controller.js'
+    );
+    assert.isFunction(module.PerformanceController);
+  });
+
+  test('all controllers can be imported from the main entry point', async () => {
+    const module = await import('@lit-labs/observers');
+    assert.isFunction(module.ResizeController);
+    assert.isFunction(module.IntersectionController);
+    assert.isFunction(module.MutationController);
+    assert.isFunction(module.PerformanceController);
+  });
+
+  test('lit-html dependencies are resolvable from resize-controller', async () => {
+    // These are the specific lit-html imports that fail under pnpm
+    // hoist=false when lit-html is not declared as a dependency.
+    const asyncDirective = await import('lit-html/async-directive.js');
+    assert.isFunction(asyncDirective.AsyncDirective);
+
+    const directive = await import('lit-html/directive.js');
+    assert.isFunction(directive.directive);
+
+    const isServerModule = await import('lit-html/is-server.js');
+    assert.isDefined(isServerModule.isServer);
+  });
+
+  test('multiple imports of the same controller do not throw', async () => {
+    // Simulate multiple bundle loads importing the same module
+    const [mod1, mod2] = await Promise.all([
+      import('@lit-labs/observers/resize-controller.js'),
+      import('@lit-labs/observers/resize-controller.js'),
+    ]);
+    assert.strictEqual(mod1.ResizeController, mod2.ResizeController);
+  });
+});


### PR DESCRIPTION
## Summary
- Move `lit-html` from `devDependencies` to `dependencies` in `@lit-labs/observers` so it is available for runtime module resolution in non-hoisted environments
- Add `lit-html` to the rollup `external` list to explicitly mark it as an external dependency in the production build
- Populate the empty `src/index.ts` main entry point with re-exports of all 4 controllers and their types

## Test plan
- [x] Added 7 tests verifying each controller is importable, lit-html dependencies resolve, and multiple imports are safe
- [x] All 60 tests pass on Chromium and Firefox in both dev and prod modes
- [x] No regressions in existing controller tests

Fixes #5214