### PR TITLE
feat(@lit-labs/analyzer): add dependency custom element discovery

### DIFF
--- a/packages/labs/analyzer/src/index.ts
+++ b/packages/labs/analyzer/src/index.ts
@@ -31,6 +31,15 @@ export type {
 
 export type {AbsolutePath, PackagePath} from './lib/paths.js';
 
+export type {
+  DependencyCustomElement,
+  DependencyProperty,
+  DependencyAttribute,
+  DependencyEvent,
+} from './lib/dependency-analyzer.js';
+
+export {DependencyAnalyzer} from './lib/dependency-analyzer.js';
+
 // Any non-type exports below must be safe to use on objects between multiple
 // versions of the analyzer library
 export {getImportsStringForReferences} from './lib/model.js';

--- a/packages/labs/analyzer/src/lib/cem-reader.ts
+++ b/packages/labs/analyzer/src/lib/cem-reader.ts
@@ -1,0 +1,221 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/**
+ * Reader for Custom Elements Manifest (CEM) files.
+ *
+ * Follows the Custom Elements Manifest v1 specification to extract
+ * custom element metadata from dependency packages that publish a
+ * `custom-elements.json` file.
+ */
+
+import {
+  DependencyCustomElement,
+  DependencyProperty,
+  DependencyAttribute,
+  DependencyEvent,
+} from './dependency-analyzer.js';
+
+// CEM v1 schema types (subset relevant to element discovery)
+
+interface CEMManifest {
+  schemaVersion: string;
+  modules?: CEMModule[];
+}
+
+interface CEMModule {
+  kind?: string;
+  path?: string;
+  declarations?: CEMDeclaration[];
+  exports?: CEMExport[];
+}
+
+interface CEMDeclaration {
+  kind?: string;
+  name?: string;
+  customElement?: boolean;
+  tagName?: string;
+  description?: string;
+  members?: CEMMember[];
+  attributes?: CEMAttribute[];
+  events?: CEMEvent[];
+  superclass?: {name?: string; package?: string; module?: string};
+}
+
+interface CEMMember {
+  kind?: string;
+  name?: string;
+  type?: {text?: string};
+  default?: string;
+  description?: string;
+  attribute?: string;
+  reflects?: boolean;
+  privacy?: string;
+  static?: boolean;
+  readonly?: boolean;
+}
+
+interface CEMAttribute {
+  name?: string;
+  type?: {text?: string};
+  default?: string;
+  description?: string;
+  fieldName?: string;
+}
+
+interface CEMEvent {
+  name?: string;
+  type?: {text?: string};
+  description?: string;
+}
+
+interface CEMExport {
+  kind?: string;
+  name?: string;
+  declaration?: {name?: string; module?: string};
+}
+
+/**
+ * Parses a Custom Elements Manifest JSON string and extracts custom element
+ * metadata.
+ *
+ * @param jsonContent The raw JSON content of a `custom-elements.json` file
+ * @param packageName The npm package name this manifest belongs to
+ * @returns Array of custom element metadata found in the manifest
+ */
+export function parseCustomElementsManifest(
+  jsonContent: string,
+  packageName: string
+): DependencyCustomElement[] {
+  let manifest: CEMManifest;
+  try {
+    manifest = JSON.parse(jsonContent) as CEMManifest;
+  } catch {
+    return [];
+  }
+
+  if (!manifest.modules || !Array.isArray(manifest.modules)) {
+    return [];
+  }
+
+  const elements: DependencyCustomElement[] = [];
+  // Track tag name → class name from custom-element-definition exports
+  const definitionExports = new Map<
+    string,
+    {className: string; modulePath: string}
+  >();
+
+  // First pass: collect custom-element-definition exports
+  for (const module of manifest.modules) {
+    if (!module.exports) continue;
+    for (const exp of module.exports) {
+      if (
+        exp.kind === 'custom-element-definition' &&
+        exp.name &&
+        exp.declaration?.name
+      ) {
+        definitionExports.set(exp.name, {
+          className: exp.declaration.name,
+          modulePath: exp.declaration.module ?? module.path ?? '',
+        });
+      }
+    }
+  }
+
+  // Second pass: extract element metadata from declarations
+  for (const module of manifest.modules) {
+    if (!module.declarations) continue;
+    for (const decl of module.declarations) {
+      if (decl.kind !== 'class' || !decl.customElement) continue;
+
+      // Determine tag name from the declaration or from definition exports
+      const tagName =
+        decl.tagName ?? getTagNameFromExports(decl.name, definitionExports);
+      if (!tagName || !decl.name) continue;
+
+      const properties = new Map<string, DependencyProperty>();
+      const attributes = new Map<string, DependencyAttribute>();
+      const events = new Map<string, DependencyEvent>();
+
+      // Extract members (fields and methods)
+      if (decl.members) {
+        for (const member of decl.members) {
+          if (
+            member.kind === 'field' &&
+            member.name &&
+            member.privacy !== 'private' &&
+            member.privacy !== 'protected' &&
+            !member.static
+          ) {
+            properties.set(member.name, {
+              name: member.name,
+              type: member.type?.text,
+              default: member.default,
+              description: member.description,
+              attribute: member.attribute,
+              reflects: member.reflects,
+            });
+          }
+        }
+      }
+
+      // Extract attributes
+      if (decl.attributes) {
+        for (const attr of decl.attributes) {
+          if (attr.name) {
+            attributes.set(attr.name, {
+              name: attr.name,
+              type: attr.type?.text,
+              default: attr.default,
+              description: attr.description,
+              fieldName: attr.fieldName,
+            });
+          }
+        }
+      }
+
+      // Extract events
+      if (decl.events) {
+        for (const event of decl.events) {
+          if (event.name) {
+            events.set(event.name, {
+              name: event.name,
+              type: event.type?.text,
+              description: event.description,
+            });
+          }
+        }
+      }
+
+      elements.push({
+        tagName,
+        className: decl.name,
+        packageName,
+        modulePath: module.path ?? '',
+        properties,
+        attributes,
+        events,
+        description: decl.description,
+        source: 'cem',
+      });
+    }
+  }
+
+  return elements;
+}
+
+function getTagNameFromExports(
+  className: string | undefined,
+  exports: Map<string, {className: string; modulePath: string}>
+): string | undefined {
+  if (!className) return undefined;
+  for (const [tagName, info] of exports) {
+    if (info.className === className) {
+      return tagName;
+    }
+  }
+  return undefined;
+}

--- a/packages/labs/analyzer/src/lib/dependency-analyzer.ts
+++ b/packages/labs/analyzer/src/lib/dependency-analyzer.ts
@@ -1,0 +1,228 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/**
+ * Dependency analyzer for discovering custom elements from installed packages.
+ *
+ * Uses a layered approach:
+ * 1. Custom Elements Manifest (CEM) — preferred when a package publishes
+ *    `custom-elements.json`
+ * 2. Compiled fallback — scans compiled JS entry points for
+ *    `customElements.define()` calls
+ *
+ * Results are cached per package name + version and lazily loaded on first
+ * access.
+ */
+
+import type {AnalyzerInterface} from './model.js';
+import {parseCustomElementsManifest} from './cem-reader.js';
+
+/**
+ * Minimal filesystem interface needed by the dependency analyzer.
+ * Compatible with `AnalyzerInterface['fs']` but requires only `readFile`.
+ */
+export type DependencyFs = Pick<AnalyzerInterface['fs'], 'readFile'>;
+
+/**
+ * Minimal path interface needed by the dependency analyzer.
+ * Compatible with `AnalyzerInterface['path']` but requires only `join` and
+ * `normalize`.
+ */
+export type DependencyPath = Pick<
+  AnalyzerInterface['path'],
+  'join' | 'normalize'
+>;
+
+// Public types for dependency element metadata
+
+export interface DependencyProperty {
+  name: string;
+  type?: string | undefined;
+  default?: string | undefined;
+  description?: string | undefined;
+  attribute?: string | undefined;
+  reflects?: boolean | undefined;
+}
+
+export interface DependencyAttribute {
+  name: string;
+  type?: string | undefined;
+  default?: string | undefined;
+  description?: string | undefined;
+  fieldName?: string | undefined;
+}
+
+export interface DependencyEvent {
+  name: string;
+  type?: string | undefined;
+  description?: string | undefined;
+}
+
+export interface DependencyCustomElement {
+  tagName: string;
+  className: string;
+  packageName: string;
+  modulePath: string;
+  properties: Map<string, DependencyProperty>;
+  attributes: Map<string, DependencyAttribute>;
+  events: Map<string, DependencyEvent>;
+  description?: string | undefined;
+  source: 'cem' | 'compiled';
+}
+
+/**
+ * Discovers and caches custom element metadata from dependency packages.
+ *
+ * Provides a tag-name-based registry that merges elements found across
+ * all analyzed packages. Each package is analyzed at most once per
+ * name+version combination.
+ */
+export class DependencyAnalyzer {
+  /**
+   * Cache of analyzed packages keyed by `packageName@version`.
+   * Prevents redundant parsing when multiple modules reference the same
+   * dependency.
+   */
+  private readonly _cache = new Map<string, DependencyCustomElement[]>();
+
+  /**
+   * Global tag-name registry mapping tag names to their element metadata.
+   * Populated lazily as packages are analyzed.
+   */
+  private readonly _registry = new Map<string, DependencyCustomElement>();
+
+  private readonly _fs: DependencyFs;
+  private readonly _path: DependencyPath;
+
+  constructor(fs: DependencyFs, path: DependencyPath) {
+    this._fs = fs;
+    this._path = path;
+  }
+
+  /**
+   * Returns the custom element metadata for the given tag name, or
+   * `undefined` if no element with that tag has been discovered.
+   */
+  getCustomElement(tagName: string): DependencyCustomElement | undefined {
+    return this._registry.get(tagName);
+  }
+
+  /**
+   * Returns all custom elements discovered across all analyzed packages.
+   */
+  getAllCustomElements(): DependencyCustomElement[] {
+    return Array.from(this._registry.values());
+  }
+
+  /**
+   * Analyzes a dependency package at `packageRoot` for custom element
+   * definitions. Uses the CEM if available, falling back to compiled
+   * analysis.
+   *
+   * Results are cached by package name and version so repeated calls
+   * for the same package are inexpensive.
+   */
+  analyzePackage(packageRoot: string): DependencyCustomElement[] {
+    const packageJsonPath = this._path.join(packageRoot, 'package.json');
+    const packageJsonContent = this._fs.readFile(packageJsonPath);
+    if (!packageJsonContent) return [];
+
+    let packageJson: {
+      name?: string;
+      version?: string;
+      customElements?: string;
+      module?: string;
+      main?: string;
+    };
+    try {
+      packageJson = JSON.parse(packageJsonContent);
+    } catch {
+      return [];
+    }
+
+    const packageName = packageJson.name ?? '';
+    const version = packageJson.version ?? '0.0.0';
+    const cacheKey = `${packageName}@${version}`;
+
+    // Return cached results
+    const cached = this._cache.get(cacheKey);
+    if (cached !== undefined) return cached;
+
+    // Try CEM first, fall back to compiled analysis
+    let elements = this._tryReadCEM(packageRoot, packageJson, packageName);
+    if (elements.length === 0) {
+      elements = this._analyzeCompiled(packageRoot, packageJson, packageName);
+    }
+
+    // Cache and register
+    this._cache.set(cacheKey, elements);
+    for (const el of elements) {
+      this._registry.set(el.tagName, el);
+    }
+
+    return elements;
+  }
+
+  /**
+   * Attempts to read and parse a Custom Elements Manifest from the package.
+   * Checks the `customElements` field in `package.json` for a custom path,
+   * falling back to the standard `custom-elements.json`.
+   */
+  private _tryReadCEM(
+    packageRoot: string,
+    packageJson: {customElements?: string},
+    packageName: string
+  ): DependencyCustomElement[] {
+    const cemPath = packageJson.customElements ?? 'custom-elements.json';
+    const cemFullPath = this._path.join(packageRoot, cemPath);
+    const content = this._fs.readFile(cemFullPath);
+    if (!content) return [];
+    return parseCustomElementsManifest(content, packageName);
+  }
+
+  /**
+   * Fallback analysis: scans the package's main entry point for
+   * `customElements.define()` calls using a regex-based approach.
+   *
+   * This provides basic tag-name/class-name discovery for packages
+   * that don't publish a CEM.
+   */
+  private _analyzeCompiled(
+    packageRoot: string,
+    packageJson: {module?: string; main?: string},
+    packageName: string
+  ): DependencyCustomElement[] {
+    const elements: DependencyCustomElement[] = [];
+
+    const mainFile = packageJson.module ?? packageJson.main;
+    if (!mainFile) return elements;
+
+    const mainPath = this._path.join(packageRoot, mainFile);
+    const content = this._fs.readFile(mainPath);
+    if (!content) return elements;
+
+    // Match customElements.define('tag-name', ClassName) patterns
+    const defineRegex =
+      /customElements\.define\(\s*['"]([^'"]+)['"]\s*,\s*(\w+)/g;
+    let match;
+    while ((match = defineRegex.exec(content)) !== null) {
+      const tagName = match[1];
+      const className = match[2];
+      elements.push({
+        tagName,
+        className,
+        packageName,
+        modulePath: mainFile,
+        properties: new Map(),
+        attributes: new Map(),
+        events: new Map(),
+        source: 'compiled',
+      });
+    }
+
+    return elements;
+  }
+}

--- a/packages/labs/analyzer/src/test/server/dependency-analyzer_test.ts
+++ b/packages/labs/analyzer/src/test/server/dependency-analyzer_test.ts
@@ -1,0 +1,504 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import * as assert from 'node:assert';
+import {describe as suite, test} from 'node:test';
+import * as path from 'path';
+import {parseCustomElementsManifest} from '../../lib/cem-reader.js';
+import {
+  DependencyAnalyzer,
+  DependencyFs,
+  DependencyPath,
+} from '../../lib/dependency-analyzer.js';
+import {InMemoryAnalyzer} from './utils.js';
+
+/**
+ * Creates a mock filesystem backed by a Record of normalized paths → content.
+ */
+const createMockFs = (files: Record<string, string>): DependencyFs => ({
+  readFile: (p: string) => files[path.normalize(p)],
+});
+
+const mockPath: DependencyPath = path;
+
+suite('CEM Reader', () => {
+  test('parses a basic CEM with tag name on declaration', () => {
+    const cem = JSON.stringify({
+      schemaVersion: '1.0.0',
+      modules: [
+        {
+          kind: 'javascript-module',
+          path: 'src/my-element.js',
+          declarations: [
+            {
+              kind: 'class',
+              name: 'MyElement',
+              customElement: true,
+              tagName: 'my-element',
+              description: 'A test element',
+              members: [
+                {
+                  kind: 'field',
+                  name: 'label',
+                  type: {text: 'string'},
+                  default: "'hello'",
+                  description: 'The label text',
+                  attribute: 'label',
+                  reflects: true,
+                },
+                {
+                  kind: 'field',
+                  name: '_internal',
+                  privacy: 'private',
+                  type: {text: 'number'},
+                },
+                {
+                  kind: 'field',
+                  name: 'count',
+                  type: {text: 'number'},
+                  static: true,
+                },
+              ],
+              attributes: [
+                {
+                  name: 'label',
+                  type: {text: 'string'},
+                  default: "'hello'",
+                  fieldName: 'label',
+                },
+              ],
+              events: [
+                {
+                  name: 'label-changed',
+                  type: {text: 'CustomEvent'},
+                  description: 'Fired when label changes',
+                },
+              ],
+            },
+          ],
+          exports: [
+            {
+              kind: 'js',
+              name: 'MyElement',
+              declaration: {name: 'MyElement', module: 'src/my-element.js'},
+            },
+          ],
+        },
+      ],
+    });
+
+    const elements = parseCustomElementsManifest(cem, '@test/pkg');
+    assert.equal(elements.length, 1);
+
+    const el = elements[0];
+    assert.equal(el.tagName, 'my-element');
+    assert.equal(el.className, 'MyElement');
+    assert.equal(el.packageName, '@test/pkg');
+    assert.equal(el.modulePath, 'src/my-element.js');
+    assert.equal(el.description, 'A test element');
+    assert.equal(el.source, 'cem');
+
+    // Only public non-static fields become properties
+    assert.equal(el.properties.size, 1);
+    const labelProp = el.properties.get('label');
+    assert.ok(labelProp);
+    assert.equal(labelProp.type, 'string');
+    assert.equal(labelProp.attribute, 'label');
+    assert.equal(labelProp.reflects, true);
+
+    // Attributes
+    assert.equal(el.attributes.size, 1);
+    const labelAttr = el.attributes.get('label');
+    assert.ok(labelAttr);
+    assert.equal(labelAttr.fieldName, 'label');
+
+    // Events
+    assert.equal(el.events.size, 1);
+    const event = el.events.get('label-changed');
+    assert.ok(event);
+    assert.equal(event.type, 'CustomEvent');
+  });
+
+  test('resolves tag name from custom-element-definition exports', () => {
+    const cem = JSON.stringify({
+      schemaVersion: '1.0.0',
+      modules: [
+        {
+          kind: 'javascript-module',
+          path: 'src/fancy-button.js',
+          declarations: [
+            {
+              kind: 'class',
+              name: 'FancyButton',
+              customElement: true,
+              // No tagName on declaration — resolved from exports
+            },
+          ],
+          exports: [
+            {
+              kind: 'custom-element-definition',
+              name: 'fancy-button',
+              declaration: {
+                name: 'FancyButton',
+                module: 'src/fancy-button.js',
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    const elements = parseCustomElementsManifest(cem, '@test/buttons');
+    assert.equal(elements.length, 1);
+    assert.equal(elements[0].tagName, 'fancy-button');
+    assert.equal(elements[0].className, 'FancyButton');
+  });
+
+  test('skips non-custom-element classes', () => {
+    const cem = JSON.stringify({
+      schemaVersion: '1.0.0',
+      modules: [
+        {
+          kind: 'javascript-module',
+          path: 'src/utils.js',
+          declarations: [
+            {
+              kind: 'class',
+              name: 'UtilityClass',
+              // customElement is not set
+            },
+            {
+              kind: 'variable',
+              name: 'VERSION',
+            },
+          ],
+        },
+      ],
+    });
+
+    const elements = parseCustomElementsManifest(cem, '@test/utils');
+    assert.equal(elements.length, 0);
+  });
+
+  test('handles invalid JSON gracefully', () => {
+    const elements = parseCustomElementsManifest('not valid json', '@test/bad');
+    assert.equal(elements.length, 0);
+  });
+
+  test('handles manifest with no modules', () => {
+    const cem = JSON.stringify({schemaVersion: '1.0.0'});
+    const elements = parseCustomElementsManifest(cem, '@test/empty');
+    assert.equal(elements.length, 0);
+  });
+
+  test('parses multiple elements across modules', () => {
+    const cem = JSON.stringify({
+      schemaVersion: '1.0.0',
+      modules: [
+        {
+          kind: 'javascript-module',
+          path: 'src/element-a.js',
+          declarations: [
+            {
+              kind: 'class',
+              name: 'ElementA',
+              customElement: true,
+              tagName: 'element-a',
+            },
+          ],
+        },
+        {
+          kind: 'javascript-module',
+          path: 'src/element-b.js',
+          declarations: [
+            {
+              kind: 'class',
+              name: 'ElementB',
+              customElement: true,
+              tagName: 'element-b',
+            },
+          ],
+        },
+      ],
+    });
+
+    const elements = parseCustomElementsManifest(cem, '@test/multi');
+    assert.equal(elements.length, 2);
+    assert.equal(elements[0].tagName, 'element-a');
+    assert.equal(elements[1].tagName, 'element-b');
+  });
+});
+
+suite('DependencyAnalyzer', () => {
+  test('analyzes package with CEM', () => {
+    const cem = JSON.stringify({
+      schemaVersion: '1.0.0',
+      modules: [
+        {
+          kind: 'javascript-module',
+          path: 'src/my-widget.js',
+          declarations: [
+            {
+              kind: 'class',
+              name: 'MyWidget',
+              customElement: true,
+              tagName: 'my-widget',
+              description: 'A widget element',
+              members: [
+                {
+                  kind: 'field',
+                  name: 'size',
+                  type: {text: 'number'},
+                  default: '16',
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    const files: Record<string, string> = {};
+    files[path.normalize('/packages/my-widget/package.json')] = JSON.stringify({
+      name: '@test/my-widget',
+      version: '1.0.0',
+    });
+    files[path.normalize('/packages/my-widget/custom-elements.json')] = cem;
+
+    const analyzer = new DependencyAnalyzer(createMockFs(files), mockPath);
+
+    const elements = analyzer.analyzePackage('/packages/my-widget');
+    assert.equal(elements.length, 1);
+    assert.equal(elements[0].tagName, 'my-widget');
+    assert.equal(elements[0].source, 'cem');
+    assert.equal(elements[0].properties.get('size')?.type, 'number');
+  });
+
+  test('falls back to compiled analysis when no CEM', () => {
+    const jsContent = `
+      class MyButton extends HTMLElement {}
+      customElements.define('my-button', MyButton);
+    `;
+
+    const files: Record<string, string> = {};
+    files[path.normalize('/packages/my-button/package.json')] = JSON.stringify({
+      name: '@test/my-button',
+      version: '2.0.0',
+      module: 'index.js',
+    });
+    files[path.normalize('/packages/my-button/index.js')] = jsContent;
+
+    const analyzer = new DependencyAnalyzer(createMockFs(files), mockPath);
+
+    const elements = analyzer.analyzePackage('/packages/my-button');
+    assert.equal(elements.length, 1);
+    assert.equal(elements[0].tagName, 'my-button');
+    assert.equal(elements[0].className, 'MyButton');
+    assert.equal(elements[0].source, 'compiled');
+  });
+
+  test('caches results by package name and version', () => {
+    let cemReadCount = 0;
+    const cem = JSON.stringify({
+      schemaVersion: '1.0.0',
+      modules: [
+        {
+          kind: 'javascript-module',
+          path: 'src/cached-el.js',
+          declarations: [
+            {
+              kind: 'class',
+              name: 'CachedEl',
+              customElement: true,
+              tagName: 'cached-el',
+            },
+          ],
+        },
+      ],
+    });
+
+    const files: Record<string, string> = {};
+    const pkgJsonPath = path.normalize('/pkg/package.json');
+    const cemPath = path.normalize('/pkg/custom-elements.json');
+    files[pkgJsonPath] = JSON.stringify({
+      name: '@test/cached',
+      version: '1.0.0',
+    });
+    files[cemPath] = cem;
+
+    const countingFs: DependencyFs = {
+      readFile: (p: string) => {
+        const normalized = path.normalize(p);
+        if (normalized === cemPath) {
+          cemReadCount++;
+        }
+        return files[normalized];
+      },
+    };
+
+    const analyzer = new DependencyAnalyzer(countingFs, mockPath);
+
+    const first = analyzer.analyzePackage('/pkg');
+    assert.equal(cemReadCount, 1, 'CEM should be read once on first call');
+    const second = analyzer.analyzePackage('/pkg');
+
+    // CEM should not be re-read on cached second call
+    assert.equal(cemReadCount, 1, 'CEM should not be re-read from cache');
+    assert.deepStrictEqual(first, second);
+  });
+
+  test('getCustomElement returns element by tag name', () => {
+    const cem = JSON.stringify({
+      schemaVersion: '1.0.0',
+      modules: [
+        {
+          kind: 'javascript-module',
+          path: 'src/lookup-el.js',
+          declarations: [
+            {
+              kind: 'class',
+              name: 'LookupEl',
+              customElement: true,
+              tagName: 'lookup-el',
+              description: 'An element for lookup tests',
+            },
+          ],
+        },
+      ],
+    });
+
+    const files: Record<string, string> = {};
+    files[path.normalize('/pkg/package.json')] = JSON.stringify({
+      name: '@test/lookup',
+      version: '1.0.0',
+    });
+    files[path.normalize('/pkg/custom-elements.json')] = cem;
+
+    const analyzer = new DependencyAnalyzer(createMockFs(files), mockPath);
+
+    // Before analysis, element is not in registry
+    assert.equal(analyzer.getCustomElement('lookup-el'), undefined);
+
+    analyzer.analyzePackage('/pkg');
+
+    // After analysis, element is findable by tag name
+    const el = analyzer.getCustomElement('lookup-el');
+    assert.ok(el);
+    assert.equal(el.tagName, 'lookup-el');
+    assert.equal(el.description, 'An element for lookup tests');
+  });
+
+  test('getAllCustomElements returns all discovered elements', () => {
+    const cem = JSON.stringify({
+      schemaVersion: '1.0.0',
+      modules: [
+        {
+          kind: 'javascript-module',
+          path: 'src/el-one.js',
+          declarations: [
+            {
+              kind: 'class',
+              name: 'ElOne',
+              customElement: true,
+              tagName: 'el-one',
+            },
+          ],
+        },
+        {
+          kind: 'javascript-module',
+          path: 'src/el-two.js',
+          declarations: [
+            {
+              kind: 'class',
+              name: 'ElTwo',
+              customElement: true,
+              tagName: 'el-two',
+            },
+          ],
+        },
+      ],
+    });
+
+    const files: Record<string, string> = {};
+    files[path.normalize('/pkg/package.json')] = JSON.stringify({
+      name: '@test/multi',
+      version: '1.0.0',
+    });
+    files[path.normalize('/pkg/custom-elements.json')] = cem;
+
+    const analyzer = new DependencyAnalyzer(createMockFs(files), mockPath);
+    analyzer.analyzePackage('/pkg');
+
+    const all = analyzer.getAllCustomElements();
+    assert.equal(all.length, 2);
+    const tagNames = all.map((e) => e.tagName).sort();
+    assert.deepStrictEqual(tagNames, ['el-one', 'el-two']);
+  });
+
+  test('handles missing package.json', () => {
+    const analyzer = new DependencyAnalyzer(
+      {readFile: () => undefined},
+      mockPath
+    );
+
+    const elements = analyzer.analyzePackage('/nonexistent');
+    assert.equal(elements.length, 0);
+  });
+
+  test('respects customElements field in package.json for CEM path', () => {
+    const cem = JSON.stringify({
+      schemaVersion: '1.0.0',
+      modules: [
+        {
+          kind: 'javascript-module',
+          path: 'src/custom-path-el.js',
+          declarations: [
+            {
+              kind: 'class',
+              name: 'CustomPathEl',
+              customElement: true,
+              tagName: 'custom-path-el',
+            },
+          ],
+        },
+      ],
+    });
+
+    const files: Record<string, string> = {};
+    files[path.normalize('/pkg/package.json')] = JSON.stringify({
+      name: '@test/custom-path',
+      version: '1.0.0',
+      customElements: 'dist/elements.json',
+    });
+    files[path.normalize('/pkg/dist/elements.json')] = cem;
+
+    const analyzer = new DependencyAnalyzer(createMockFs(files), mockPath);
+
+    const elements = analyzer.analyzePackage('/pkg');
+    assert.equal(elements.length, 1);
+    assert.equal(elements[0].tagName, 'custom-path-el');
+  });
+});
+
+suite('Analyzer dependency integration', () => {
+  test('Analyzer exposes dependencyAnalyzer', () => {
+    const analyzer = new InMemoryAnalyzer('js', {
+      '/package.json': JSON.stringify({name: '@test/dep-integration'}),
+    });
+    assert.ok(analyzer.dependencyAnalyzer);
+    assert.ok(analyzer.dependencyAnalyzer instanceof DependencyAnalyzer);
+  });
+
+  test('getDependencyCustomElement returns undefined for unknown tags', () => {
+    const analyzer = new InMemoryAnalyzer('js', {
+      '/package.json': JSON.stringify({name: '@test/dep-unknown'}),
+    });
+    assert.equal(
+      analyzer.getDependencyCustomElement('nonexistent-element'),
+      undefined
+    );
+  });
+});


### PR DESCRIPTION
Summary
Add CEM v1 reader that parses custom-elements.json files to extract custom element metadata (tag names, properties, attributes, events)
Add DependencyAnalyzer class with lazy loading, per-package caching, CEM-first strategy with compiled JS fallback for packages without a manifest
Extend Analyzer class with analyzeDependency() and getDependencyCustomElement() methods for dependency element lookup
Export all new types (DependencyCustomElement, DependencyProperty, DependencyAttribute, DependencyEvent) and DependencyAnalyzer from the package entry point

Test plan
 CEM Reader: parses elements with inline tag names, resolves tag names from custom-element-definition exports, filters out non-custom-element classes, handles invalid JSON and empty manifests, parses multiple elements across modules
 DependencyAnalyzer: analyzes packages with CEM, falls back to compiled analysis, caches results by package+version, provides tag-name lookup via getCustomElement(), returns all elements via getAllCustomElements(), handles missing packages, respects customElements field in package.json
 Analyzer integration: exposes dependencyAnalyzer property, getDependencyCustomElement() returns undefined for unknown tags
 All 477 tests pass (476 existing + 15 new)
 
 Fixes #5191 