### PR TITLE
fix(@lit-labs/signals): restore SignalWatcher support for abstract ba…

### DIFF
--- a/packages/labs/signals/src/index.ts
+++ b/packages/labs/signals/src/index.ts
@@ -10,6 +10,7 @@ export * from 'signal-polyfill';
 export * from './lib/signal-watcher.js';
 export * from './lib/watch.js';
 export * from './lib/html-tag.js';
+export type {Constructor, AbstractConstructor} from './lib/mixin-types.js';
 
 export const State = Signal.State;
 export const Computed = Signal.Computed;

--- a/packages/labs/signals/src/lib/mixin-types.ts
+++ b/packages/labs/signals/src/lib/mixin-types.ts
@@ -1,0 +1,25 @@
+/**
+ * @license
+ * Copyright 2023 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/**
+ * Shared constructor type utilities for Lit mixins.
+ *
+ * These types support the standard TypeScript mixin pattern, allowing mixins
+ * to accept both concrete and abstract base classes.
+ */
+
+/**
+ * A concrete constructor type. Instances of this type can be called with `new`.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type Constructor<T = {}> = new (...args: any[]) => T;
+
+/**
+ * An abstract constructor type. Accepts both abstract and concrete classes.
+ * Use this as the constraint in mixin functions to allow abstract base classes.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type AbstractConstructor<T = {}> = abstract new (...args: any[]) => T;


### PR DESCRIPTION
Summary
Fix regression where SignalWatcher rejects abstract base classes (broken since v0.2.0)
Add shared Constructor / AbstractConstructor mixin type utilities
Use function overloads to preserve correct return types for both concrete and abstract inputs
Export mixin types for consumer use

Fixes #5199 