### PR TITLE
fix(@lit-labs/signals): export SignalWatcherApi and EffectOptions to …

### DIFF
--- a/packages/labs/signals/src/index.ts
+++ b/packages/labs/signals/src/index.ts
@@ -8,6 +8,10 @@ import {Signal} from 'signal-polyfill';
 
 export * from 'signal-polyfill';
 export * from './lib/signal-watcher.js';
+// Explicit re-exports of the SignalWatcher public API types so they are
+// clearly part of the package surface and never cause TS4020 errors when
+// users export classes that extend SignalWatcher.
+export type {SignalWatcherApi, EffectOptions} from './lib/signal-watcher.js';
 export * from './lib/watch.js';
 export * from './lib/html-tag.js';
 

--- a/packages/labs/signals/src/lib/signal-watcher.ts
+++ b/packages/labs/signals/src/lib/signal-watcher.ts
@@ -11,7 +11,7 @@ export interface SignalWatcher extends ReactiveElement {
   _watcher?: Signal.subtle.Watcher;
 }
 
-interface EffectOptions {
+export interface EffectOptions {
   /**
    * By default effects run after the element has updated. If `beforeUpdate`
    * is set to `true`, the effect will run before the element updates.
@@ -41,7 +41,13 @@ const effectWatcher = new Signal.subtle.Watcher(() => {
   });
 });
 
-interface SignalWatcherApi {
+/**
+ * The public API added to elements by the `SignalWatcher` mixin.
+ *
+ * Exported so that it can appear in the `extends` clause of user-exported
+ * classes without causing TS4020 errors.
+ */
+export interface SignalWatcherApi {
   updateEffect(fn: () => void, options?: EffectOptions): () => void;
 }
 

--- a/packages/labs/signals/src/lib/watch.ts
+++ b/packages/labs/signals/src/lib/watch.ts
@@ -7,7 +7,7 @@
 import {DirectiveResult, Part, directive} from 'lit/directive.js';
 import {AsyncDirective} from 'lit/async-directive.js';
 import {Signal} from 'signal-polyfill';
-import {SignalWatcher} from './signal-watcher.js';
+import type {SignalWatcher} from './signal-watcher.js';
 
 // Watcher for directives that are not associated with a host element.
 let effectsPending = false;


### PR DESCRIPTION
Summary
Fixes #5192 — TypeScript TS4020 error when exporting a class that extends SignalWatcher.

Root cause: SignalWatcher(Base) returns T & Constructor<SignalWatcherApi>. When TypeScript emits .d.ts files for a module that has export class MyElement extends SignalWatcher(LitElement), it must reference SignalWatcherApi in the extends clause. Since SignalWatcherApi and its dependency EffectOptions were private (unexported), TypeScript raised TS4020.

Changes:

signal-watcher.ts — Export EffectOptions and SignalWatcherApi with JSDoc documenting them as public API.
index.ts — Add explicit export type {SignalWatcherApi, EffectOptions} re-exports alongside the existing export * to clearly document these as part of the package surface and prevent future regressions.
watch.ts — Change import {SignalWatcher} to import type {SignalWatcher} (type hygiene; SignalWatcher is only used in type positions in this file).
signal-watcher_test.ts — Add a type-only regression test verifying that SignalWatcherApi and EffectOptions are usable as named type annotations, and a runtime test verifying that updateEffect works correctly when passed an EffectOptions-typed options object.
