### PR TITLE
[labs/rollup-plugin-minify-html-literals] Fix @container queries drop…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1701,37 +1701,6 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "node_modules/@babel/plugin-proposal-nullish-coalescing-operator": {
-      "version": "7.18.6",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.18.6",
-        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-proposal-optional-chaining": {
-      "version": "7.21.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.20.2",
-        "@babel/helper-skip-transparent-expression-wrappers": "^7.20.0",
-        "@babel/plugin-syntax-optional-chaining": "^7.8.3"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
     "node_modules/@babel/plugin-proposal-private-property-in-object": {
       "version": "7.21.0-placeholder-for-preset-env.2",
       "dev": true,
@@ -1832,34 +1801,12 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "node_modules/@babel/plugin-syntax-nullish-coalescing-operator": {
-      "version": "7.8.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.8.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
     "node_modules/@babel/plugin-syntax-numeric-separator": {
       "version": "7.10.4",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.10.4"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-syntax-optional-chaining": {
-      "version": "7.8.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.8.0"
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
@@ -3985,32 +3932,6 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
-    "node_modules/@koa/cors": {
-      "version": "3.4.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "vary": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 8.0.0"
-      }
-    },
-    "node_modules/@koa/router": {
-      "version": "12.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.3.4",
-        "http-errors": "^2.0.0",
-        "koa-compose": "^4.1.0",
-        "methods": "^1.1.2",
-        "path-to-regexp": "^6.3.0"
-      },
-      "engines": {
-        "node": ">= 12"
-      }
-    },
     "node_modules/@lit-examples/nextjs-v13": {
       "resolved": "examples/nextjs-v13",
       "link": true
@@ -4168,8 +4089,32 @@
       "link": true
     },
     "node_modules/@lit-labs/ssr": {
-      "resolved": "packages/labs/ssr",
-      "link": true
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr/-/ssr-4.0.0.tgz",
+      "integrity": "sha512-pODr+t7cZVIrCRLuSLuWAACDnztEk5IrRFwFsbxyAyWcP2XP8aKuUZdVM/biXqxvIyHyCKtNZ92Gdcr+pjA5BQ==",
+      "dependencies": {
+        "@lit-labs/ssr-client": "^1.1.7",
+        "@lit-labs/ssr-dom-shim": "^1.5.0",
+        "@lit/reactive-element": "^2.0.4",
+        "@parse5/tools": "^0.3.0",
+        "enhanced-resolve": "^5.10.0",
+        "lit": "^3.1.2",
+        "lit-element": "^4.0.4",
+        "lit-html": "^3.1.2",
+        "node-fetch": "^3.2.8",
+        "parse5": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=13.9.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=20.0.0 <25.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@lit-labs/ssr-client": {
       "resolved": "packages/labs/ssr-client",
@@ -4697,155 +4642,10 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@open-wc/building-utils": {
-      "version": "2.21.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/core": "^7.11.1",
-        "@babel/plugin-syntax-dynamic-import": "^7.8.3",
-        "@webcomponents/shadycss": "^1.10.2",
-        "@webcomponents/webcomponentsjs": "^2.5.0",
-        "arrify": "^2.0.1",
-        "browserslist": "^4.16.5",
-        "chokidar": "^3.4.3",
-        "clean-css": "^5.3.1",
-        "clone": "^2.1.2",
-        "core-js-bundle": "^3.8.1",
-        "deepmerge": "^4.2.2",
-        "es-module-shims": "^1.4.1",
-        "html-minifier-terser": "^5.1.1",
-        "lru-cache": "^6.0.0",
-        "minimatch": "^7.4.2",
-        "parse5": "^7.1.2",
-        "path-is-inside": "^1.0.2",
-        "regenerator-runtime": "^0.13.7",
-        "resolve": "^1.19.0",
-        "rimraf": "^3.0.2",
-        "shady-css-scoped-element": "^0.0.2",
-        "systemjs": "^6.8.3",
-        "terser": "^4.8.1",
-        "valid-url": "^1.0.9",
-        "whatwg-fetch": "^3.5.0",
-        "whatwg-url": "^7.1.0"
-      }
-    },
-    "node_modules/@open-wc/building-utils/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/@open-wc/building-utils/node_modules/clean-css": {
-      "version": "5.3.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "source-map": "~0.6.0"
-      },
-      "engines": {
-        "node": ">= 10.0"
-      }
-    },
-    "node_modules/@open-wc/building-utils/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@open-wc/building-utils/node_modules/minimatch": {
-      "version": "7.4.6",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@open-wc/building-utils/node_modules/source-map": {
-      "version": "0.6.1",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@open-wc/building-utils/node_modules/yallist": {
-      "version": "4.0.0",
-      "dev": true,
-      "license": "ISC"
-    },
     "node_modules/@open-wc/dedupe-mixin": {
       "version": "1.4.0",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@open-wc/karma-esm": {
-      "version": "3.0.9",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@open-wc/building-utils": "^2.18.3",
-        "babel-plugin-istanbul": "^5.1.4",
-        "chokidar": "^3.0.0",
-        "deepmerge": "^4.2.2",
-        "es-dev-server": "^1.57.8",
-        "minimatch": "^3.0.4",
-        "node-fetch": "^2.6.0",
-        "polyfills-loader": "^1.7.4",
-        "portfinder": "^1.0.21",
-        "request": "^2.88.0"
-      }
-    },
-    "node_modules/@open-wc/karma-esm/node_modules/node-fetch": {
-      "version": "2.7.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@open-wc/karma-esm/node_modules/tr46": {
-      "version": "0.0.3",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@open-wc/karma-esm/node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "dev": true,
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/@open-wc/karma-esm/node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
-      }
     },
     "node_modules/@open-wc/scoped-elements": {
       "version": "2.2.4",
@@ -4886,431 +4686,6 @@
         "@open-wc/scoped-elements": "^2.2.4",
         "lit": "^2.0.0 || ^3.0.0",
         "lit-html": "^2.0.0 || ^3.0.0"
-      }
-    },
-    "node_modules/@open-wc/testing-karma": {
-      "version": "4.0.9",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@open-wc/karma-esm": "^3.0.9",
-        "@types/karma": "^5.0.0",
-        "@types/karma-coverage-istanbul-reporter": "^2.1.0",
-        "@types/karma-mocha": "^1.3.0",
-        "@types/karma-mocha-reporter": "^2.2.0",
-        "axe-core": "^4.0.2",
-        "karma": "^5.1.1",
-        "karma-chrome-launcher": "^3.1.0",
-        "karma-coverage": "^2.0.2",
-        "karma-mocha": "^1.0.0",
-        "karma-mocha-reporter": "^2.0.0",
-        "karma-mocha-snapshot": "^0.2.1",
-        "karma-snapshot": "^0.6.0",
-        "karma-source-map-support": "^1.3.0",
-        "mocha": "^6.2.2"
-      }
-    },
-    "node_modules/@open-wc/testing-karma/node_modules/ansi-colors": {
-      "version": "3.2.3",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@open-wc/testing-karma/node_modules/ansi-regex": {
-      "version": "4.1.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@open-wc/testing-karma/node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@open-wc/testing-karma/node_modules/camelcase": {
-      "version": "5.3.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@open-wc/testing-karma/node_modules/cliui": {
-      "version": "5.0.0",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^3.1.0",
-        "strip-ansi": "^5.2.0",
-        "wrap-ansi": "^5.1.0"
-      }
-    },
-    "node_modules/@open-wc/testing-karma/node_modules/color-convert": {
-      "version": "1.9.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "node_modules/@open-wc/testing-karma/node_modules/color-name": {
-      "version": "1.1.3",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@open-wc/testing-karma/node_modules/debug": {
-      "version": "3.2.6",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.1"
-      }
-    },
-    "node_modules/@open-wc/testing-karma/node_modules/decamelize": {
-      "version": "1.2.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@open-wc/testing-karma/node_modules/diff": {
-      "version": "3.5.0",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.3.1"
-      }
-    },
-    "node_modules/@open-wc/testing-karma/node_modules/emoji-regex": {
-      "version": "7.0.3",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@open-wc/testing-karma/node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/@open-wc/testing-karma/node_modules/find-up": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "locate-path": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@open-wc/testing-karma/node_modules/flat": {
-      "version": "4.1.1",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "is-buffer": "~2.0.3"
-      },
-      "bin": {
-        "flat": "cli.js"
-      }
-    },
-    "node_modules/@open-wc/testing-karma/node_modules/glob": {
-      "version": "7.1.3",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.4",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/@open-wc/testing-karma/node_modules/has-flag": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@open-wc/testing-karma/node_modules/is-buffer": {
-      "version": "2.0.5",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@open-wc/testing-karma/node_modules/is-fullwidth-code-point": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@open-wc/testing-karma/node_modules/js-yaml": {
-      "version": "3.13.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
-    "node_modules/@open-wc/testing-karma/node_modules/locate-path": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "p-locate": "^3.0.0",
-        "path-exists": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@open-wc/testing-karma/node_modules/minimatch": {
-      "version": "3.0.4",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/@open-wc/testing-karma/node_modules/mkdirp": {
-      "version": "0.5.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "minimist": "^1.2.5"
-      },
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      }
-    },
-    "node_modules/@open-wc/testing-karma/node_modules/mocha": {
-      "version": "6.2.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-colors": "3.2.3",
-        "browser-stdout": "1.3.1",
-        "debug": "3.2.6",
-        "diff": "3.5.0",
-        "escape-string-regexp": "1.0.5",
-        "find-up": "3.0.0",
-        "glob": "7.1.3",
-        "growl": "1.10.5",
-        "he": "1.2.0",
-        "js-yaml": "3.13.1",
-        "log-symbols": "2.2.0",
-        "minimatch": "3.0.4",
-        "mkdirp": "0.5.4",
-        "ms": "2.1.1",
-        "node-environment-flags": "1.0.5",
-        "object.assign": "4.1.0",
-        "strip-json-comments": "2.0.1",
-        "supports-color": "6.0.0",
-        "which": "1.3.1",
-        "wide-align": "1.1.3",
-        "yargs": "13.3.2",
-        "yargs-parser": "13.1.2",
-        "yargs-unparser": "1.6.0"
-      },
-      "bin": {
-        "_mocha": "bin/_mocha",
-        "mocha": "bin/mocha"
-      },
-      "engines": {
-        "node": ">= 6.0.0"
-      }
-    },
-    "node_modules/@open-wc/testing-karma/node_modules/ms": {
-      "version": "2.1.1",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@open-wc/testing-karma/node_modules/object.assign": {
-      "version": "4.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "define-properties": "^1.1.2",
-        "function-bind": "^1.1.1",
-        "has-symbols": "^1.0.0",
-        "object-keys": "^1.0.11"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/@open-wc/testing-karma/node_modules/p-locate": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "p-limit": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@open-wc/testing-karma/node_modules/path-exists": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@open-wc/testing-karma/node_modules/string-width": {
-      "version": "3.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^7.0.1",
-        "is-fullwidth-code-point": "^2.0.0",
-        "strip-ansi": "^5.1.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@open-wc/testing-karma/node_modules/strip-ansi": {
-      "version": "5.2.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@open-wc/testing-karma/node_modules/strip-json-comments": {
-      "version": "2.0.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@open-wc/testing-karma/node_modules/supports-color": {
-      "version": "6.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@open-wc/testing-karma/node_modules/which": {
-      "version": "1.3.1",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "which": "bin/which"
-      }
-    },
-    "node_modules/@open-wc/testing-karma/node_modules/wrap-ansi": {
-      "version": "5.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^3.2.0",
-        "string-width": "^3.0.0",
-        "strip-ansi": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@open-wc/testing-karma/node_modules/y18n": {
-      "version": "4.0.3",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/@open-wc/testing-karma/node_modules/yargs": {
-      "version": "13.3.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cliui": "^5.0.0",
-        "find-up": "^3.0.0",
-        "get-caller-file": "^2.0.1",
-        "require-directory": "^2.1.1",
-        "require-main-filename": "^2.0.0",
-        "set-blocking": "^2.0.0",
-        "string-width": "^3.0.0",
-        "which-module": "^2.0.0",
-        "y18n": "^4.0.0",
-        "yargs-parser": "^13.1.2"
-      }
-    },
-    "node_modules/@open-wc/testing-karma/node_modules/yargs-parser": {
-      "version": "13.1.2",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "camelcase": "^5.0.0",
-        "decamelize": "^1.2.0"
-      }
-    },
-    "node_modules/@open-wc/testing-karma/node_modules/yargs-unparser": {
-      "version": "1.6.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "flat": "^4.1.0",
-        "lodash": "^4.17.15",
-        "yargs": "^13.3.0"
-      },
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/@parse5/tools": {
@@ -6095,40 +5470,11 @@
       "version": "7.0.6",
       "license": "MIT"
     },
-    "node_modules/@types/babel__core": {
-      "version": "7.20.5",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/parser": "^7.20.7",
-        "@babel/types": "^7.20.7",
-        "@types/babel__generator": "*",
-        "@types/babel__template": "*",
-        "@types/babel__traverse": "*"
-      }
-    },
     "node_modules/@types/babel__generator": {
       "version": "7.27.0",
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.0.0"
-      }
-    },
-    "node_modules/@types/babel__template": {
-      "version": "7.4.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/parser": "^7.1.0",
-        "@babel/types": "^7.0.0"
-      }
-    },
-    "node_modules/@types/babel__traverse": {
-      "version": "7.28.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/types": "^7.28.2"
       }
     },
     "node_modules/@types/body-parser": {
@@ -6138,16 +5484,6 @@
         "@types/connect": "*",
         "@types/node": "*"
       }
-    },
-    "node_modules/@types/browserslist": {
-      "version": "4.8.0",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/browserslist-useragent": {
-      "version": "3.0.7",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@types/cacheable-request": {
       "version": "6.0.3",
@@ -6159,11 +5495,6 @@
         "@types/node": "*",
         "@types/responselike": "^1.0.0"
       }
-    },
-    "node_modules/@types/caniuse-api": {
-      "version": "3.0.6",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@types/chai": {
       "version": "4.3.20",
@@ -6287,14 +5618,6 @@
       "version": "1.0.8",
       "license": "MIT"
     },
-    "node_modules/@types/etag": {
-      "version": "1.8.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/execa": {
       "version": "0.9.0",
       "license": "MIT",
@@ -6391,36 +5714,6 @@
       "version": "0.0.29",
       "license": "MIT"
     },
-    "node_modules/@types/karma": {
-      "version": "5.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*",
-        "log4js": "^4.0.0"
-      }
-    },
-    "node_modules/@types/karma-coverage-istanbul-reporter": {
-      "version": "2.1.4",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/karma-mocha": {
-      "version": "1.3.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/karma": "*"
-      }
-    },
-    "node_modules/@types/karma-mocha-reporter": {
-      "version": "2.2.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/karma": "*"
-      }
-    },
     "node_modules/@types/keygrip": {
       "version": "1.0.6",
       "license": "MIT"
@@ -6447,78 +5740,11 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/koa__cors": {
-      "version": "3.3.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/koa": "*"
-      }
-    },
-    "node_modules/@types/koa__router": {
-      "version": "8.0.11",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/koa": "*"
-      }
-    },
     "node_modules/@types/koa-compose": {
       "version": "3.2.8",
       "license": "MIT",
       "dependencies": {
         "@types/koa": "*"
-      }
-    },
-    "node_modules/@types/koa-compress": {
-      "version": "2.0.9",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/koa": "*",
-        "@types/node": "*"
-      }
-    },
-    "node_modules/@types/koa-cors": {
-      "version": "0.0.6",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/koa": "*"
-      }
-    },
-    "node_modules/@types/koa-etag": {
-      "version": "3.0.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/etag": "*",
-        "@types/koa": "*"
-      }
-    },
-    "node_modules/@types/koa-mount": {
-      "version": "4.0.5",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/koa": "*"
-      }
-    },
-    "node_modules/@types/koa-send": {
-      "version": "4.1.6",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/koa": "*"
-      }
-    },
-    "node_modules/@types/koa-static": {
-      "version": "4.0.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/koa": "*",
-        "@types/koa-send": "*"
       }
     },
     "node_modules/@types/line-reader": {
@@ -6529,11 +5755,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/lru-cache": {
-      "version": "5.1.1",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/marked": {
       "version": "4.3.2",
       "dev": true,
@@ -6541,11 +5762,6 @@
     },
     "node_modules/@types/mime": {
       "version": "1.3.5",
-      "license": "MIT"
-    },
-    "node_modules/@types/mime-types": {
-      "version": "2.1.4",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/minimatch": {
@@ -6572,11 +5788,6 @@
     },
     "node_modules/@types/parse5": {
       "version": "6.0.3",
-      "license": "MIT"
-    },
-    "node_modules/@types/path-is-inside": {
-      "version": "1.0.3",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/prettier": {
@@ -6621,11 +5832,6 @@
     },
     "node_modules/@types/relateurl": {
       "version": "0.2.33",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/resolve": {
-      "version": "1.20.6",
       "dev": true,
       "license": "MIT"
     },
@@ -6685,14 +5891,6 @@
       "version": "1.103.0",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@types/whatwg-url": {
-      "version": "6.4.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
     },
     "node_modules/@types/which": {
       "version": "1.3.2",
@@ -8311,11 +7509,6 @@
         "node": ">=0.4.0"
       }
     },
-    "node_modules/after": {
-      "version": "0.8.2",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/agent-base": {
       "version": "6.0.2",
       "license": "MIT",
@@ -8451,11 +7644,6 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
-    },
-    "node_modules/any-promise": {
-      "version": "1.3.0",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/anymatch": {
       "version": "3.1.3",
@@ -8762,27 +7950,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/array.prototype.reduce": {
-      "version": "1.0.8",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.4",
-        "define-properties": "^1.2.1",
-        "es-abstract": "^1.23.9",
-        "es-array-method-boxes-properly": "^1.0.0",
-        "es-errors": "^1.3.0",
-        "es-object-atoms": "^1.1.1",
-        "is-string": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/array.prototype.tosorted": {
       "version": "1.1.4",
       "license": "MIT",
@@ -8816,11 +7983,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/arraybuffer.slice": {
-      "version": "0.0.7",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/arrify": {
       "version": "2.0.1",
       "dev": true,
@@ -8834,26 +7996,10 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/asn1": {
-      "version": "0.2.6",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": "~2.1.0"
-      }
-    },
     "node_modules/assert-never": {
       "version": "1.4.0",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/assert-plus": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8"
-      }
     },
     "node_modules/assertion-error": {
       "version": "2.0.1",
@@ -8942,19 +8088,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/aws-sign2": {
-      "version": "0.7.0",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/aws4": {
-      "version": "1.13.2",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/axe-core": {
       "version": "4.10.3",
       "license": "MPL-2.0",
@@ -8975,62 +8108,6 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/babel-plugin-istanbul": {
-      "version": "5.2.0",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "find-up": "^3.0.0",
-        "istanbul-lib-instrument": "^3.3.0",
-        "test-exclude": "^5.2.3"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/babel-plugin-istanbul/node_modules/find-up": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "locate-path": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/babel-plugin-istanbul/node_modules/locate-path": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "p-locate": "^3.0.0",
-        "path-exists": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/babel-plugin-istanbul/node_modules/p-locate": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "p-limit": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/babel-plugin-istanbul/node_modules/path-exists": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/babel-plugin-polyfill-corejs2": {
@@ -9096,20 +8173,6 @@
         "node": ">= 10.0.0"
       }
     },
-    "node_modules/backo2": {
-      "version": "1.0.2",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/bail": {
-      "version": "1.0.5",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "license": "MIT"
@@ -9140,13 +8203,6 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/base64-arraybuffer": {
-      "version": "0.1.4",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.6.0"
       }
     },
     "node_modules/base64-js": {
@@ -9188,14 +8244,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/bcrypt-pbkdf": {
-      "version": "1.0.2",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "tweetnacl": "^0.14.3"
-      }
-    },
     "node_modules/better-path-resolve": {
       "version": "1.0.0",
       "dev": true,
@@ -9224,83 +8272,6 @@
       "dependencies": {
         "readable-stream": "^2.3.5",
         "safe-buffer": "^5.1.1"
-      }
-    },
-    "node_modules/blob": {
-      "version": "0.0.5",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/body-parser": {
-      "version": "1.20.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "bytes": "3.1.2",
-        "content-type": "~1.0.5",
-        "debug": "2.6.9",
-        "depd": "2.0.0",
-        "destroy": "1.2.0",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.4.24",
-        "on-finished": "2.4.1",
-        "qs": "6.13.0",
-        "raw-body": "2.5.2",
-        "type-is": "~1.6.18",
-        "unpipe": "1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8",
-        "npm": "1.2.8000 || >= 1.4.16"
-      }
-    },
-    "node_modules/body-parser/node_modules/debug": {
-      "version": "2.6.9",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/body-parser/node_modules/iconv-lite": {
-      "version": "0.4.24",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/body-parser/node_modules/ms": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/body-parser/node_modules/on-finished": {
-      "version": "2.4.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ee-first": "1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/body-parser/node_modules/qs": {
-      "version": "6.13.0",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "side-channel": "^1.0.6"
-      },
-      "engines": {
-        "node": ">=0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/boolbase": {
@@ -9930,11 +8901,6 @@
         "tslib": "^2.0.3"
       }
     },
-    "node_modules/caseless": {
-      "version": "0.12.0",
-      "dev": true,
-      "license": "Apache-2.0"
-    },
     "node_modules/chai": {
       "version": "5.3.1",
       "dev": true,
@@ -10074,39 +9040,12 @@
     "node_modules/changelog-parser/node_modules/line-reader": {
       "version": "0.2.4"
     },
-    "node_modules/character-entities": {
-      "version": "1.2.4",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/character-entities-legacy": {
-      "version": "1.1.4",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
     "node_modules/character-parser": {
       "version": "2.2.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-regex": "^1.0.3"
-      }
-    },
-    "node_modules/character-reference-invalid": {
-      "version": "1.1.4",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/chardet": {
@@ -10284,23 +9223,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/clean-css": {
-      "version": "4.2.4",
-      "license": "MIT",
-      "dependencies": {
-        "source-map": "~0.6.0"
-      },
-      "engines": {
-        "node": ">= 4.0"
-      }
-    },
-    "node_modules/clean-css/node_modules/source-map": {
-      "version": "0.6.1",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/cli-cursor": {
@@ -10492,15 +9414,6 @@
         "node": ">=8.0.0"
       }
     },
-    "node_modules/collapse-white-space": {
-      "version": "1.0.6",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
     "node_modules/collection-visit": {
       "version": "1.0.0",
       "dev": true,
@@ -10531,14 +9444,6 @@
       "version": "2.0.20",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/colors": {
-      "version": "1.4.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.1.90"
-      }
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -10646,10 +9551,6 @@
         "typescript": ">=3.x || >= 4.x || >= 5.x"
       }
     },
-    "node_modules/component-bind": {
-      "version": "1.0.0",
-      "dev": true
-    },
     "node_modules/component-emitter": {
       "version": "1.3.1",
       "dev": true,
@@ -10657,10 +9558,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/component-inherit": {
-      "version": "0.0.3",
-      "dev": true
     },
     "node_modules/compress-commons": {
       "version": "4.1.2",
@@ -10687,17 +9584,6 @@
       },
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/compressible": {
-      "version": "2.0.18",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": ">= 1.43.0 < 2"
-      },
-      "engines": {
-        "node": ">= 0.6"
       }
     },
     "node_modules/compressing": {
@@ -11112,25 +9998,9 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
-    "node_modules/custom-event": {
-      "version": "1.0.1",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
       "license": "BSD-2-Clause"
-    },
-    "node_modules/dashdash": {
-      "version": "1.14.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10"
-      }
     },
     "node_modules/data-uri-to-buffer": {
       "version": "4.0.1",
@@ -11188,14 +10058,6 @@
       "version": "1.4.0",
       "dev": true,
       "license": "BSD-3-Clause"
-    },
-    "node_modules/date-format": {
-      "version": "2.1.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0"
-      }
     },
     "node_modules/debounce": {
       "version": "1.2.1",
@@ -11722,11 +10584,6 @@
         }
       }
     },
-    "node_modules/di": {
-      "version": "0.0.1",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/didyoumean2": {
       "version": "4.1.0",
       "dev": true,
@@ -11795,17 +10652,6 @@
       "version": "1.1.0",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/dom-serialize": {
-      "version": "2.2.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "custom-event": "~1.0.0",
-        "ent": "~2.2.0",
-        "extend": "^3.0.0",
-        "void-elements": "^2.0.0"
-      }
     },
     "node_modules/dom-serializer": {
       "version": "2.0.0",
@@ -11954,15 +10800,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/ecc-jsbn": {
-      "version": "0.1.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.1.0"
       }
     },
     "node_modules/ecdsa-sig-formatter": {
@@ -12202,20 +11039,6 @@
         "node": ">=8.6"
       }
     },
-    "node_modules/ent": {
-      "version": "2.2.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.3",
-        "es-errors": "^1.3.0",
-        "punycode": "^1.4.1",
-        "safe-regex-test": "^1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/entities": {
       "version": "4.5.0",
       "license": "BSD-2-Clause",
@@ -12236,19 +11059,6 @@
       "bin": {
         "errno": "cli.js"
       }
-    },
-    "node_modules/error-ex": {
-      "version": "1.3.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-arrayish": "^0.2.1"
-      }
-    },
-    "node_modules/error-ex/node_modules/is-arrayish": {
-      "version": "0.2.1",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/errorstacks": {
       "version": "2.4.1",
@@ -12320,360 +11130,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/es-array-method-boxes-properly": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/es-define-property": {
       "version": "1.0.1",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-dev-server": {
-      "version": "1.60.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/core": "^7.11.1",
-        "@babel/plugin-proposal-dynamic-import": "^7.10.4",
-        "@babel/plugin-proposal-nullish-coalescing-operator": "^7.10.4",
-        "@babel/plugin-proposal-optional-chaining": "^7.11.0",
-        "@babel/plugin-syntax-class-properties": "^7.8.3",
-        "@babel/plugin-syntax-import-meta": "^7.10.4",
-        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
-        "@babel/plugin-syntax-numeric-separator": "^7.8.3",
-        "@babel/plugin-syntax-optional-chaining": "^7.8.3",
-        "@babel/plugin-transform-template-literals": "^7.8.3",
-        "@babel/preset-env": "^7.9.0",
-        "@koa/cors": "^3.1.0",
-        "@open-wc/building-utils": "^2.18.3",
-        "@rollup/plugin-node-resolve": "^7.1.1",
-        "@rollup/pluginutils": "^3.0.0",
-        "@types/babel__core": "^7.1.3",
-        "@types/browserslist": "^4.8.0",
-        "@types/browserslist-useragent": "^3.0.0",
-        "@types/caniuse-api": "^3.0.0",
-        "@types/command-line-args": "^5.0.0",
-        "@types/command-line-usage": "^5.0.1",
-        "@types/debounce": "^1.2.0",
-        "@types/koa": "^2.0.48",
-        "@types/koa__cors": "^3.0.1",
-        "@types/koa-compress": "^2.0.9",
-        "@types/koa-etag": "^3.0.0",
-        "@types/koa-static": "^4.0.1",
-        "@types/lru-cache": "^5.1.0",
-        "@types/mime-types": "^2.1.0",
-        "@types/minimatch": "^3.0.3",
-        "@types/path-is-inside": "^1.0.0",
-        "@types/whatwg-url": "^6.4.0",
-        "browserslist": "^4.9.1",
-        "browserslist-useragent": "^3.0.2",
-        "builtin-modules": "^3.1.0",
-        "camelcase": "^5.3.1",
-        "caniuse-api": "^3.0.0",
-        "caniuse-lite": "^1.0.30001033",
-        "chokidar": "^3.0.0",
-        "command-line-args": "^5.0.2",
-        "command-line-usage": "^6.1.0",
-        "debounce": "^1.2.0",
-        "deepmerge": "^4.2.2",
-        "es-module-lexer": "^0.3.13",
-        "get-stream": "^5.1.0",
-        "is-stream": "^2.0.0",
-        "isbinaryfile": "^4.0.2",
-        "koa": "^2.7.0",
-        "koa-compress": "^3.0.0",
-        "koa-etag": "^3.0.0",
-        "koa-static": "^5.0.0",
-        "lru-cache": "^5.1.1",
-        "mime-types": "^2.1.27",
-        "minimatch": "^3.0.4",
-        "open": "^7.0.3",
-        "parse5": "^5.1.1",
-        "path-is-inside": "^1.0.2",
-        "polyfills-loader": "^1.7.4",
-        "portfinder": "^1.0.21",
-        "rollup": "^2.7.2",
-        "strip-ansi": "^5.2.0",
-        "systemjs": "^6.3.1",
-        "tslib": "^1.11.1",
-        "useragent": "^2.3.0",
-        "whatwg-url": "^7.0.0"
-      },
-      "bin": {
-        "es-dev-server": "dist/cli.js"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/es-dev-server/node_modules/@rollup/plugin-node-resolve": {
-      "version": "7.1.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@rollup/pluginutils": "^3.0.8",
-        "@types/resolve": "0.0.8",
-        "builtin-modules": "^3.1.0",
-        "is-module": "^1.0.0",
-        "resolve": "^1.14.2"
-      },
-      "engines": {
-        "node": ">= 8.0.0"
-      },
-      "peerDependencies": {
-        "rollup": "^1.20.0||^2.0.0"
-      }
-    },
-    "node_modules/es-dev-server/node_modules/@types/resolve": {
-      "version": "0.0.8",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
-    "node_modules/es-dev-server/node_modules/ansi-regex": {
-      "version": "4.1.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/es-dev-server/node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/es-dev-server/node_modules/array-back": {
-      "version": "4.0.2",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/es-dev-server/node_modules/browserslist-useragent": {
-      "version": "3.1.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "browserslist": "^4.19.1",
-        "electron-to-chromium": "^1.4.67",
-        "semver": "^7.3.5",
-        "useragent": "^2.3.0",
-        "yamlparser": "^0.0.2"
-      },
-      "engines": {
-        "node": ">= 6.x.x"
-      }
-    },
-    "node_modules/es-dev-server/node_modules/camelcase": {
-      "version": "5.3.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/es-dev-server/node_modules/chalk": {
-      "version": "2.4.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/es-dev-server/node_modules/color-convert": {
-      "version": "1.9.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "node_modules/es-dev-server/node_modules/color-name": {
-      "version": "1.1.3",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/es-dev-server/node_modules/command-line-usage": {
-      "version": "6.1.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "array-back": "^4.0.2",
-        "chalk": "^2.4.2",
-        "table-layout": "^1.0.2",
-        "typical": "^5.2.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/es-dev-server/node_modules/es-module-lexer": {
-      "version": "0.3.26",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/es-dev-server/node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/es-dev-server/node_modules/get-stream": {
-      "version": "5.2.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "pump": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/es-dev-server/node_modules/has-flag": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/es-dev-server/node_modules/isbinaryfile": {
-      "version": "4.0.10",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/gjtorikian/"
-      }
-    },
-    "node_modules/es-dev-server/node_modules/koa-etag": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "etag": "^1.3.0",
-        "mz": "^2.1.0"
-      }
-    },
-    "node_modules/es-dev-server/node_modules/open": {
-      "version": "7.4.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-docker": "^2.0.0",
-        "is-wsl": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/es-dev-server/node_modules/parse5": {
-      "version": "5.1.1",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/es-dev-server/node_modules/rollup": {
-      "version": "2.79.2",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "rollup": "dist/bin/rollup"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.2"
-      }
-    },
-    "node_modules/es-dev-server/node_modules/strip-ansi": {
-      "version": "5.2.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/es-dev-server/node_modules/supports-color": {
-      "version": "5.5.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/es-dev-server/node_modules/table-layout": {
-      "version": "1.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "array-back": "^4.0.1",
-        "deep-extend": "~0.6.0",
-        "typical": "^5.2.0",
-        "wordwrapjs": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/es-dev-server/node_modules/tslib": {
-      "version": "1.14.1",
-      "dev": true,
-      "license": "0BSD"
-    },
-    "node_modules/es-dev-server/node_modules/typical": {
-      "version": "5.2.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/es-dev-server/node_modules/wordwrapjs": {
-      "version": "4.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "reduce-flatten": "^2.0.0",
-        "typical": "^5.2.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
       }
     },
     "node_modules/es-errors": {
@@ -13546,11 +12007,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/extend": {
-      "version": "3.0.2",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/extend-shallow": {
       "version": "2.0.1",
       "dev": true,
@@ -13626,14 +12082,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/extsprintf": {
-      "version": "1.3.0",
-      "dev": true,
-      "engines": [
-        "node >=0.6.0"
-      ],
-      "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -13931,27 +12379,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/forever-agent": {
-      "version": "0.6.1",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/form-data": {
-      "version": "2.3.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.6",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 0.12"
-      }
-    },
     "node_modules/form-data-encoder": {
       "version": "2.1.4",
       "license": "MIT",
@@ -14185,14 +12612,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/getpass": {
-      "version": "0.1.7",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "^1.0.0"
-      }
-    },
     "node_modules/glob": {
       "version": "10.4.5",
       "dev": true,
@@ -14354,14 +12773,6 @@
         "node": ">=6.0"
       }
     },
-    "node_modules/growl": {
-      "version": "1.10.5",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.x"
-      }
-    },
     "node_modules/gzip-size": {
       "version": "7.0.0",
       "dev": true,
@@ -14413,26 +12824,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/har-schema": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/har-validator": {
-      "version": "5.1.5",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "^6.12.3",
-        "har-schema": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/has-bigints": {
       "version": "1.1.0",
       "license": "MIT",
@@ -14442,24 +12833,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/has-binary2": {
-      "version": "1.0.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "isarray": "2.0.1"
-      }
-    },
-    "node_modules/has-binary2/node_modules/isarray": {
-      "version": "2.0.1",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/has-cors": {
-      "version": "1.1.0",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
@@ -14614,11 +12987,6 @@
         "node": ">=10.0.0"
       }
     },
-    "node_modules/hosted-git-info": {
-      "version": "2.8.9",
-      "dev": true,
-      "license": "ISC"
-    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "license": "MIT"
@@ -14691,52 +13059,6 @@
     "node_modules/html-minifier-next/node_modules/terser/node_modules/commander": {
       "version": "2.20.3",
       "license": "MIT"
-    },
-    "node_modules/html-minifier-terser": {
-      "version": "5.1.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "camel-case": "^4.1.1",
-        "clean-css": "^4.2.3",
-        "commander": "^4.1.1",
-        "he": "^1.2.0",
-        "param-case": "^3.0.3",
-        "relateurl": "^0.2.7",
-        "terser": "^4.6.3"
-      },
-      "bin": {
-        "html-minifier-terser": "cli.js"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/html-minifier-terser/node_modules/camel-case": {
-      "version": "4.1.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "pascal-case": "^3.1.2",
-        "tslib": "^2.0.3"
-      }
-    },
-    "node_modules/html-minifier-terser/node_modules/commander": {
-      "version": "4.1.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/html-minifier-terser/node_modules/param-case": {
-      "version": "3.0.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "dot-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
     },
     "node_modules/htmlparser2": {
       "version": "8.0.2",
@@ -14851,20 +13173,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 14"
-      }
-    },
-    "node_modules/http-signature": {
-      "version": "1.2.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "^1.0.0",
-        "jsprim": "^1.2.2",
-        "sshpk": "^1.7.0"
-      },
-      "engines": {
-        "node": ">=0.8",
-        "npm": ">=1.3.7"
       }
     },
     "node_modules/http2-wrapper": {
@@ -15038,10 +13346,6 @@
         "node": ">=0.8.19"
       }
     },
-    "node_modules/indexof": {
-      "version": "0.0.1",
-      "dev": true
-    },
     "node_modules/inflation": {
       "version": "2.1.0",
       "license": "MIT",
@@ -15137,28 +13441,6 @@
       },
       "engines": {
         "node": ">= 0.10"
-      }
-    },
-    "node_modules/is-alphabetical": {
-      "version": "1.0.4",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/is-alphanumerical": {
-      "version": "1.0.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-alphabetical": "^1.0.0",
-        "is-decimal": "^1.0.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/is-array-buffer": {
@@ -15335,15 +13617,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-decimal": {
-      "version": "1.0.4",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
     "node_modules/is-descriptor": {
       "version": "1.0.3",
       "dev": true,
@@ -15454,15 +13727,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/is-hexadecimal": {
-      "version": "1.0.4",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
     "node_modules/is-interactive": {
       "version": "2.0.0",
       "dev": true,
@@ -15544,14 +13808,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/is-plain-obj": {
-      "version": "1.1.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/is-plain-object": {
@@ -15677,11 +13933,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-typedarray": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/is-unicode-supported": {
       "version": "0.1.0",
       "dev": true,
@@ -15743,30 +13994,12 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/is-whitespace-character": {
-      "version": "1.0.4",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
     "node_modules/is-windows": {
       "version": "1.0.2",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-word-character": {
-      "version": "1.0.4",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/is-wsl": {
@@ -15818,49 +14051,11 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/isstream": {
-      "version": "0.1.2",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/istanbul-lib-instrument": {
-      "version": "3.3.0",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@babel/generator": "^7.4.0",
-        "@babel/parser": "^7.4.3",
-        "@babel/template": "^7.4.0",
-        "@babel/traverse": "^7.4.3",
-        "@babel/types": "^7.4.0",
-        "istanbul-lib-coverage": "^2.0.5",
-        "semver": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/istanbul-lib-instrument/node_modules/istanbul-lib-coverage": {
-      "version": "2.0.5",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/istanbul-lib-instrument/node_modules/semver": {
-      "version": "6.3.1",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
       }
     },
     "node_modules/istanbul-lib-report": {
@@ -15873,27 +14068,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/istanbul-lib-source-maps": {
-      "version": "4.0.1",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "debug": "^4.1.1",
-        "istanbul-lib-coverage": "^3.0.0",
-        "source-map": "^0.6.1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/istanbul-lib-source-maps/node_modules/source-map": {
-      "version": "0.6.1",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/istanbul-reports": {
@@ -16014,11 +14188,6 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
-    "node_modules/jsbn": {
-      "version": "0.1.1",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/jsesc": {
       "version": "3.1.0",
       "license": "MIT",
@@ -16033,22 +14202,12 @@
       "version": "3.0.1",
       "license": "MIT"
     },
-    "node_modules/json-parse-better-errors": {
-      "version": "1.0.2",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "license": "MIT",
       "peer": true
-    },
-    "node_modules/json-schema": {
-      "version": "0.4.0",
-      "dev": true,
-      "license": "(AFL-2.1 OR BSD-3-Clause)"
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
@@ -16057,11 +14216,6 @@
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "license": "MIT"
-    },
-    "node_modules/json-stringify-safe": {
-      "version": "5.0.1",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/json5": {
       "version": "2.2.3",
@@ -16112,20 +14266,6 @@
       "engines": {
         "node": ">=12",
         "npm": ">=6"
-      }
-    },
-    "node_modules/jsprim": {
-      "version": "1.4.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "1.0.0",
-        "extsprintf": "1.3.0",
-        "json-schema": "0.4.0",
-        "verror": "1.10.0"
-      },
-      "engines": {
-        "node": ">=0.6.0"
       }
     },
     "node_modules/jstat": {
@@ -16191,700 +14331,6 @@
       "dependencies": {
         "jwa": "^1.4.1",
         "safe-buffer": "^5.0.1"
-      }
-    },
-    "node_modules/karma": {
-      "version": "5.2.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "body-parser": "^1.19.0",
-        "braces": "^3.0.2",
-        "chokidar": "^3.4.2",
-        "colors": "^1.4.0",
-        "connect": "^3.7.0",
-        "di": "^0.0.1",
-        "dom-serialize": "^2.2.1",
-        "glob": "^7.1.6",
-        "graceful-fs": "^4.2.4",
-        "http-proxy": "^1.18.1",
-        "isbinaryfile": "^4.0.6",
-        "lodash": "^4.17.19",
-        "log4js": "^6.2.1",
-        "mime": "^2.4.5",
-        "minimatch": "^3.0.4",
-        "qjobs": "^1.2.0",
-        "range-parser": "^1.2.1",
-        "rimraf": "^3.0.2",
-        "socket.io": "^2.3.0",
-        "source-map": "^0.6.1",
-        "tmp": "0.2.1",
-        "ua-parser-js": "0.7.22",
-        "yargs": "^15.3.1"
-      },
-      "bin": {
-        "karma": "bin/karma"
-      },
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/karma-chrome-launcher": {
-      "version": "3.2.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "which": "^1.2.1"
-      }
-    },
-    "node_modules/karma-chrome-launcher/node_modules/which": {
-      "version": "1.3.1",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "which": "bin/which"
-      }
-    },
-    "node_modules/karma-coverage": {
-      "version": "2.2.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "istanbul-lib-coverage": "^3.2.0",
-        "istanbul-lib-instrument": "^5.1.0",
-        "istanbul-lib-report": "^3.0.0",
-        "istanbul-lib-source-maps": "^4.0.1",
-        "istanbul-reports": "^3.0.5",
-        "minimatch": "^3.0.4"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
-    "node_modules/karma-coverage/node_modules/istanbul-lib-instrument": {
-      "version": "5.2.1",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@babel/core": "^7.12.3",
-        "@babel/parser": "^7.14.7",
-        "@istanbuljs/schema": "^0.1.2",
-        "istanbul-lib-coverage": "^3.2.0",
-        "semver": "^6.3.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/karma-coverage/node_modules/semver": {
-      "version": "6.3.1",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/karma-mocha": {
-      "version": "1.3.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "minimist": "1.2.0"
-      }
-    },
-    "node_modules/karma-mocha-reporter": {
-      "version": "2.2.5",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^2.1.0",
-        "log-symbols": "^2.1.0",
-        "strip-ansi": "^4.0.0"
-      },
-      "peerDependencies": {
-        "karma": ">=0.13"
-      }
-    },
-    "node_modules/karma-mocha-reporter/node_modules/ansi-regex": {
-      "version": "3.0.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/karma-mocha-reporter/node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/karma-mocha-reporter/node_modules/chalk": {
-      "version": "2.4.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/karma-mocha-reporter/node_modules/color-convert": {
-      "version": "1.9.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "node_modules/karma-mocha-reporter/node_modules/color-name": {
-      "version": "1.1.3",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/karma-mocha-reporter/node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/karma-mocha-reporter/node_modules/has-flag": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/karma-mocha-reporter/node_modules/strip-ansi": {
-      "version": "4.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/karma-mocha-reporter/node_modules/supports-color": {
-      "version": "5.5.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/karma-mocha-snapshot": {
-      "version": "0.2.1",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/karma-mocha/node_modules/minimist": {
-      "version": "1.2.0",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/karma-snapshot": {
-      "version": "0.6.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mkdirp": "^0.5.1",
-        "remark-parse": "^4.0.0",
-        "unified": "^6.1.5"
-      }
-    },
-    "node_modules/karma-snapshot/node_modules/mkdirp": {
-      "version": "0.5.6",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "minimist": "^1.2.6"
-      },
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      }
-    },
-    "node_modules/karma-source-map-support": {
-      "version": "1.4.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "source-map-support": "^0.5.5"
-      }
-    },
-    "node_modules/karma/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/karma/node_modules/camelcase": {
-      "version": "5.3.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/karma/node_modules/cliui": {
-      "version": "6.0.0",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.0",
-        "wrap-ansi": "^6.2.0"
-      }
-    },
-    "node_modules/karma/node_modules/connect": {
-      "version": "3.7.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "2.6.9",
-        "finalhandler": "1.1.2",
-        "parseurl": "~1.3.3",
-        "utils-merge": "1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.10.0"
-      }
-    },
-    "node_modules/karma/node_modules/connect/node_modules/debug": {
-      "version": "2.6.9",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/karma/node_modules/connect/node_modules/ms": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/karma/node_modules/cookie": {
-      "version": "0.4.2",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/karma/node_modules/date-format": {
-      "version": "4.0.14",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0"
-      }
-    },
-    "node_modules/karma/node_modules/decamelize": {
-      "version": "1.2.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/karma/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/karma/node_modules/engine.io": {
-      "version": "3.6.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "accepts": "~1.3.4",
-        "base64id": "2.0.0",
-        "cookie": "~0.4.1",
-        "debug": "~4.1.0",
-        "engine.io-parser": "~2.2.0",
-        "ws": "~7.5.10"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/karma/node_modules/engine.io-client": {
-      "version": "3.5.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "component-emitter": "~1.3.0",
-        "component-inherit": "0.0.3",
-        "debug": "~3.1.0",
-        "engine.io-parser": "~2.2.0",
-        "has-cors": "1.1.0",
-        "indexof": "0.0.1",
-        "parseqs": "0.0.6",
-        "parseuri": "0.0.6",
-        "ws": "~7.5.10",
-        "xmlhttprequest-ssl": "~1.6.2",
-        "yeast": "0.1.2"
-      }
-    },
-    "node_modules/karma/node_modules/engine.io-client/node_modules/debug": {
-      "version": "3.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/karma/node_modules/engine.io-client/node_modules/ms": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/karma/node_modules/engine.io-parser": {
-      "version": "2.2.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "after": "0.8.2",
-        "arraybuffer.slice": "~0.0.7",
-        "base64-arraybuffer": "0.1.4",
-        "blob": "0.0.5",
-        "has-binary2": "~1.0.2"
-      }
-    },
-    "node_modules/karma/node_modules/engine.io/node_modules/debug": {
-      "version": "4.1.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.1"
-      }
-    },
-    "node_modules/karma/node_modules/finalhandler": {
-      "version": "1.1.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "2.6.9",
-        "encodeurl": "~1.0.2",
-        "escape-html": "~1.0.3",
-        "on-finished": "~2.3.0",
-        "parseurl": "~1.3.3",
-        "statuses": "~1.5.0",
-        "unpipe": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/karma/node_modules/finalhandler/node_modules/debug": {
-      "version": "2.6.9",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/karma/node_modules/finalhandler/node_modules/ms": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/karma/node_modules/fs-extra": {
-      "version": "8.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=6 <7 || >=8"
-      }
-    },
-    "node_modules/karma/node_modules/glob": {
-      "version": "7.2.3",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/karma/node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/karma/node_modules/isarray": {
-      "version": "2.0.1",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/karma/node_modules/isbinaryfile": {
-      "version": "4.0.10",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/gjtorikian/"
-      }
-    },
-    "node_modules/karma/node_modules/log4js": {
-      "version": "6.9.1",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "date-format": "^4.0.14",
-        "debug": "^4.3.4",
-        "flatted": "^3.2.7",
-        "rfdc": "^1.3.0",
-        "streamroller": "^3.1.5"
-      },
-      "engines": {
-        "node": ">=8.0"
-      }
-    },
-    "node_modules/karma/node_modules/socket.io": {
-      "version": "2.5.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "~4.1.0",
-        "engine.io": "~3.6.0",
-        "has-binary2": "~1.0.2",
-        "socket.io-adapter": "~1.1.0",
-        "socket.io-client": "2.5.0",
-        "socket.io-parser": "~3.4.0"
-      }
-    },
-    "node_modules/karma/node_modules/socket.io-adapter": {
-      "version": "1.1.2",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/karma/node_modules/socket.io-client": {
-      "version": "2.5.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "backo2": "1.0.2",
-        "component-bind": "1.0.0",
-        "component-emitter": "~1.3.0",
-        "debug": "~3.1.0",
-        "engine.io-client": "~3.5.0",
-        "has-binary2": "~1.0.2",
-        "indexof": "0.0.1",
-        "parseqs": "0.0.6",
-        "parseuri": "0.0.6",
-        "socket.io-parser": "~3.3.0",
-        "to-array": "0.1.4"
-      }
-    },
-    "node_modules/karma/node_modules/socket.io-client/node_modules/debug": {
-      "version": "3.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/karma/node_modules/socket.io-client/node_modules/ms": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/karma/node_modules/socket.io-client/node_modules/socket.io-parser": {
-      "version": "3.3.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "component-emitter": "~1.3.0",
-        "debug": "~3.1.0",
-        "isarray": "2.0.1"
-      }
-    },
-    "node_modules/karma/node_modules/socket.io-parser": {
-      "version": "3.4.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "component-emitter": "1.2.1",
-        "debug": "~4.1.0",
-        "isarray": "2.0.1"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
-    "node_modules/karma/node_modules/socket.io-parser/node_modules/component-emitter": {
-      "version": "1.2.1",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/karma/node_modules/socket.io-parser/node_modules/debug": {
-      "version": "4.1.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.1"
-      }
-    },
-    "node_modules/karma/node_modules/socket.io/node_modules/debug": {
-      "version": "4.1.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.1"
-      }
-    },
-    "node_modules/karma/node_modules/source-map": {
-      "version": "0.6.1",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/karma/node_modules/statuses": {
-      "version": "1.5.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/karma/node_modules/streamroller": {
-      "version": "3.1.5",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "date-format": "^4.0.14",
-        "debug": "^4.3.4",
-        "fs-extra": "^8.1.0"
-      },
-      "engines": {
-        "node": ">=8.0"
-      }
-    },
-    "node_modules/karma/node_modules/string-width": {
-      "version": "4.2.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/karma/node_modules/ua-parser-js": {
-      "version": "0.7.22",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/karma/node_modules/wrap-ansi": {
-      "version": "6.2.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/karma/node_modules/xmlhttprequest-ssl": {
-      "version": "1.6.3",
-      "dev": true,
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/karma/node_modules/y18n": {
-      "version": "4.0.3",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/karma/node_modules/yargs": {
-      "version": "15.4.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cliui": "^6.0.0",
-        "decamelize": "^1.2.0",
-        "find-up": "^4.1.0",
-        "get-caller-file": "^2.0.1",
-        "require-directory": "^2.1.1",
-        "require-main-filename": "^2.0.0",
-        "set-blocking": "^2.0.0",
-        "string-width": "^4.2.0",
-        "which-module": "^2.0.0",
-        "y18n": "^4.0.0",
-        "yargs-parser": "^18.1.2"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/karma/node_modules/yargs-parser": {
-      "version": "18.1.3",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "camelcase": "^5.0.0",
-        "decamelize": "^1.2.0"
-      },
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/keygrip": {
@@ -16968,20 +14414,6 @@
       "version": "4.1.0",
       "license": "MIT"
     },
-    "node_modules/koa-compress": {
-      "version": "3.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "bytes": "^3.0.0",
-        "compressible": "^2.0.0",
-        "koa-is-json": "^1.0.0",
-        "statuses": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 8.0.0"
-      }
-    },
     "node_modules/koa-convert": {
       "version": "2.0.0",
       "license": "MIT",
@@ -16993,22 +14425,12 @@
         "node": ">= 10"
       }
     },
-    "node_modules/koa-cors": {
-      "version": "0.0.16",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/koa-etag": {
       "version": "4.0.0",
       "license": "MIT",
       "dependencies": {
         "etag": "^1.8.1"
       }
-    },
-    "node_modules/koa-is-json": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/koa-mount": {
       "version": "4.2.0",
@@ -17798,28 +15220,6 @@
       "resolved": "packages/lit-html",
       "link": true
     },
-    "node_modules/load-json-file": {
-      "version": "4.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.1.2",
-        "parse-json": "^4.0.0",
-        "pify": "^3.0.0",
-        "strip-bom": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/load-json-file/node_modules/pify": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/loader-runner": {
       "version": "4.3.0",
       "license": "MIT",
@@ -18066,11 +15466,6 @@
       "version": "4.1.1",
       "license": "MIT"
     },
-    "node_modules/lodash.sortby": {
-      "version": "4.7.0",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/lodash.startcase": {
       "version": "4.4.0",
       "dev": true,
@@ -18094,81 +15489,6 @@
       "version": "4.2.0",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/log-symbols": {
-      "version": "2.2.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/log-symbols/node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/log-symbols/node_modules/chalk": {
-      "version": "2.4.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/log-symbols/node_modules/color-convert": {
-      "version": "1.9.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "node_modules/log-symbols/node_modules/color-name": {
-      "version": "1.1.3",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/log-symbols/node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/log-symbols/node_modules/has-flag": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/log-symbols/node_modules/supports-color": {
-      "version": "5.5.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
     },
     "node_modules/log-update": {
       "version": "4.0.0",
@@ -18248,26 +15568,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/log4js": {
-      "version": "4.5.1",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "date-format": "^2.0.0",
-        "debug": "^4.1.1",
-        "flatted": "^2.0.0",
-        "rfdc": "^1.1.4",
-        "streamroller": "^1.0.6"
-      },
-      "engines": {
-        "node": ">=6.0"
-      }
-    },
-    "node_modules/log4js/node_modules/flatted": {
-      "version": "2.0.2",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/loglevel": {
       "version": "1.9.2",
@@ -18372,15 +15672,6 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/markdown-escapes": {
-      "version": "1.0.4",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/markdown-it": {
@@ -18497,14 +15788,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/methods": {
-      "version": "1.1.2",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/micromatch": {
       "version": "4.0.8",
       "license": "MIT",
@@ -18524,25 +15807,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/mime": {
-      "version": "2.6.0",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "mime": "cli.js"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/mime-db": {
-      "version": "1.54.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
       }
     },
     "node_modules/mime-types": {
@@ -19016,16 +16280,6 @@
         "mustache": "bin/mustache"
       }
     },
-    "node_modules/mz": {
-      "version": "2.7.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "any-promise": "^1.0.0",
-        "object-assign": "^4.0.1",
-        "thenify-all": "^1.0.0"
-      }
-    },
     "node_modules/nanocolors": {
       "version": "0.2.13",
       "license": "MIT"
@@ -19393,23 +16647,6 @@
         "node": ">=10.5.0"
       }
     },
-    "node_modules/node-environment-flags": {
-      "version": "1.0.5",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "object.getownpropertydescriptors": "^2.0.3",
-        "semver": "^5.7.0"
-      }
-    },
-    "node_modules/node-environment-flags/node_modules/semver": {
-      "version": "5.7.2",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
     "node_modules/node-fetch": {
       "version": "3.3.2",
       "license": "MIT",
@@ -19451,25 +16688,6 @@
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/normalize-package-data": {
-      "version": "2.5.0",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "hosted-git-info": "^2.1.4",
-        "resolve": "^1.10.0",
-        "semver": "2 || 3 || 4 || 5",
-        "validate-npm-package-license": "^3.0.1"
-      }
-    },
-    "node_modules/normalize-package-data/node_modules/semver": {
-      "version": "5.7.2",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver"
       }
     },
     "node_modules/normalize-path": {
@@ -19556,14 +16774,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/oauth-sign": {
-      "version": "0.9.0",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/object-assign": {
@@ -19690,26 +16900,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/object.getownpropertydescriptors": {
-      "version": "2.1.8",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "array.prototype.reduce": "^1.0.6",
-        "call-bind": "^1.0.7",
-        "define-properties": "^1.2.1",
-        "es-abstract": "^1.23.2",
-        "es-object-atoms": "^1.0.0",
-        "gopd": "^1.0.1",
-        "safe-array-concat": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.8"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -19990,14 +17180,6 @@
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
-    "node_modules/os-tmpdir": {
-      "version": "1.0.2",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/outdent": {
       "version": "0.5.0",
       "dev": true,
@@ -20196,31 +17378,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/parse-entities": {
-      "version": "1.2.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "character-entities": "^1.0.0",
-        "character-entities-legacy": "^1.0.0",
-        "character-reference-invalid": "^1.0.0",
-        "is-alphanumerical": "^1.0.0",
-        "is-decimal": "^1.0.0",
-        "is-hexadecimal": "^1.0.0"
-      }
-    },
-    "node_modules/parse-json": {
-      "version": "4.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "error-ex": "^1.3.1",
-        "json-parse-better-errors": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/parse5": {
       "version": "7.3.0",
       "license": "MIT",
@@ -20240,16 +17397,6 @@
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
-    },
-    "node_modules/parseqs": {
-      "version": "0.0.6",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/parseuri": {
-      "version": "0.0.6",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/parseurl": {
       "version": "1.3.3",
@@ -20321,11 +17468,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/path-is-inside": {
-      "version": "1.0.2",
-      "dev": true,
-      "license": "(WTFPL OR MIT)"
-    },
     "node_modules/path-key": {
       "version": "3.1.1",
       "license": "MIT",
@@ -20384,11 +17526,6 @@
     },
     "node_modules/pend": {
       "version": "1.2.0",
-      "license": "MIT"
-    },
-    "node_modules/performance-now": {
-      "version": "2.1.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/picocolors": {
@@ -20680,46 +17817,6 @@
         "semver-compare": "^1.0.0"
       }
     },
-    "node_modules/polyfills-loader": {
-      "version": "1.7.6",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/core": "^7.11.1",
-        "@open-wc/building-utils": "^2.18.3",
-        "@webcomponents/webcomponentsjs": "^2.4.0",
-        "abortcontroller-polyfill": "^1.4.0",
-        "core-js-bundle": "^3.6.0",
-        "deepmerge": "^4.2.2",
-        "dynamic-import-polyfill": "^0.1.1",
-        "es-module-shims": "^0.4.6",
-        "intersection-observer": "^0.7.0",
-        "parse5": "^5.1.1",
-        "regenerator-runtime": "^0.13.3",
-        "resize-observer-polyfill": "^1.5.1",
-        "systemjs": "^6.3.1",
-        "terser": "^4.6.7",
-        "whatwg-fetch": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/polyfills-loader/node_modules/es-module-shims": {
-      "version": "0.4.7",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/polyfills-loader/node_modules/intersection-observer": {
-      "version": "0.7.0",
-      "dev": true,
-      "license": "W3C-20150513"
-    },
-    "node_modules/polyfills-loader/node_modules/parse5": {
-      "version": "5.1.1",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/portfinder": {
       "version": "1.0.37",
       "dev": true,
@@ -20947,30 +18044,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/pseudomap": {
-      "version": "1.0.2",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/psl": {
-      "version": "1.15.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "punycode": "^2.3.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/lupomontero"
-      }
-    },
-    "node_modules/psl/node_modules/punycode": {
-      "version": "2.3.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/pug": {
       "version": "3.0.3",
       "dev": true,
@@ -21098,11 +18171,6 @@
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
       }
-    },
-    "node_modules/punycode": {
-      "version": "1.4.1",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/puppeteer": {
       "version": "15.5.0",
@@ -21236,14 +18304,6 @@
         "utf-8-validate": {
           "optional": true
         }
-      }
-    },
-    "node_modules/qjobs": {
-      "version": "1.2.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.9"
       }
     },
     "node_modules/qs": {
@@ -21395,92 +18455,6 @@
     "node_modules/react-is": {
       "version": "16.13.1",
       "license": "MIT"
-    },
-    "node_modules/read-pkg": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "load-json-file": "^4.0.0",
-        "normalize-package-data": "^2.3.2",
-        "path-type": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/read-pkg-up": {
-      "version": "4.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "find-up": "^3.0.0",
-        "read-pkg": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/read-pkg-up/node_modules/find-up": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "locate-path": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/read-pkg-up/node_modules/locate-path": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "p-locate": "^3.0.0",
-        "path-exists": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/read-pkg-up/node_modules/p-locate": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "p-limit": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/read-pkg-up/node_modules/path-exists": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/read-pkg/node_modules/path-type": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "pify": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/read-pkg/node_modules/pify": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
     },
     "node_modules/read-yaml-file": {
       "version": "1.1.0",
@@ -21799,28 +18773,6 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/remark-parse": {
-      "version": "4.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "collapse-white-space": "^1.0.2",
-        "is-alphabetical": "^1.0.0",
-        "is-decimal": "^1.0.0",
-        "is-whitespace-character": "^1.0.0",
-        "is-word-character": "^1.0.0",
-        "markdown-escapes": "^1.0.0",
-        "parse-entities": "^1.0.2",
-        "repeat-string": "^1.5.4",
-        "state-toggle": "^1.0.0",
-        "trim": "0.0.1",
-        "trim-trailing-lines": "^1.0.0",
-        "unherit": "^1.0.4",
-        "unist-util-remove-position": "^1.0.0",
-        "vfile-location": "^2.0.0",
-        "xtend": "^4.0.1"
-      }
-    },
     "node_modules/remove-markdown": {
       "version": "0.2.2",
       "license": "MIT"
@@ -21839,52 +18791,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10"
-      }
-    },
-    "node_modules/replace-ext": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
-    "node_modules/request": {
-      "version": "2.88.2",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "aws-sign2": "~0.7.0",
-        "aws4": "^1.8.0",
-        "caseless": "~0.12.0",
-        "combined-stream": "~1.0.6",
-        "extend": "~3.0.2",
-        "forever-agent": "~0.6.1",
-        "form-data": "~2.3.2",
-        "har-validator": "~5.1.3",
-        "http-signature": "~1.2.0",
-        "is-typedarray": "~1.0.0",
-        "isstream": "~0.1.2",
-        "json-stringify-safe": "~5.0.1",
-        "mime-types": "~2.1.19",
-        "oauth-sign": "~0.9.0",
-        "performance-now": "^2.1.0",
-        "qs": "~6.5.2",
-        "safe-buffer": "^5.1.2",
-        "tough-cookie": "~2.5.0",
-        "tunnel-agent": "^0.6.0",
-        "uuid": "^3.3.2"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/request/node_modules/qs": {
-      "version": "6.5.3",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.6"
       }
     },
     "node_modules/require-directory": {
@@ -23573,34 +20479,6 @@
         "signal-exit": "^4.0.1"
       }
     },
-    "node_modules/spdx-correct": {
-      "version": "3.2.0",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "spdx-expression-parse": "^3.0.0",
-        "spdx-license-ids": "^3.0.0"
-      }
-    },
-    "node_modules/spdx-exceptions": {
-      "version": "2.5.0",
-      "dev": true,
-      "license": "CC-BY-3.0"
-    },
-    "node_modules/spdx-expression-parse": {
-      "version": "3.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "spdx-exceptions": "^2.1.0",
-        "spdx-license-ids": "^3.0.0"
-      }
-    },
-    "node_modules/spdx-license-ids": {
-      "version": "3.0.22",
-      "dev": true,
-      "license": "CC0-1.0"
-    },
     "node_modules/split-on-first": {
       "version": "1.1.0",
       "dev": true,
@@ -23659,30 +20537,6 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
-    "node_modules/sshpk": {
-      "version": "1.18.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "asn1": "~0.2.3",
-        "assert-plus": "^1.0.0",
-        "bcrypt-pbkdf": "^1.0.0",
-        "dashdash": "^1.12.0",
-        "ecc-jsbn": "~0.1.1",
-        "getpass": "^0.1.1",
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.0.2",
-        "tweetnacl": "~0.14.0"
-      },
-      "bin": {
-        "sshpk-conv": "bin/sshpk-conv",
-        "sshpk-sign": "bin/sshpk-sign",
-        "sshpk-verify": "bin/sshpk-verify"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/stable-hash": {
       "version": "0.0.5",
       "license": "MIT"
@@ -23693,15 +20547,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=16"
-      }
-    },
-    "node_modules/state-toggle": {
-      "version": "1.0.3",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/static-extend": {
@@ -23790,37 +20635,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10"
-      }
-    },
-    "node_modules/streamroller": {
-      "version": "1.0.6",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "async": "^2.6.2",
-        "date-format": "^2.0.0",
-        "debug": "^3.2.6",
-        "fs-extra": "^7.0.1",
-        "lodash": "^4.17.14"
-      },
-      "engines": {
-        "node": ">=6.0"
-      }
-    },
-    "node_modules/streamroller/node_modules/async": {
-      "version": "2.6.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "lodash": "^4.17.14"
-      }
-    },
-    "node_modules/streamroller/node_modules/debug": {
-      "version": "3.2.7",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.1"
       }
     },
     "node_modules/streamsearch": {
@@ -24813,61 +21627,9 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/test-exclude": {
-      "version": "5.2.3",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "glob": "^7.1.3",
-        "minimatch": "^3.0.4",
-        "read-pkg-up": "^4.0.0",
-        "require-main-filename": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/test-exclude/node_modules/glob": {
-      "version": "7.2.3",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/text-table": {
       "version": "0.2.0",
       "license": "MIT"
-    },
-    "node_modules/thenify": {
-      "version": "3.3.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "any-promise": "^1.0.0"
-      }
-    },
-    "node_modules/thenify-all": {
-      "version": "1.6.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "thenify": ">= 3.1.0 < 4"
-      },
-      "engines": {
-        "node": ">=0.8"
-      }
     },
     "node_modules/through": {
       "version": "2.3.8",
@@ -24886,21 +21648,6 @@
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
-    },
-    "node_modules/tmp": {
-      "version": "0.2.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "rimraf": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8.17.0"
-      }
-    },
-    "node_modules/to-array": {
-      "version": "0.1.4",
-      "dev": true
     },
     "node_modules/to-buffer": {
       "version": "1.2.1",
@@ -25007,64 +21754,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/tough-cookie": {
-      "version": "2.5.0",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "psl": "^1.1.28",
-        "punycode": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
-    "node_modules/tough-cookie/node_modules/punycode": {
-      "version": "2.3.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/tr46": {
-      "version": "1.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "punycode": "^2.1.0"
-      }
-    },
-    "node_modules/tr46/node_modules/punycode": {
-      "version": "2.3.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/trim": {
-      "version": "0.0.1",
-      "dev": true
-    },
-    "node_modules/trim-trailing-lines": {
-      "version": "1.1.4",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/trough": {
-      "version": "1.0.5",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
     "node_modules/truncate-utf8-bytes": {
       "version": "1.0.2",
       "license": "WTFPL",
@@ -25161,22 +21850,6 @@
       "engines": {
         "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
       }
-    },
-    "node_modules/tunnel-agent": {
-      "version": "0.6.0",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "safe-buffer": "^5.0.1"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/tweetnacl": {
-      "version": "0.14.5",
-      "dev": true,
-      "license": "Unlicense"
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -25527,19 +22200,6 @@
       "version": "6.21.0",
       "license": "MIT"
     },
-    "node_modules/unherit": {
-      "version": "1.1.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.0",
-        "xtend": "^4.0.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.1",
       "dev": true,
@@ -25576,19 +22236,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/unified": {
-      "version": "6.2.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "bail": "^1.0.0",
-        "extend": "^3.0.0",
-        "is-plain-obj": "^1.1.0",
-        "trough": "^1.0.0",
-        "vfile": "^2.0.0",
-        "x-is-string": "^0.1.0"
-      }
-    },
     "node_modules/union-value": {
       "version": "1.0.1",
       "dev": true,
@@ -25601,44 +22248,6 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/unist-util-is": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/unist-util-remove-position": {
-      "version": "1.1.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "unist-util-visit": "^1.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/unist-util-stringify-position": {
-      "version": "1.1.2",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/unist-util-visit": {
-      "version": "1.4.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "unist-util-visit-parents": "^2.0.0"
-      }
-    },
-    "node_modules/unist-util-visit-parents": {
-      "version": "2.1.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "unist-util-is": "^3.0.0"
       }
     },
     "node_modules/universalify": {
@@ -25807,40 +22416,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/useragent": {
-      "version": "2.3.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "lru-cache": "4.1.x",
-        "tmp": "0.0.x"
-      }
-    },
-    "node_modules/useragent/node_modules/lru-cache": {
-      "version": "4.1.5",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "pseudomap": "^1.0.2",
-        "yallist": "^2.1.2"
-      }
-    },
-    "node_modules/useragent/node_modules/tmp": {
-      "version": "0.0.33",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "os-tmpdir": "~1.0.2"
-      },
-      "engines": {
-        "node": ">=0.6.0"
-      }
-    },
-    "node_modules/useragent/node_modules/yallist": {
-      "version": "2.1.2",
-      "dev": true,
-      "license": "ISC"
-    },
     "node_modules/utf8-byte-length": {
       "version": "1.0.5",
       "license": "(WTFPL OR MIT)"
@@ -25855,14 +22430,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
-      }
-    },
-    "node_modules/uuid": {
-      "version": "3.4.0",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "uuid": "bin/uuid"
       }
     },
     "node_modules/uvu": {
@@ -25904,74 +22471,11 @@
       "version": "1.0.9",
       "dev": true
     },
-    "node_modules/validate-npm-package-license": {
-      "version": "3.0.4",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "spdx-correct": "^3.0.0",
-        "spdx-expression-parse": "^3.0.0"
-      }
-    },
     "node_modules/vary": {
       "version": "1.1.2",
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/verror": {
-      "version": "1.10.0",
-      "dev": true,
-      "engines": [
-        "node >=0.6.0"
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "^1.0.0",
-        "core-util-is": "1.0.2",
-        "extsprintf": "^1.2.0"
-      }
-    },
-    "node_modules/verror/node_modules/core-util-is": {
-      "version": "1.0.2",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/vfile": {
-      "version": "2.3.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-buffer": "^1.1.4",
-        "replace-ext": "1.0.0",
-        "unist-util-stringify-position": "^1.0.0",
-        "vfile-message": "^1.0.0"
-      }
-    },
-    "node_modules/vfile-location": {
-      "version": "2.0.6",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/vfile-message": {
-      "version": "1.1.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "unist-util-stringify-position": "^1.1.1"
-      }
-    },
-    "node_modules/void-elements": {
-      "version": "2.0.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/vscode-css-languageservice": {
@@ -26478,11 +22982,6 @@
         }
       }
     },
-    "node_modules/webidl-conversions": {
-      "version": "4.0.2",
-      "dev": true,
-      "license": "BSD-2-Clause"
-    },
     "node_modules/webpack": {
       "version": "5.101.3",
       "license": "MIT",
@@ -26561,16 +23060,6 @@
       "version": "3.6.20",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/whatwg-url": {
-      "version": "7.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "lodash.sortby": "^4.7.0",
-        "tr46": "^1.0.1",
-        "webidl-conversions": "^4.0.2"
-      }
     },
     "node_modules/which": {
       "version": "2.0.2",
@@ -26665,53 +23154,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/wide-align": {
-      "version": "1.1.3",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^1.0.2 || 2"
-      }
-    },
-    "node_modules/wide-align/node_modules/ansi-regex": {
-      "version": "3.0.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/wide-align/node_modules/is-fullwidth-code-point": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/wide-align/node_modules/string-width": {
-      "version": "2.1.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-fullwidth-code-point": "^2.0.0",
-        "strip-ansi": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/wide-align/node_modules/strip-ansi": {
-      "version": "4.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/wireit": {
@@ -26921,10 +23363,6 @@
         }
       }
     },
-    "node_modules/x-is-string": {
-      "version": "0.1.0",
-      "dev": true
-    },
     "node_modules/xmlhttprequest-ssl": {
       "version": "2.1.2",
       "dev": true,
@@ -26960,10 +23398,6 @@
       "engines": {
         "node": ">= 14"
       }
-    },
-    "node_modules/yamlparser": {
-      "version": "0.0.2",
-      "dev": true
     },
     "node_modules/yargs": {
       "version": "17.7.2",
@@ -27053,11 +23487,6 @@
       "dependencies": {
         "buffer-crc32": "~0.2.3"
       }
-    },
-    "node_modules/yeast": {
-      "version": "0.1.2",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/ylru": {
       "version": "1.4.0",
@@ -27206,7 +23635,7 @@
     },
     "packages/labs/analyzer": {
       "name": "@lit-labs/analyzer",
-      "version": "0.13.2",
+      "version": "0.14.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@parse5/tools": "^0.7.0",
@@ -27290,10 +23719,10 @@
     },
     "packages/labs/cli": {
       "name": "@lit-labs/cli",
-      "version": "0.6.5",
+      "version": "0.6.6",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@lit-labs/analyzer": "^0.13.0",
+        "@lit-labs/analyzer": "^0.14.0",
         "@lit-labs/gen-utils": "^0.3.0",
         "@lit/localize-tools": "^0.8.0",
         "chalk": "^5.0.1",
@@ -27318,7 +23747,7 @@
     },
     "packages/labs/cli-localize": {
       "name": "@lit-labs/cli-localize",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@lit/localize-tools": "^0.8.0"
@@ -27440,10 +23869,10 @@
     },
     "packages/labs/compiler": {
       "name": "@lit-labs/compiler",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@lit-labs/analyzer": "^0.13.0",
+        "@lit-labs/analyzer": "^0.14.0",
         "@parse5/tools": "^0.3.0",
         "lit-html": "^3.2.0",
         "parse5": "^7.1.2",
@@ -27491,10 +23920,10 @@
     },
     "packages/labs/eleventy-plugin-lit": {
       "name": "@lit-labs/eleventy-plugin-lit",
-      "version": "1.0.5",
+      "version": "1.0.6",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@lit-labs/ssr": "^3.3.0",
+        "@lit-labs/ssr": "^4.0.0",
         "lit": "^2.7.0 || ^3.0.0"
       },
       "devDependencies": {
@@ -27508,10 +23937,10 @@
     },
     "packages/labs/eslint-plugin": {
       "name": "eslint-plugin-lit",
-      "version": "0.0.3",
+      "version": "0.0.4",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@lit-labs/analyzer": "^0.13.0",
+        "@lit-labs/analyzer": "^0.14.0",
         "@typescript-eslint/utils": "^6.19.0",
         "typescript": "~5.9.0"
       },
@@ -27524,7 +23953,7 @@
     },
     "packages/labs/forms": {
       "name": "@lit-labs/forms",
-      "version": "0.0.0",
+      "version": "0.1.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@lit/reactive-element": "^2.0.0"
@@ -27536,10 +23965,10 @@
     },
     "packages/labs/gen-manifest": {
       "name": "@lit-labs/gen-manifest",
-      "version": "0.3.4",
+      "version": "0.3.5",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@lit-labs/analyzer": "^0.13.0",
+        "@lit-labs/analyzer": "^0.14.0",
         "@lit-labs/gen-utils": "^0.3.0",
         "custom-elements-manifest": "^2.0.0"
       },
@@ -27559,10 +23988,10 @@
     },
     "packages/labs/gen-utils": {
       "name": "@lit-labs/gen-utils",
-      "version": "0.3.3",
+      "version": "0.3.4",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@lit-labs/analyzer": "^0.13.0"
+        "@lit-labs/analyzer": "^0.14.0"
       },
       "devDependencies": {
         "@lit-internal/tests": "^0.0.1",
@@ -27574,10 +24003,10 @@
     },
     "packages/labs/gen-wrapper-angular": {
       "name": "@lit-labs/gen-wrapper-angular",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@lit-labs/analyzer": "^0.13.0",
+        "@lit-labs/analyzer": "^0.14.0",
         "@lit-labs/gen-utils": "^0.3.0"
       },
       "devDependencies": {
@@ -27592,10 +24021,10 @@
     },
     "packages/labs/gen-wrapper-react": {
       "name": "@lit-labs/gen-wrapper-react",
-      "version": "0.3.4",
+      "version": "0.3.5",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@lit-labs/analyzer": "^0.13.0",
+        "@lit-labs/analyzer": "^0.14.0",
         "@lit-labs/gen-utils": "^0.3.0"
       },
       "devDependencies": {
@@ -27607,10 +24036,10 @@
     },
     "packages/labs/gen-wrapper-vue": {
       "name": "@lit-labs/gen-wrapper-vue",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@lit-labs/analyzer": "^0.13.0",
+        "@lit-labs/analyzer": "^0.14.0",
         "@lit-labs/gen-utils": "^0.3.0",
         "@lit-labs/vue-utils": "^0.1.1"
       },
@@ -27623,7 +24052,7 @@
     },
     "packages/labs/motion": {
       "name": "@lit-labs/motion",
-      "version": "1.0.9",
+      "version": "1.1.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "lit": "^3.1.2",
@@ -27653,7 +24082,7 @@
     },
     "packages/labs/observers": {
       "name": "@lit-labs/observers",
-      "version": "2.0.6",
+      "version": "2.1.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@lit/reactive-element": "^1.0.0 || ^2.0.0"
@@ -27845,17 +24274,17 @@
     },
     "packages/labs/rollup-plugin-minify-html-literals": {
       "name": "@lit-labs/rollup-plugin-minify-html-literals",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "clean-css": "^4.2.1",
+        "clean-css": "^5.3.3",
         "html-minifier-next": "^2.1.3",
         "magic-string": "^0.30.11",
         "rollup-pluginutils": "^2.8.2",
         "typescript": "^2.9.2 || ^3.0.0 || ^4.0.0 || ^5.0.0"
       },
       "devDependencies": {
-        "@types/clean-css": "^4.2.0",
+        "@types/clean-css": "^4.2.11",
         "@types/html-minifier-next": "^1.1.0",
         "@types/node": "^22.17.0",
         "@types/sinon": "^5.0.1",
@@ -27866,6 +24295,17 @@
       },
       "peerDependencies": {
         "rollup": "^0.65.2 || ^1.0.0 || ^2.0.0 || ^3.0.0 || ^4.0.0"
+      }
+    },
+    "packages/labs/rollup-plugin-minify-html-literals/node_modules/clean-css": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-5.3.3.tgz",
+      "integrity": "sha512-D5J+kHaVb/wKSFcyyV75uCn8fiY4sV38XJoe4CUyGQ+mOU/fMVYUdH1hJC+CJQ5uY3EnW27SbJYS4X8BiLrAFg==",
+      "dependencies": {
+        "source-map": "~0.6.0"
+      },
+      "engines": {
+        "node": ">= 10.0"
       }
     },
     "packages/labs/rollup-plugin-minify-html-literals/node_modules/husky": {
@@ -27886,6 +24326,14 @@
       "version": "1.0.0",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "packages/labs/rollup-plugin-minify-html-literals/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -27933,7 +24381,7 @@
     },
     "packages/labs/signals": {
       "name": "@lit-labs/signals",
-      "version": "0.1.3",
+      "version": "0.2.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "lit": "^2.0.0 || ^3.0.0",
@@ -27945,11 +24393,12 @@
     },
     "packages/labs/ssr": {
       "name": "@lit-labs/ssr",
-      "version": "3.3.1",
+      "version": "4.0.0",
+      "extraneous": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@lit-labs/ssr-client": "^1.1.7",
-        "@lit-labs/ssr-dom-shim": "^1.3.0",
+        "@lit-labs/ssr-dom-shim": "^1.5.0",
         "@lit/reactive-element": "^2.0.4",
         "@parse5/tools": "^0.3.0",
         "enhanced-resolve": "^5.10.0",
@@ -27994,7 +24443,7 @@
     },
     "packages/labs/ssr-client": {
       "name": "@lit-labs/ssr-client",
-      "version": "1.1.7",
+      "version": "1.1.8",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@lit/reactive-element": "^2.0.4",
@@ -28007,15 +24456,15 @@
     },
     "packages/labs/ssr-dom-shim": {
       "name": "@lit-labs/ssr-dom-shim",
-      "version": "1.4.0",
+      "version": "1.5.1",
       "license": "BSD-3-Clause"
     },
     "packages/labs/ssr-react": {
       "name": "@lit-labs/ssr-react",
-      "version": "0.3.3",
+      "version": "0.3.4",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@lit-labs/ssr": "^3.3.0",
+        "@lit-labs/ssr": "^4.0.0",
         "@lit-labs/ssr-client": "^1.1.7"
       },
       "devDependencies": {
@@ -28033,16 +24482,6 @@
         "react": "17 || 18 || 19"
       }
     },
-    "packages/labs/ssr/node_modules/@types/node": {
-      "version": "20.19.23",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.23.tgz",
-      "integrity": "sha512-yIdlVVVHXpmqRhtyovZAcSy0MiPcYWGkoO4CGe/+jpP0hmNuihm4XhHbADpK++MsiLHP5MVlv+bcgdF99kSiFQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~6.21.0"
-      }
-    },
     "packages/labs/task": {
       "name": "@lit-labs/task",
       "version": "3.1.0",
@@ -28058,7 +24497,7 @@
     },
     "packages/labs/test-projects/test-element-a": {
       "name": "@lit-internal/test-element-a",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "dependencies": {
         "lit": "file:../../../lit"
       },
@@ -28068,9 +24507,9 @@
     },
     "packages/labs/test-projects/test-elements-react": {
       "name": "@lit-internal/test-elements-react",
-      "version": "1.0.9",
+      "version": "1.0.10",
       "dependencies": {
-        "@lit-internal/test-element-a": "1.0.1",
+        "@lit-internal/test-element-a": "1.0.2",
         "@lit/react": "1.0.8"
       },
       "peerDependencies": {
@@ -28084,10 +24523,10 @@
     },
     "packages/labs/testing": {
       "name": "@lit-labs/testing",
-      "version": "0.2.7",
+      "version": "0.2.8",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@lit-labs/ssr": "^3.3.0",
+        "@lit-labs/ssr": "^4.0.0",
         "@lit-labs/ssr-client": "^1.1.4",
         "@web/test-runner-commands": "^0.6.1",
         "@webcomponents/template-shadowroot": "^0.1.0",
@@ -28110,10 +24549,10 @@
     },
     "packages/labs/tsserver-plugin": {
       "name": "@lit-labs/tsserver-plugin",
-      "version": "0.0.1",
+      "version": "0.1.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@lit-labs/analyzer": "^0.13.1",
+        "@lit-labs/analyzer": "^0.14.0",
         "@parse5/tools": "^0.5.0",
         "typescript": "~5.9.0"
       },
@@ -28157,10 +24596,10 @@
     },
     "packages/labs/vscode-extension": {
       "name": "@lit-labs/vscode-extension",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "dependencies": {
-        "@lit-labs/analyzer": "^0.13.2",
-        "@lit-labs/tsserver-plugin": "^0.0.1"
+        "@lit-labs/analyzer": "^0.14.0",
+        "@lit-labs/tsserver-plugin": "^0.1.0"
       },
       "devDependencies": {
         "@types/node": "^22.17.0",
@@ -28185,7 +24624,7 @@
       }
     },
     "packages/lit": {
-      "version": "3.3.1",
+      "version": "3.3.2",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@lit/reactive-element": "^2.1.0",
@@ -28201,10 +24640,10 @@
       }
     },
     "packages/lit-element": {
-      "version": "4.2.1",
+      "version": "4.2.2",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@lit-labs/ssr-dom-shim": "^1.4.0",
+        "@lit-labs/ssr-dom-shim": "^1.5.0",
         "@lit/reactive-element": "^2.1.0",
         "lit-html": "^3.3.0"
       },
@@ -28218,7 +24657,7 @@
       }
     },
     "packages/lit-html": {
-      "version": "3.3.1",
+      "version": "3.3.2",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@types/trusted-types": "^2.0.2"
@@ -28313,7 +24752,7 @@
     },
     "packages/lit-starter-ts": {
       "name": "@lit/lit-starter-ts",
-      "version": "2.0.2",
+      "version": "2.0.3",
       "license": "BSD-3-Clause",
       "dependencies": {
         "lit": "^3.2.0"
@@ -28613,7 +25052,7 @@
     },
     "packages/localize-tools": {
       "name": "@lit/localize-tools",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@lit/localize": "^0.12.0",
@@ -28633,7 +25072,7 @@
       },
       "devDependencies": {
         "@lit-internal/tests": "0.0.1",
-        "@lit-labs/ssr": "^3.2.2",
+        "@lit-labs/ssr": "^4.0.0",
         "@lit/ts-transformers": "^2.0.1",
         "@types/fs-extra": "^9.0.1",
         "@types/minimist": "^1.2.0",
@@ -28699,7 +25138,7 @@
     },
     "packages/localize/examples/transform-js": {
       "name": "@lit-internal/localize-examples-transform-js",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "dependencies": {
         "@lit/localize": "^0.12.0",
         "lit": "^3.2.0"
@@ -28716,7 +25155,7 @@
     },
     "packages/localize/examples/transform-ts": {
       "name": "@lit-internal/localize-examples-transform-ts",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "dependencies": {
         "@lit/localize": "^0.12.0",
         "lit": "^3.2.0"
@@ -28889,10 +25328,10 @@
     },
     "packages/reactive-element": {
       "name": "@lit/reactive-element",
-      "version": "2.1.1",
+      "version": "2.1.2",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@lit-labs/ssr-dom-shim": "^1.4.0"
+        "@lit-labs/ssr-dom-shim": "^1.5.0"
       },
       "devDependencies": {
         "@babel/cli": "^7.22.10",
@@ -28936,7 +25375,7 @@
     },
     "packages/tests-typescript": {
       "name": "@lit-internal/tests-typescript",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "dependencies": {
         "lit": "*",
         "typescript": "5.9.2",

--- a/packages/labs/rollup-plugin-minify-html-literals/package.json
+++ b/packages/labs/rollup-plugin-minify-html-literals/package.json
@@ -62,7 +62,7 @@
   },
   "c8": {},
   "dependencies": {
-    "clean-css": "^4.2.1",
+    "clean-css": "^5.3.3",
     "html-minifier-next": "^2.1.3",
     "magic-string": "^0.30.11",
     "rollup-pluginutils": "^2.8.2",
@@ -72,7 +72,7 @@
     "rollup": "^0.65.2 || ^1.0.0 || ^2.0.0 || ^3.0.0 || ^4.0.0"
   },
   "devDependencies": {
-    "@types/clean-css": "^4.2.0",
+    "@types/clean-css": "^4.2.11",
     "@types/html-minifier-next": "^1.1.0",
     "@types/node": "^22.17.0",
     "@types/sinon": "^5.0.1",

--- a/packages/labs/rollup-plugin-minify-html-literals/src/lib/types/clean-css.ts
+++ b/packages/labs/rollup-plugin-minify-html-literals/src/lib/types/clean-css.ts
@@ -11,8 +11,12 @@ declare module 'clean-css/lib/options/optimization-level.js' {
 
   export interface OptimizationLevelOptions {
     [OptimizationLevel.Zero]: {};
+    // CleanCSS v5 removed the `transform` callback from its level-1 optimizer
+    // (it was used to intercept and rewrite individual property values). The
+    // remaining level-1 options are still supported and behave the same as in
+    // v4. Omitting 'transform' here keeps the return type accurate for v5.
     [OptimizationLevel.One]: Required<
-      Omit<Exclude<OptimizationsOptions['1'], undefined>, 'all'>
+      Omit<Exclude<OptimizationsOptions['1'], undefined>, 'all' | 'transform'>
     >;
     [OptimizationLevel.Two]: Required<
       Omit<Exclude<OptimizationsOptions['2'], undefined>, 'all'>


### PR DESCRIPTION
## Summary

Fixes #5207: CSS `@container` queries inside `css\`\`` tagged template literals are silently dropped by `@lit-labs/rollup-plugin-minify-html-literals` during build.

- Upgrade `clean-css` from `^4.2.1` → `^5.3.3`, which natively recognises `@container`, `@layer`, and `@scope` at-rules
- Remove the now-dead `transform` callback from `adjustMinifyCSSOptions()` (CleanCSS v5 removed this from its level-1 optimizer); update `types/clean-css.ts` accordingly
- Fix a semicolon-preservation regression: CleanCSS v5 collapses `;;` → `;` when a template part begins with `;` (the declaration separator between two interpolated CSS properties). The single remaining `;` is consumed by `splitHTMLByPlaceholder`, stripping it from the output. `minify-html-literals.ts` now restores the leading `;` for such parts, except when the part starts with `}` (a trailing semicolon before a closing brace that CleanCSS correctly removed)
- Add a regression test for `@container` that fails on CleanCSS v4 and passes on v5

## Files changed

| File | Change |
|---|---|
| `package.json` | `clean-css` v4 → v5, `@types/clean-css` → `^4.2.11` |
| `src/lib/strategy.ts` | Remove dead `transform` callback; add `?.` on `tidySelectors` |
| `src/lib/types/clean-css.ts` | Omit `'transform'` from `OptimizationLevel.One` type |
| `src/lib/minify-html-literals.ts` | Restore stripped `;` separator after CSS split |
| `src/test/minify-html-literals.spec.ts` | Add `@container` regression test |