### PR TITLE
fix(@lit-labs/ssr): fix event target stack corruption when FallbackRe…

### DIFF
--- a/packages/labs/ssr/src/test/test-files/render-test-module.ts
+++ b/packages/labs/ssr/src/test/test-files/render-test-module.ts
@@ -10,6 +10,7 @@ import {classMap} from 'lit/directives/class-map.js';
 import {ref, createRef} from 'lit/directives/ref.js';
 import {LitElement, css, PropertyValues} from 'lit';
 import {property, customElement} from 'lit/decorators.js';
+import {HTMLElement as SSRHTMLElement} from '@lit-labs/ssr-dom-shim';
 import type {HTMLElementWithEventMeta} from '@lit-labs/ssr-dom-shim';
 import {html as serverhtml} from '../../lib/server-template.js';
 export {digestForTemplateResult} from '@lit-labs/ssr-client';
@@ -441,6 +442,21 @@ export const eventNestedSlotWithUnnamedAndNamedSlotChild = html`<test-events-nes
 
 // prettier-ignore
 export const eventNestedSlotWithNamedAndUnnamedSlotChild = html`<test-events-nested-slots><test-events-child slot="a"></test-events-child><test-events-child></test-events-child></test-events-nested-slots>`;
+
+// A plain HTMLElement custom element with no shadow DOM. During SSR this is
+// handled by FallbackRenderer, since LitElementRenderer only matches LitElement
+// subclasses. This exercises the event target stack path through an element
+// that has no ElementRenderer-provided shadow root.
+// We extend SSRHTMLElement (from the shim) rather than the global HTMLElement
+// so this class works in both shimmed and empty VM contexts.
+class TestFallbackWrapper extends SSRHTMLElement {}
+customElements.define(
+  'test-fallback-wrapper',
+  TestFallbackWrapper as unknown as typeof HTMLElement
+);
+
+// prettier-ignore
+export const eventParentWithFallbackWrapper = html`<test-events-parent value="fallback-test"><test-fallback-wrapper><test-events-child></test-events-child></test-fallback-wrapper></test-events-parent>`;
 
 /* Directives */
 


### PR DESCRIPTION
## Summary

- **Fixes SSR event/context propagation broken by non-Lit custom element wrappers** (e.g. Web Awesome `<wa-page>`, issue #5178). When such elements are handled by `FallbackRenderer`, three stack push/pop mismatches corrupted `eventTargetStack` and `customElementHostStack`, causing `@lit/context` `context-request` events to bypass providers entirely.

- **`render-value.ts` — three stack-balance fixes:**
  - `custom-element-close`: conditionally pops `eventTargetStack` only when the renderer has an element instance (matching the conditional push in `custom-element-open`)
  - `custom-element-shadow`: moves `customElementHostStack.pop()` outside the `if (shadowContents !== undefined)` block so it always executes, not just when a shadow root is rendered
  - `slot-element-close`: conditionally pops `eventTargetStack` only when the shadow host renderer has an element instance (matching the conditional push in `slot-element-open`)

- **`element-renderer.ts` — `FallbackRenderer` creates a minimal element:** Uses the SSR dom shim to create an `HTMLElement` with the correct `localName`, so `FallbackRenderer`-handled elements participate in the SSR event target chain. Events from their descendants now bubble through them to ancestor context providers.
