### PR TITLE
[labs/analyzer] Warn instead of error on CSS module import resolution

### DIFF
--- a/.changeset/chubby-moose-remain.md
+++ b/.changeset/chubby-moose-remain.md
@@ -1,0 +1,5 @@
+---
+'@lit-labs/analyzer': patch
+---
+
+Warn instead of error on unresolved non-TypeScript or non-JavaScript imports

--- a/package-lock.json
+++ b/package-lock.json
@@ -27142,7 +27142,6 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@parse5/tools": "^0.7.0",
-        "enhanced-resolve": "^5.20.0",
         "lit-html": "^3.1.2",
         "package-json-type": "^1.0.3",
         "parse5": "^7.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4063,6 +4063,10 @@
       "resolved": "packages/internal-scripts",
       "link": true
     },
+    "node_modules/@lit-internal/test-css-styles": {
+      "resolved": "packages/labs/test-projects/test-css-styles",
+      "link": true
+    },
     "node_modules/@lit-internal/test-element-a": {
       "resolved": "packages/labs/test-projects/test-element-a",
       "link": true
@@ -7198,22 +7202,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/@wdio/config/node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
-      }
-    },
     "node_modules/@wdio/config/node_modules/undici-types": {
       "version": "5.26.5",
       "dev": true,
@@ -7320,22 +7308,6 @@
         "typescript": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@wdio/utils/node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
       }
     },
     "node_modules/@wdio/utils/node_modules/undici-types": {
@@ -11655,22 +11627,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/devtools/node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
-      }
-    },
     "node_modules/devtools/node_modules/undici-types": {
       "version": "5.26.5",
       "dev": true,
@@ -12180,11 +12136,13 @@
       }
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.18.3",
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.20.0.tgz",
+      "integrity": "sha512-/ce7+jQ1PQ6rVXwe+jKEg5hW5ciicHwIQUagZkp6IufBoY3YDgdTTY1azVs0qoRgVmvsNB+rbjLJxDAeHHtwsQ==",
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.4",
-        "tapable": "^2.2.0"
+        "tapable": "^2.3.0"
       },
       "engines": {
         "node": ">=10.13.0"
@@ -24603,10 +24561,16 @@
       }
     },
     "node_modules/tapable": {
-      "version": "2.2.2",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.0.tgz",
+      "integrity": "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==",
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/tar-fs": {
@@ -26244,22 +26208,6 @@
         }
       }
     },
-    "node_modules/webdriver/node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
-      }
-    },
     "node_modules/webdriver/node_modules/undici-types": {
       "version": "5.26.5",
       "dev": true,
@@ -26428,22 +26376,6 @@
       "version": "0.0.981744",
       "dev": true,
       "license": "BSD-3-Clause"
-    },
-    "node_modules/webdriverio/node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
-      }
     },
     "node_modules/webdriverio/node_modules/undici-types": {
       "version": "5.26.5",
@@ -27206,10 +27138,11 @@
     },
     "packages/labs/analyzer": {
       "name": "@lit-labs/analyzer",
-      "version": "0.13.2",
+      "version": "0.14.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@parse5/tools": "^0.7.0",
+        "enhanced-resolve": "^5.20.0",
         "lit-html": "^3.1.2",
         "package-json-type": "^1.0.3",
         "parse5": "^7.3.0",
@@ -27290,10 +27223,10 @@
     },
     "packages/labs/cli": {
       "name": "@lit-labs/cli",
-      "version": "0.6.5",
+      "version": "0.6.6",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@lit-labs/analyzer": "^0.13.0",
+        "@lit-labs/analyzer": "^0.14.0",
         "@lit-labs/gen-utils": "^0.3.0",
         "@lit/localize-tools": "^0.8.0",
         "chalk": "^5.0.1",
@@ -27318,7 +27251,7 @@
     },
     "packages/labs/cli-localize": {
       "name": "@lit-labs/cli-localize",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@lit/localize-tools": "^0.8.0"
@@ -27440,10 +27373,10 @@
     },
     "packages/labs/compiler": {
       "name": "@lit-labs/compiler",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@lit-labs/analyzer": "^0.13.0",
+        "@lit-labs/analyzer": "^0.14.0",
         "@parse5/tools": "^0.3.0",
         "lit-html": "^3.2.0",
         "parse5": "^7.1.2",
@@ -27491,10 +27424,10 @@
     },
     "packages/labs/eleventy-plugin-lit": {
       "name": "@lit-labs/eleventy-plugin-lit",
-      "version": "1.0.5",
+      "version": "1.0.6",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@lit-labs/ssr": "^3.3.0",
+        "@lit-labs/ssr": "^4.0.0",
         "lit": "^2.7.0 || ^3.0.0"
       },
       "devDependencies": {
@@ -27508,10 +27441,10 @@
     },
     "packages/labs/eslint-plugin": {
       "name": "eslint-plugin-lit",
-      "version": "0.0.3",
+      "version": "0.0.4",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@lit-labs/analyzer": "^0.13.0",
+        "@lit-labs/analyzer": "^0.14.0",
         "@typescript-eslint/utils": "^6.19.0",
         "typescript": "~5.9.0"
       },
@@ -27524,7 +27457,7 @@
     },
     "packages/labs/forms": {
       "name": "@lit-labs/forms",
-      "version": "0.0.0",
+      "version": "0.1.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@lit/reactive-element": "^2.0.0"
@@ -27536,10 +27469,10 @@
     },
     "packages/labs/gen-manifest": {
       "name": "@lit-labs/gen-manifest",
-      "version": "0.3.4",
+      "version": "0.3.5",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@lit-labs/analyzer": "^0.13.0",
+        "@lit-labs/analyzer": "^0.14.0",
         "@lit-labs/gen-utils": "^0.3.0",
         "custom-elements-manifest": "^2.0.0"
       },
@@ -27559,10 +27492,10 @@
     },
     "packages/labs/gen-utils": {
       "name": "@lit-labs/gen-utils",
-      "version": "0.3.3",
+      "version": "0.3.4",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@lit-labs/analyzer": "^0.13.0"
+        "@lit-labs/analyzer": "^0.14.0"
       },
       "devDependencies": {
         "@lit-internal/tests": "^0.0.1",
@@ -27574,10 +27507,10 @@
     },
     "packages/labs/gen-wrapper-angular": {
       "name": "@lit-labs/gen-wrapper-angular",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@lit-labs/analyzer": "^0.13.0",
+        "@lit-labs/analyzer": "^0.14.0",
         "@lit-labs/gen-utils": "^0.3.0"
       },
       "devDependencies": {
@@ -27592,10 +27525,10 @@
     },
     "packages/labs/gen-wrapper-react": {
       "name": "@lit-labs/gen-wrapper-react",
-      "version": "0.3.4",
+      "version": "0.3.5",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@lit-labs/analyzer": "^0.13.0",
+        "@lit-labs/analyzer": "^0.14.0",
         "@lit-labs/gen-utils": "^0.3.0"
       },
       "devDependencies": {
@@ -27607,10 +27540,10 @@
     },
     "packages/labs/gen-wrapper-vue": {
       "name": "@lit-labs/gen-wrapper-vue",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@lit-labs/analyzer": "^0.13.0",
+        "@lit-labs/analyzer": "^0.14.0",
         "@lit-labs/gen-utils": "^0.3.0",
         "@lit-labs/vue-utils": "^0.1.1"
       },
@@ -27623,7 +27556,7 @@
     },
     "packages/labs/motion": {
       "name": "@lit-labs/motion",
-      "version": "1.0.9",
+      "version": "1.1.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "lit": "^3.1.2",
@@ -27653,7 +27586,7 @@
     },
     "packages/labs/observers": {
       "name": "@lit-labs/observers",
-      "version": "2.0.6",
+      "version": "2.1.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@lit/reactive-element": "^1.0.0 || ^2.0.0"
@@ -27845,7 +27778,7 @@
     },
     "packages/labs/rollup-plugin-minify-html-literals": {
       "name": "@lit-labs/rollup-plugin-minify-html-literals",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "BSD-3-Clause",
       "dependencies": {
         "clean-css": "^4.2.1",
@@ -27933,7 +27866,7 @@
     },
     "packages/labs/signals": {
       "name": "@lit-labs/signals",
-      "version": "0.1.3",
+      "version": "0.2.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "lit": "^2.0.0 || ^3.0.0",
@@ -27945,11 +27878,11 @@
     },
     "packages/labs/ssr": {
       "name": "@lit-labs/ssr",
-      "version": "3.3.1",
+      "version": "4.0.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@lit-labs/ssr-client": "^1.1.7",
-        "@lit-labs/ssr-dom-shim": "^1.3.0",
+        "@lit-labs/ssr-dom-shim": "^1.5.0",
         "@lit/reactive-element": "^2.0.4",
         "@parse5/tools": "^0.3.0",
         "enhanced-resolve": "^5.10.0",
@@ -27994,7 +27927,7 @@
     },
     "packages/labs/ssr-client": {
       "name": "@lit-labs/ssr-client",
-      "version": "1.1.7",
+      "version": "1.1.8",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@lit/reactive-element": "^2.0.4",
@@ -28007,15 +27940,15 @@
     },
     "packages/labs/ssr-dom-shim": {
       "name": "@lit-labs/ssr-dom-shim",
-      "version": "1.4.0",
+      "version": "1.5.1",
       "license": "BSD-3-Clause"
     },
     "packages/labs/ssr-react": {
       "name": "@lit-labs/ssr-react",
-      "version": "0.3.3",
+      "version": "0.3.4",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@lit-labs/ssr": "^3.3.0",
+        "@lit-labs/ssr": "^4.0.0",
         "@lit-labs/ssr-client": "^1.1.7"
       },
       "devDependencies": {
@@ -28056,9 +27989,13 @@
         "lit": "^3.0.0"
       }
     },
+    "packages/labs/test-projects/test-css-styles": {
+      "name": "@lit-internal/test-css-styles",
+      "version": "1.0.0"
+    },
     "packages/labs/test-projects/test-element-a": {
       "name": "@lit-internal/test-element-a",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "dependencies": {
         "lit": "file:../../../lit"
       },
@@ -28068,9 +28005,9 @@
     },
     "packages/labs/test-projects/test-elements-react": {
       "name": "@lit-internal/test-elements-react",
-      "version": "1.0.9",
+      "version": "1.0.10",
       "dependencies": {
-        "@lit-internal/test-element-a": "1.0.1",
+        "@lit-internal/test-element-a": "1.0.2",
         "@lit/react": "1.0.8"
       },
       "peerDependencies": {
@@ -28084,10 +28021,10 @@
     },
     "packages/labs/testing": {
       "name": "@lit-labs/testing",
-      "version": "0.2.7",
+      "version": "0.2.8",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@lit-labs/ssr": "^3.3.0",
+        "@lit-labs/ssr": "^4.0.0",
         "@lit-labs/ssr-client": "^1.1.4",
         "@web/test-runner-commands": "^0.6.1",
         "@webcomponents/template-shadowroot": "^0.1.0",
@@ -28110,10 +28047,10 @@
     },
     "packages/labs/tsserver-plugin": {
       "name": "@lit-labs/tsserver-plugin",
-      "version": "0.0.1",
+      "version": "0.1.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@lit-labs/analyzer": "^0.13.1",
+        "@lit-labs/analyzer": "^0.14.0",
         "@parse5/tools": "^0.5.0",
         "typescript": "~5.9.0"
       },
@@ -28157,10 +28094,10 @@
     },
     "packages/labs/vscode-extension": {
       "name": "@lit-labs/vscode-extension",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "dependencies": {
-        "@lit-labs/analyzer": "^0.13.2",
-        "@lit-labs/tsserver-plugin": "^0.0.1"
+        "@lit-labs/analyzer": "^0.14.0",
+        "@lit-labs/tsserver-plugin": "^0.1.0"
       },
       "devDependencies": {
         "@types/node": "^22.17.0",
@@ -28185,7 +28122,7 @@
       }
     },
     "packages/lit": {
-      "version": "3.3.1",
+      "version": "3.3.2",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@lit/reactive-element": "^2.1.0",
@@ -28201,10 +28138,10 @@
       }
     },
     "packages/lit-element": {
-      "version": "4.2.1",
+      "version": "4.2.2",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@lit-labs/ssr-dom-shim": "^1.4.0",
+        "@lit-labs/ssr-dom-shim": "^1.5.0",
         "@lit/reactive-element": "^2.1.0",
         "lit-html": "^3.3.0"
       },
@@ -28218,7 +28155,7 @@
       }
     },
     "packages/lit-html": {
-      "version": "3.3.1",
+      "version": "3.3.2",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@types/trusted-types": "^2.0.2"
@@ -28313,7 +28250,7 @@
     },
     "packages/lit-starter-ts": {
       "name": "@lit/lit-starter-ts",
-      "version": "2.0.2",
+      "version": "2.0.3",
       "license": "BSD-3-Clause",
       "dependencies": {
         "lit": "^3.2.0"
@@ -28613,7 +28550,7 @@
     },
     "packages/localize-tools": {
       "name": "@lit/localize-tools",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@lit/localize": "^0.12.0",
@@ -28633,7 +28570,7 @@
       },
       "devDependencies": {
         "@lit-internal/tests": "0.0.1",
-        "@lit-labs/ssr": "^3.2.2",
+        "@lit-labs/ssr": "^4.0.0",
         "@lit/ts-transformers": "^2.0.1",
         "@types/fs-extra": "^9.0.1",
         "@types/minimist": "^1.2.0",
@@ -28699,7 +28636,7 @@
     },
     "packages/localize/examples/transform-js": {
       "name": "@lit-internal/localize-examples-transform-js",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "dependencies": {
         "@lit/localize": "^0.12.0",
         "lit": "^3.2.0"
@@ -28716,7 +28653,7 @@
     },
     "packages/localize/examples/transform-ts": {
       "name": "@lit-internal/localize-examples-transform-ts",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "dependencies": {
         "@lit/localize": "^0.12.0",
         "lit": "^3.2.0"
@@ -28889,10 +28826,10 @@
     },
     "packages/reactive-element": {
       "name": "@lit/reactive-element",
-      "version": "2.1.1",
+      "version": "2.1.2",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@lit-labs/ssr-dom-shim": "^1.4.0"
+        "@lit-labs/ssr-dom-shim": "^1.5.0"
       },
       "devDependencies": {
         "@babel/cli": "^7.22.10",
@@ -28936,7 +28873,7 @@
     },
     "packages/tests-typescript": {
       "name": "@lit-internal/tests-typescript",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "dependencies": {
         "lit": "*",
         "typescript": "5.9.2",

--- a/packages/labs/analyzer/package.json
+++ b/packages/labs/analyzer/package.json
@@ -58,7 +58,7 @@
       ]
     },
     "test:server": {
-      "command": "node --enable-source-maps --test-reporter=spec --test test/server/*_test.js test/server/**/*_test.js",
+      "command": "node --enable-source-maps --test-reporter=spec --test test/server/**/*_test.js",
       "dependencies": [
         "build"
       ],
@@ -97,6 +97,7 @@
   },
   "dependencies": {
     "@parse5/tools": "^0.7.0",
+    "enhanced-resolve": "^5.20.0",
     "lit-html": "^3.1.2",
     "package-json-type": "^1.0.3",
     "parse5": "^7.3.0",

--- a/packages/labs/analyzer/package.json
+++ b/packages/labs/analyzer/package.json
@@ -97,7 +97,6 @@
   },
   "dependencies": {
     "@parse5/tools": "^0.7.0",
-    "enhanced-resolve": "^5.20.0",
     "lit-html": "^3.1.2",
     "package-json-type": "^1.0.3",
     "parse5": "^7.3.0",

--- a/packages/labs/analyzer/src/lib/javascript/modules.ts
+++ b/packages/labs/analyzer/src/lib/javascript/modules.ts
@@ -11,6 +11,7 @@
  */
 
 import type ts from 'typescript';
+import enhancedResolve from 'enhanced-resolve';
 import {
   Module,
   AnalyzerInterface,
@@ -362,18 +363,35 @@ export const getPathForModuleSpecifier = (
     analyzer.commandLine.options,
     analyzer.fs
   ).resolvedModule?.resolvedFileName;
-  if (resolvedPath === undefined) {
-    analyzer.addDiagnostic(
-      createDiagnostic({
-        typescript: analyzer.typescript,
-        node: location,
-        message: `Could not resolve specifier ${specifier} to filesystem path.`,
-        category: analyzer.typescript.DiagnosticCategory.Error,
-      })
-    );
-    return undefined;
+  if (resolvedPath !== undefined) {
+    return analyzer.path.normalize(resolvedPath) as AbsolutePath;
   }
-  return analyzer.path.normalize(resolvedPath) as AbsolutePath;
+  // TypeScript's resolveModuleName doesn't resolve non-JS/TS files (e.g.
+  // CSS modules imported with `import ... with {type: 'css'}`). Fall back
+  // to enhanced-resolve which handles package exports, symlinks, etc.
+  const sourceDir = analyzer.path.dirname(location.getSourceFile().fileName);
+  try {
+    const resolved = enhancedResolve.create.sync({
+      extensions: [],
+      mainFields: ['module', 'main'],
+      conditionNames: ['import', 'default'],
+      fullySpecified: true,
+    })(sourceDir, specifier);
+    if (typeof resolved === 'string') {
+      return analyzer.path.normalize(resolved) as AbsolutePath;
+    }
+  } catch {
+    // Fall through to diagnostic
+  }
+  analyzer.addDiagnostic(
+    createDiagnostic({
+      typescript: analyzer.typescript,
+      node: location,
+      message: `Could not resolve specifier ${specifier} to filesystem path.`,
+      category: analyzer.typescript.DiagnosticCategory.Error,
+    })
+  );
+  return undefined;
 };
 
 /**

--- a/packages/labs/analyzer/src/lib/javascript/modules.ts
+++ b/packages/labs/analyzer/src/lib/javascript/modules.ts
@@ -11,7 +11,6 @@
  */
 
 import type ts from 'typescript';
-import enhancedResolve from 'enhanced-resolve';
 import {
   Module,
   AnalyzerInterface,
@@ -350,6 +349,26 @@ export const getPathForModuleSpecifierExpression = (
 };
 
 /**
+ * Extensions that TypeScript can resolve and the analyzer can process.
+ * Specifiers ending in any other extension that don't resolve to a file
+ * generate a warning.
+ */
+const analyzableExtensions = [
+  '.js',
+  '.mjs',
+  '.cjs',
+  '.ts',
+  '.mts',
+  '.cts',
+  '.tsx',
+  '.jsx',
+];
+
+const hasNonAnalyzableExtension = (specifier: string) =>
+  specifier.includes('.') &&
+  !analyzableExtensions.some((e) => specifier.endsWith(e));
+
+/**
  * Resolve a module specifier to an absolute path on disk.
  */
 export const getPathForModuleSpecifier = (
@@ -367,21 +386,18 @@ export const getPathForModuleSpecifier = (
     return analyzer.path.normalize(resolvedPath) as AbsolutePath;
   }
   // TypeScript's resolveModuleName doesn't resolve non-JS/TS files (e.g.
-  // CSS modules imported with `import ... with {type: 'css'}`). Fall back
-  // to enhanced-resolve which handles package exports, symlinks, etc.
-  const sourceDir = analyzer.path.dirname(location.getSourceFile().fileName);
-  try {
-    const resolved = enhancedResolve.create.sync({
-      extensions: [],
-      mainFields: ['module', 'main'],
-      conditionNames: ['import', 'default'],
-      fullySpecified: true,
-    })(sourceDir, specifier);
-    if (typeof resolved === 'string') {
-      return analyzer.path.normalize(resolved) as AbsolutePath;
-    }
-  } catch {
-    // Fall through to diagnostic
+  // CSS modules imported with `import ... with {type: 'css'}`). Emit a
+  // warning and return undefined since the analyzer can't analyze those files.
+  if (hasNonAnalyzableExtension(specifier)) {
+    analyzer.addDiagnostic(
+      createDiagnostic({
+        typescript: analyzer.typescript,
+        node: location,
+        message: `Could not resolve specifier ${specifier} to an analyzable file.`,
+        category: analyzer.typescript.DiagnosticCategory.Warning,
+      })
+    );
+    return undefined;
   }
   analyzer.addDiagnostic(
     createDiagnostic({

--- a/packages/labs/analyzer/src/test/server/javascript/modules_test.ts
+++ b/packages/labs/analyzer/src/test/server/javascript/modules_test.ts
@@ -19,13 +19,13 @@ import {
 
 for (const lang of languages) {
   suite(`Module tests (${lang})`, () => {
-    const {module} = setupAnalyzerForTestWithModule(
-      lang,
-      'modules',
-      'module-a'
-    );
-
     test('Dependencies correctly analyzed', () => {
+      const {module} = setupAnalyzerForTestWithModule(
+        lang,
+        'modules',
+        'module-a'
+      );
+
       const getMonorepoSubpath = (f: string) =>
         f?.slice(f.lastIndexOf('packages' + path.sep));
       const expectedDeps = new Set([
@@ -40,6 +40,58 @@ for (const lang of languages) {
         path.normalize(`packages/lit/index.d.ts`),
       ]);
       assert.equal(expectedDeps.size, module.dependencies.size);
+      for (const d of module.dependencies) {
+        assert.ok(
+          expectedDeps.has(getMonorepoSubpath(d)),
+          `${getMonorepoSubpath(d)} not in\n ${Array.from(expectedDeps).join(
+            '\n'
+          )}`
+        );
+      }
+    });
+
+    test('Handles relative CSS imports', () => {
+      const {module} = setupAnalyzerForTestWithModule(
+        lang,
+        'css-modules',
+        'element-a'
+      );
+
+      const getMonorepoSubpath = (f: string) =>
+        f?.slice(f.lastIndexOf('packages' + path.sep));
+      const expectedDeps = new Set([
+        path.normalize(
+          `packages/labs/analyzer/test-files/${lang}/css-modules/${lang === 'ts' ? 'src/' : ''}element-a.css`
+        ),
+        path.normalize(`packages/lit/index.d.ts`),
+      ]);
+      assert.equal(module.dependencies.size, expectedDeps.size);
+      for (const d of module.dependencies) {
+        assert.ok(
+          expectedDeps.has(getMonorepoSubpath(d)),
+          `${getMonorepoSubpath(d)} not in\n ${Array.from(expectedDeps).join(
+            '\n'
+          )}`
+        );
+      }
+    });
+
+    test('Handles cross-package CSS imports', () => {
+      const {module} = setupAnalyzerForTestWithModule(
+        lang,
+        'css-modules',
+        'element-b'
+      );
+
+      const getMonorepoSubpath = (f: string) =>
+        f?.slice(f.lastIndexOf('packages' + path.sep));
+      const expectedDeps = new Set([
+        path.normalize(
+          `packages/labs/test-projects/test-css-styles/button.css`
+        ),
+        path.normalize(`packages/lit/index.d.ts`),
+      ]);
+      assert.equal(module.dependencies.size, expectedDeps.size);
       for (const d of module.dependencies) {
         assert.ok(
           expectedDeps.has(getMonorepoSubpath(d)),

--- a/packages/labs/analyzer/src/test/server/javascript/modules_test.ts
+++ b/packages/labs/analyzer/src/test/server/javascript/modules_test.ts
@@ -50,21 +50,27 @@ for (const lang of languages) {
       }
     });
 
-    test('Handles relative CSS imports', () => {
-      const {module} = setupAnalyzerForTestWithModule(
-        lang,
-        'css-modules',
-        'element-a'
-      );
+    test('Handles relative CSS imports without errors', () => {
+      const {
+        module,
+        analyzer,
+        typescript: ts,
+      } = setupAnalyzerForTestWithModule(lang, 'css-modules', 'element-a', {
+        throwOnWarnings: false,
+      });
 
+      // CSS imports should produce warnings, not errors
+      const diagnostics = [...analyzer.getDiagnostics()];
+      assert.ok(diagnostics.length > 0, 'Expected warnings for CSS imports');
+      for (const d of diagnostics) {
+        assert.equal(d.category, ts.DiagnosticCategory.Warning);
+      }
+
+      // CSS files are not tracked as dependencies (the analyzer can't
+      // analyze them), but the import should not cause an error
       const getMonorepoSubpath = (f: string) =>
         f?.slice(f.lastIndexOf('packages' + path.sep));
-      const expectedDeps = new Set([
-        path.normalize(
-          `packages/labs/analyzer/test-files/${lang}/css-modules/${lang === 'ts' ? 'src/' : ''}element-a.css`
-        ),
-        path.normalize(`packages/lit/index.d.ts`),
-      ]);
+      const expectedDeps = new Set([path.normalize(`packages/lit/index.d.ts`)]);
       assert.equal(module.dependencies.size, expectedDeps.size);
       for (const d of module.dependencies) {
         assert.ok(
@@ -76,21 +82,25 @@ for (const lang of languages) {
       }
     });
 
-    test('Handles cross-package CSS imports', () => {
-      const {module} = setupAnalyzerForTestWithModule(
-        lang,
-        'css-modules',
-        'element-b'
-      );
+    test('Handles cross-package CSS imports without errors', () => {
+      const {
+        module,
+        analyzer,
+        typescript: ts,
+      } = setupAnalyzerForTestWithModule(lang, 'css-modules', 'element-b', {
+        throwOnWarnings: false,
+      });
+
+      // CSS imports should produce warnings, not errors
+      const diagnostics = [...analyzer.getDiagnostics()];
+      assert.ok(diagnostics.length > 0, 'Expected warnings for CSS imports');
+      for (const d of diagnostics) {
+        assert.equal(d.category, ts.DiagnosticCategory.Warning);
+      }
 
       const getMonorepoSubpath = (f: string) =>
         f?.slice(f.lastIndexOf('packages' + path.sep));
-      const expectedDeps = new Set([
-        path.normalize(
-          `packages/labs/test-projects/test-css-styles/button.css`
-        ),
-        path.normalize(`packages/lit/index.d.ts`),
-      ]);
+      const expectedDeps = new Set([path.normalize(`packages/lit/index.d.ts`)]);
       assert.equal(module.dependencies.size, expectedDeps.size);
       for (const d of module.dependencies) {
         assert.ok(

--- a/packages/labs/analyzer/src/test/server/utils.ts
+++ b/packages/labs/analyzer/src/test/server/utils.ts
@@ -204,14 +204,29 @@ export class InMemoryAnalyzer extends Analyzer {
   }
 }
 
-export const setupAnalyzerForTest = (lang: Language, pkg: string) => {
+interface SetupOptions {
+  /**
+   * Whether to throw if there are any warnings in the diagnostics. Defaults to
+   * true.
+   */
+  throwOnWarnings?: boolean;
+}
+
+export const setupAnalyzerForTest = (
+  lang: Language,
+  pkg: string,
+  {throwOnWarnings = true}: SetupOptions = {}
+) => {
   const packagePath = fileURLToPath(
     new URL(`../../test-files/${lang}/${pkg}`, import.meta.url).href
   ) as AbsolutePath;
   const analyzer = createPackageAnalyzer(packagePath);
   const diagnostics = [...analyzer.getDiagnostics()];
-  if (diagnostics.length > 0) {
-    throw makeDiagnosticError(diagnostics);
+  const errors = throwOnWarnings
+    ? diagnostics
+    : diagnostics.filter((d) => d.category === ts.DiagnosticCategory.Error);
+  if (errors.length > 0) {
+    throw makeDiagnosticError(errors);
   }
   const getModule = (name: string) =>
     analyzer.getModule(
@@ -231,9 +246,10 @@ export const setupAnalyzerForTest = (lang: Language, pkg: string) => {
 export const setupAnalyzerForTestWithModule = (
   lang: Language,
   pkg: string,
-  module: string
+  module: string,
+  options?: SetupOptions
 ) => {
-  const result = setupAnalyzerForTest(lang, pkg);
+  const result = setupAnalyzerForTest(lang, pkg, options);
   return {
     ...result,
     module: result.getModule(module),

--- a/packages/labs/analyzer/test-files/js/css-modules/element-a.css
+++ b/packages/labs/analyzer/test-files/js/css-modules/element-a.css
@@ -1,0 +1,4 @@
+:host {
+  display: block;
+  color: green;
+}

--- a/packages/labs/analyzer/test-files/js/css-modules/element-a.js
+++ b/packages/labs/analyzer/test-files/js/css-modules/element-a.js
@@ -1,0 +1,16 @@
+/**
+ * @license
+ * Copyright The Lit Project Authors.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import {LitElement, html} from 'lit';
+import styles from './element-a.css' with {type: 'css'};
+
+export class ElementA extends LitElement {
+  static styles = styles;
+
+  render() {
+    return html`<p>Hello CSS Modules</p>`;
+  }
+}

--- a/packages/labs/analyzer/test-files/js/css-modules/element-b.js
+++ b/packages/labs/analyzer/test-files/js/css-modules/element-b.js
@@ -1,0 +1,16 @@
+/**
+ * @license
+ * Copyright The Lit Project Authors.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import {LitElement, html} from 'lit';
+import styles from '@lit-internal/test-css-styles/button.css' with {type: 'css'};
+
+export class ElementB extends LitElement {
+  static styles = styles;
+
+  render() {
+    return html`<button>Click me</button>`;
+  }
+}

--- a/packages/labs/analyzer/test-files/js/css-modules/package.json
+++ b/packages/labs/analyzer/test-files/js/css-modules/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@lit-internal/test-css-modules",
+  "type": "module",
+  "dependencies": {
+    "lit": "^3.3.0",
+    "@lit-internal/test-css-styles": "1.0.0"
+  }
+}

--- a/packages/labs/analyzer/test-files/ts/css-modules/package.json
+++ b/packages/labs/analyzer/test-files/ts/css-modules/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@lit-internal/test-css-modules",
+  "type": "module",
+  "dependencies": {
+    "lit": "^3.3.0",
+    "@lit-internal/test-css-styles": "1.0.0"
+  }
+}

--- a/packages/labs/analyzer/test-files/ts/css-modules/src/css-modules.d.ts
+++ b/packages/labs/analyzer/test-files/ts/css-modules/src/css-modules.d.ts
@@ -1,0 +1,4 @@
+declare module '*.css' {
+  const stylesheet: CSSStyleSheet;
+  export default stylesheet;
+}

--- a/packages/labs/analyzer/test-files/ts/css-modules/src/element-a.css
+++ b/packages/labs/analyzer/test-files/ts/css-modules/src/element-a.css
@@ -1,0 +1,4 @@
+:host {
+  display: block;
+  color: green;
+}

--- a/packages/labs/analyzer/test-files/ts/css-modules/src/element-a.ts
+++ b/packages/labs/analyzer/test-files/ts/css-modules/src/element-a.ts
@@ -1,0 +1,16 @@
+/**
+ * @license
+ * Copyright The Lit Project Authors.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import {LitElement, html} from 'lit';
+import styles from './element-a.css' with {type: 'css'};
+
+export class ElementA extends LitElement {
+  static styles = styles;
+
+  render() {
+    return html`<p>Hello CSS Modules</p>`;
+  }
+}

--- a/packages/labs/analyzer/test-files/ts/css-modules/src/element-b.ts
+++ b/packages/labs/analyzer/test-files/ts/css-modules/src/element-b.ts
@@ -1,0 +1,16 @@
+/**
+ * @license
+ * Copyright The Lit Project Authors.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import {LitElement, html} from 'lit';
+import styles from '@lit-internal/test-css-styles/button.css' with {type: 'css'};
+
+export class ElementB extends LitElement {
+  static styles = styles;
+
+  render() {
+    return html`<button>Click me</button>`;
+  }
+}

--- a/packages/labs/analyzer/test-files/ts/css-modules/tsconfig.json
+++ b/packages/labs/analyzer/test-files/ts/css-modules/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "incremental": true,
+    "tsBuildInfoFile": ".tsbuildinfo",
+    "target": "es2024",
+    "lib": ["es2024", "DOM"],
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "types": [],
+    "rootDir": "./src",
+    "outDir": "./out",
+    "skipDefaultLibCheck": true,
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": []
+}

--- a/packages/labs/test-projects/test-css-styles/button.css
+++ b/packages/labs/test-projects/test-css-styles/button.css
@@ -1,0 +1,4 @@
+.button {
+  display: inline-flex;
+  padding: 8px 16px;
+}

--- a/packages/labs/test-projects/test-css-styles/package.json
+++ b/packages/labs/test-projects/test-css-styles/package.json
@@ -1,0 +1,6 @@
+{
+  "private": true,
+  "name": "@lit-internal/test-css-styles",
+  "version": "1.0.0",
+  "type": "module"
+}


### PR DESCRIPTION
Fixes #5261 

TypeScript's resolveModuleName() doesn't work for non-TS/TS imports, so when that fails we now check to see if TypeScript should have been able to resolve the name by checking the extension, and only report an error if the file was .js, .ts, .d.ts, etc. If the file is something like .css, we emit a wraning.

Added test packages for both relative and bare specifier imports including package exports and monorepo workspace symlinks.

A previous version of this PR used enhanced-resolve to actually resolve the file, but that didn't work in the browser. Hopefully a future version of TypeScript will be able to resolve .css files similar to how it can with .json files with the resolveJsonModule option.