### PR TITLE
[labs/gen-manifest] Emit attributes derived from reactive properties

### DIFF
--- a/.changeset/grumpy-islands-end.md
+++ b/.changeset/grumpy-islands-end.md
@@ -1,0 +1,5 @@
+---
+'@lit-labs/gen-manifest': patch
+---
+
+Emit attributes for LitElement properties

--- a/packages/labs/gen-manifest/goldens/test-element-a/custom-elements.json
+++ b/packages/labs/gen-manifest/goldens/test-element-a/custom-elements.json
@@ -17,7 +17,8 @@
               "kind": "field",
               "name": "foo",
               "privacy": "public",
-              "type": {"text": "string | undefined"}
+              "type": {"text": "string | undefined"},
+              "attribute": "foo"
             },
             {
               "kind": "field",
@@ -59,6 +60,9 @@
           ],
           "tagName": "element-a",
           "customElement": true,
+          "attributes": [
+            {"name": "foo", "type": {"text": "string"}, "fieldName": "foo"}
+          ],
           "events": [
             {
               "name": "a-changed",
@@ -235,7 +239,8 @@
               "kind": "field",
               "name": "foo",
               "privacy": "public",
-              "type": {"text": "string | undefined"}
+              "type": {"text": "string | undefined"},
+              "attribute": "foo"
             },
             {
               "kind": "method",
@@ -390,6 +395,9 @@
           ],
           "tagName": "element-events",
           "customElement": true,
+          "attributes": [
+            {"name": "foo", "type": {"text": "string"}, "fieldName": "foo"}
+          ],
           "events": [
             {
               "name": "string-custom-event",
@@ -640,28 +648,33 @@
               "name": "aStr",
               "privacy": "public",
               "type": {"text": "string"},
-              "default": "'aStr'"
+              "default": "'aStr'",
+              "attribute": "astr"
             },
             {
               "kind": "field",
               "name": "aNum",
               "privacy": "public",
               "type": {"text": "number"},
-              "default": "-1"
+              "default": "-1",
+              "attribute": "anum"
             },
             {
               "kind": "field",
               "name": "aBool",
               "privacy": "public",
               "type": {"text": "boolean"},
-              "default": "false"
+              "default": "false",
+              "attribute": "abool",
+              "reflects": true
             },
             {
               "kind": "field",
               "name": "aStrArray",
               "privacy": "public",
               "type": {"text": "string[]"},
-              "default": "['a', 'b']"
+              "default": "['a', 'b']",
+              "attribute": "astrarray"
             },
             {
               "kind": "field",
@@ -679,7 +692,8 @@
                   }
                 ]
               },
-              "default": "{\n    a: 'a',\n    b: -1,\n    c: false,\n    d: ['a', 'b'],\n    e: 'isUnknown',\n    strOrNum: 'strOrNum',\n  }"
+              "default": "{\n    a: 'a',\n    b: -1,\n    c: false,\n    d: ['a', 'b'],\n    e: 'isUnknown',\n    strOrNum: 'strOrNum',\n  }",
+              "attribute": "amytype"
             },
             {
               "kind": "field",
@@ -709,6 +723,25 @@
           ],
           "tagName": "element-props",
           "customElement": true,
+          "attributes": [
+            {"name": "astr", "type": {"text": "string"}, "fieldName": "aStr"},
+            {"name": "anum", "type": {"text": "number"}, "fieldName": "aNum"},
+            {
+              "name": "abool",
+              "type": {"text": "boolean"},
+              "fieldName": "aBool"
+            },
+            {
+              "name": "astrarray",
+              "type": {"text": "array"},
+              "fieldName": "aStrArray"
+            },
+            {
+              "name": "amytype",
+              "type": {"text": "object"},
+              "fieldName": "aMyType"
+            }
+          ],
           "events": [
             {
               "name": "a-changed",
@@ -746,7 +779,8 @@
               "name": "mainDefault",
               "privacy": "public",
               "type": {"text": "string"},
-              "default": "'mainDefault'"
+              "default": "'mainDefault'",
+              "attribute": "maindefault"
             },
             {
               "kind": "method",
@@ -768,7 +802,14 @@
             }
           ],
           "tagName": "element-slots",
-          "customElement": true
+          "customElement": true,
+          "attributes": [
+            {
+              "name": "maindefault",
+              "type": {"text": "string"},
+              "fieldName": "mainDefault"
+            }
+          ]
         }
       ],
       "exports": [
@@ -974,7 +1015,8 @@
               "kind": "field",
               "name": "foo",
               "privacy": "public",
-              "type": {"text": "string | undefined"}
+              "type": {"text": "string | undefined"},
+              "attribute": "foo"
             },
             {
               "kind": "field",
@@ -1016,6 +1058,9 @@
           ],
           "tagName": "element-sub",
           "customElement": true,
+          "attributes": [
+            {"name": "foo", "type": {"text": "string"}, "fieldName": "foo"}
+          ],
           "events": [
             {
               "name": "sub-changed",

--- a/packages/labs/gen-manifest/src/index.ts
+++ b/packages/labs/gen-manifest/src/index.ts
@@ -165,14 +165,52 @@ const convertCustomElementExport = (
   };
 };
 
+/**
+ * Converts reactive properties that have attributes to CEM Attribute entries.
+ */
+const convertReactivePropertiesToAttributes = (
+  declaration: LitElementDeclaration
+): cem.Attribute[] | undefined => {
+  const attributes: cem.Attribute[] = [];
+
+  for (const [propertyName, property] of declaration.reactiveProperties) {
+    if (property.attribute === false) {
+      continue;
+    }
+
+    const attributeName =
+      typeof property.attribute === 'string'
+        ? property.attribute
+        : propertyName.toLowerCase();
+
+    // This should work for our default support types of String, Number,
+    // Boolean, Array, and Object. For other types, the type text will just be
+    // the name of the type, which is hopefully good enough for CEM consumers.
+    const typeText = property.typeOption?.toLowerCase() ?? 'string';
+
+    attributes.push({
+      name: attributeName,
+      description: ifNotEmpty(property.description),
+      summary: ifNotEmpty(property.summary),
+      type: {text: typeText},
+      default: ifNotEmpty(property.default),
+      fieldName: propertyName,
+    });
+  }
+
+  return ifNotEmpty(attributes);
+};
+
 const convertLitElementDeclaration = (
   declaration: LitElementDeclaration
 ): cem.CustomElementDeclaration => {
   return {
     ...convertClassDeclaration(declaration),
+    // Override members to add attribute/reflects info to fields
+    members: convertLitElementMembers(declaration),
     tagName: declaration.tagname,
     customElement: true,
-    // attributes: [], // TODO
+    attributes: convertReactivePropertiesToAttributes(declaration),
     events: transformIfNotEmpty(declaration.events, (v) =>
       Array.from(v.values()).map(convertEvent)
     ),
@@ -187,6 +225,44 @@ const convertLitElementDeclaration = (
     ),
     // demos: [], // TODO
   };
+};
+
+/**
+ * Convert members for a LitElementDeclaration, adding `attribute` and
+ * `reflects` properties to fields that are reactive properties.
+ */
+const convertLitElementMembers = (
+  declaration: LitElementDeclaration
+): cem.ClassMember[] | undefined => {
+  const convertField = (field: ClassField): cem.CustomElementField => {
+    const baseField = convertClassField(field);
+    const reactiveProperty = declaration.reactiveProperties.get(field.name);
+
+    if (reactiveProperty === undefined) {
+      return baseField;
+    }
+
+    // Determine attribute name (if any)
+    const attribute =
+      reactiveProperty.attribute === false
+        ? undefined
+        : typeof reactiveProperty.attribute === 'string'
+          ? reactiveProperty.attribute
+          : field.name.toLowerCase();
+
+    return {
+      ...baseField,
+      attribute: ifNotEmpty(attribute),
+      reflects: ifNotEmpty(reactiveProperty.reflect),
+    };
+  };
+
+  return ifNotEmpty([
+    ...Array.from(declaration.fields).map(convertField),
+    ...Array.from(declaration.staticFields).map(convertClassField),
+    ...Array.from(declaration.methods).map(convertClassMethod),
+    ...Array.from(declaration.staticMethods).map(convertClassMethod),
+  ]);
 };
 
 const convertClassDeclaration = (

--- a/packages/labs/test-projects/test-element-a/src/element-props.ts
+++ b/packages/labs/test-projects/test-element-a/src/element-props.ts
@@ -28,7 +28,7 @@ export class ElementProps extends LitElement {
   @property({type: Number})
   aNum = -1;
 
-  @property({type: Boolean})
+  @property({type: Boolean, reflect: true})
   aBool = false;
 
   @property({type: Array})


### PR DESCRIPTION
Addresses part of https://github.com/lit/lit/issues/2993

Adds `attributes` to custom element declarations, and `attribute` and `reflects` to custom element fields.