### PR TITLE
Fix `adoptStyles` crash in SSR when `document` is undefined

### DIFF
--- a/.changeset/fix-adopt-styles-ssr.md
+++ b/.changeset/fix-adopt-styles-ssr.md
@@ -1,0 +1,5 @@
+---
+'@lit/reactive-element': patch
+---
+
+Fix `adoptStyles` to not throw when `document` is undefined in SSR environments

--- a/packages/reactive-element/src/css-tag.ts
+++ b/packages/reactive-element/src/css-tag.ts
@@ -176,6 +176,9 @@ export const adoptStyles = (
       s instanceof CSSStyleSheet ? s : s.styleSheet!
     );
   } else {
+    // When neither adoptedStyleSheets nor document is available (e.g. SSR),
+    // styles are serialized into declarative shadow DOM by the renderer.
+    if (typeof document === 'undefined') return;
     for (const s of styles) {
       const style = document.createElement('style');
       // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/reactive-element/src/test/css-tag_test.ts
+++ b/packages/reactive-element/src/test/css-tag_test.ts
@@ -5,6 +5,7 @@
  */
 
 import {
+  adoptStyles,
   css,
   CSSResult,
   unsafeCSS,
@@ -98,6 +99,51 @@ suite('Styling', () => {
       // document.body level.
       const bodyStyles = `${cssModule}`;
       assert.equal(bodyStyles.replace(/\s/g, ''), '.my-module{color:yellow;}');
+    });
+  });
+
+  suite('adoptStyles', () => {
+    test('does not throw when document is undefined (SSR)', () => {
+      // When supportsAdoptingStyleSheets is true (modern browsers), the
+      // else-branch guard is not reachable. This test only validates the
+      // fallback path that runs in environments without adoptedStyleSheets.
+      if (supportsAdoptingStyleSheets) {
+        // In modern browsers we cannot test the fallback path directly;
+        // assert that adoptStyles works via the adoptedStyleSheets path
+        // instead as a basic sanity check.
+        const container = document.createElement('div');
+        const root = container.attachShadow({mode: 'open'});
+        const styles = [
+          css`
+            div {
+              color: red;
+            }
+          `,
+        ];
+        assert.doesNotThrow(() => adoptStyles(root, styles));
+        assert.equal(root.adoptedStyleSheets.length, 1);
+      } else {
+        // Fallback path: patch `document` to be undefined to simulate SSR.
+        const desc = Object.getOwnPropertyDescriptor(globalThis, 'document')!;
+        Object.defineProperty(globalThis, 'document', {
+          value: undefined,
+          configurable: true,
+        });
+        try {
+          const fakeRoot = {} as unknown as ShadowRoot;
+          const styles = [
+            css`
+              div {
+                color: red;
+              }
+            `,
+          ];
+          // Should silently return without throwing.
+          assert.doesNotThrow(() => adoptStyles(fakeRoot, styles));
+        } finally {
+          Object.defineProperty(globalThis, 'document', desc);
+        }
+      }
     });
   });
 });


### PR DESCRIPTION
### Problem

When `supportsAdoptingStyleSheets` is `false` (e.g., in a Node.js SSR environment without full DOM polyfills), `adoptStyles()` falls through to the `else` branch which unconditionally calls `document.createElement('style')`. In environments where `document` is undefined (such as SSR with `litSsrCallConnectedCallback` enabled), this throws a `ReferenceError`.

This is triggered when:

1. SSR rendering calls `connectedCallback` (via `litSsrCallConnectedCallback`)
2. `ReactiveElement.createRenderRoot()` calls `adoptStyles()`
3. The fallback branch tries to access `document`, which doesn't exist in Node.js

**Stack trace**:

```
10:53:17 AM [gracile] [GET] http://localhost:3032/
Calling AddTodo.connectedCallback() resulted in a thrown error. Consider removing `litSsrCallConnectedCallback` to prevent calling connectedCallback or add isServer checks to your code to prevent calling browser API during SSR.
[SSR Error] There was an error while rendering a template chunk on server-side.
It was omitted from the resulting HTML.
ReferenceError: document is not defined
    at S (file:///___/___/demo/node_modules/.pnpm/@lit+reactive-element@2.1.2/node_modules/@lit/reactive-element/node/css-tag.js:6:1101)
    at AddTodo.createRenderRoot (file:///___/___/demo/node_modules/.pnpm/@lit+reactive-element@2.1.2/node_modules/@lit/reactive-element/node/reactive-element.js:1:3387)
    at AddTodo.createRenderRoot (file:///___/___/demo/node_modules/.pnpm/lit-element@4.2.2/node_modules/lit-element/lit-element.js:6:156)
    at AddTodo.connectedCallback (file:///___/___/demo/node_modules/.pnpm/@lit+reactive-element@2.1.2/node_modules/@lit/reactive-element/node/reactive-element.js:1:3468)
    at AddTodo.connectedCallback (file:///___/___/demo/node_modules/.pnpm/lit-element@4.2.2/node_modules/lit-element/lit-element.js:6:422)
    at LitElementRenderer.connectedCallback (file:///___/___/node_modules/.pnpm/@lit-labs+ssr@4.0.0_@types+node@25.3.3/node_modules/@lit-labs/ssr/lib/lit-element-renderer.js:63:30)
    at file:///___/___/node_modules/.pnpm/@lit-labs+ssr@4.0.0_@types+node@25.3.3/node_modules/@lit-labs/ssr/lib/render-value.js:635:31
    at RenderResultIterator.next (file:///___/___/node_modules/.pnpm/@lit-labs+ssr@4.0.0_@types+node@25.3.3/node_modules/@lit-labs/ssr/lib/render.js:88:25)
    at nextSyncWithSyncValues (node:internal/streams/from:96:42)
    at readable._read (node:internal/streams/from:61:9)
```

For context, this occured within this setup:

- A "standard" Lit SSR pipeline, with the builtins minimal shimming.
- `(globalThis as any).litSsrCallConnectedCallback = true;` eagerly called flag, **before** the template rendering kicks in.
- Lit Context with Lit Elements using it, defined on both server and client.
- Just Lit Elements hydration. No Light-DOM, full `document.body` hydration.

Lit Context is not the root cause, but its usage revealed the aforementionned problem, down to `css-tag`.

### Fix

Add an early return guard in the `else` branch of `adoptStyles()`:

```ts
if (typeof document === 'undefined') return;
```

In SSR, styles are serialized into declarative shadow DOM by the renderer, so imperative DOM-based style adoption is unnecessary and should be skipped.

### Test

Added a test in `css-tag_test.ts` that verifies `adoptStyles` does not throw when `document` is unavailable. In browsers where `supportsAdoptingStyleSheets` is `true`, the test validates the primary path instead (since the fallback branch is unreachable).

### Changeset

`@lit/reactive-element`: patch
