### PR TITLE
prototype template(result) directive

### DIFF
--- a/packages/labs/ssr/src/lib/render-value.ts
+++ b/packages/labs/ssr/src/lib/render-value.ts
@@ -60,8 +60,13 @@ import {
 
 import {isRenderLightDirective} from '@lit-labs/ssr-client/directives/render-light.js';
 import {reflectedAttributeName} from './reflected-attributes.js';
+import {
+  getTemplateValue,
+  isTemplateValue,
+} from 'lit-html/directives/template.js';
 
 import type {ThunkedRenderResult} from './render-result.js';
+import {collectResult, collectResultSync} from './render-result.js';
 import {isHydratable} from './server-template.js';
 import type {Part} from 'lit-html';
 
@@ -726,7 +731,9 @@ declare global {
 export function renderValue(
   value: unknown,
   renderInfo: RenderInfo,
-  hydratable = true
+  hydratable = true,
+  emitMarkers = hydratable,
+  suppressNestedMarkers = false
 ): ThunkedRenderResult {
   if (renderInfo.customElementHostStack.length === 0) {
     // If the SSR root event target is not at the start of the event target
@@ -767,20 +774,51 @@ export function renderValue(
 
   const result: ThunkedRenderResult = [];
 
-  if (value != null && isTemplateResult(value)) {
-    if (hydratable) {
+  if (isTemplateValue(value)) {
+    result.push('<template>');
+    result.push(() => {
+      // template() needs hydratable rendering semantics, but not Lit markers in
+      // the final inert HTMLTemplateElement contents.
+      const innerResult = renderValue(
+        getTemplateValue(value),
+        renderInfo,
+        true,
+        false,
+        true
+      );
+      try {
+        return collectResultSync(innerResult);
+      } catch (error) {
+        if (
+          error instanceof Error &&
+          error.message ===
+            'Promises not supported in collectResultSync. Please use collectResult.'
+        ) {
+          return collectResult(innerResult);
+        }
+        throw error;
+      }
+    });
+    result.push('</template>');
+  } else if (value != null && isTemplateResult(value)) {
+    if (emitMarkers) {
       result.push(
         `<!--lit-part ${digestForTemplateResult(value as TemplateResult)}-->`
       );
     }
     result.push(() =>
-      renderTemplateResult(value as TemplateResult, renderInfo)
+      renderTemplateResult(
+        value as TemplateResult,
+        renderInfo,
+        emitMarkers,
+        suppressNestedMarkers
+      )
     );
-    if (hydratable) {
+    if (emitMarkers) {
       result.push(`<!--/lit-part-->`);
     }
   } else {
-    if (hydratable) {
+    if (emitMarkers) {
       result.push(`<!--lit-part-->`);
     }
     if (
@@ -792,15 +830,23 @@ export function renderValue(
       // add nothing
     } else if (!isPrimitive(value) && isIterable(value)) {
       // Check that value is not a primitive, since strings are iterable
-      for (const item of value) {
-        result.push(() => renderValue(item, renderInfo, hydratable));
+      for (const item of value as Iterable<unknown>) {
+        result.push(() =>
+          renderValue(
+            item,
+            renderInfo,
+            hydratable,
+            emitMarkers,
+            suppressNestedMarkers
+          )
+        );
       }
     } else {
       result.push(
         escapeHtml(typeof value === 'string' ? value : String(value))
       );
     }
-    if (hydratable) {
+    if (emitMarkers) {
       result.push(`<!--/lit-part-->`);
     }
   }
@@ -810,7 +856,9 @@ export function renderValue(
 
 function renderTemplateResult(
   result: TemplateResult,
-  renderInfo: RenderInfo
+  renderInfo: RenderInfo,
+  emitMarkers = isHydratable(result),
+  suppressNestedMarkers = false
 ): ThunkedRenderResult {
   // In order to render a TemplateResult we have to handle and stream out
   // different parts of the result separately:
@@ -856,7 +904,16 @@ And the inner template was:
               );
             }
           }
-          return renderValue(value, renderInfo, isValueHydratable);
+          return renderValue(
+            value,
+            renderInfo,
+            isValueHydratable,
+            // Only the template() path suppresses nested markers. Generic SSR
+            // must keep them so server-only templates can still nest hydratable
+            // templates without changing existing output.
+            suppressNestedMarkers ? false : isValueHydratable,
+            suppressNestedMarkers
+          );
         });
         break;
       }
@@ -1004,7 +1061,7 @@ And the inner template was:
           if (
             (op.boundAttributesCount > 0 ||
               renderInfo.customElementHostStack.length > 0) &&
-            hydratable
+            emitMarkers
           ) {
             return `<!--lit-node ${op.nodeIndex}-->`;
           }

--- a/packages/labs/ssr/src/test/lib/render-lit_test.ts
+++ b/packages/labs/ssr/src/test/lib/render-lit_test.ts
@@ -111,6 +111,53 @@ for (const global of [emptyVmGlobal, shimmedVmGlobal]) {
     );
   });
 
+  test('template() directive renders inert template contents', async () => {
+    const {render, templateDirectiveWithText} = await setup();
+    const result = await render(templateDirectiveWithText('foo'));
+    assert.is(
+      result,
+      `<!--lit-part AEmR7W+R0Ak=--><div><template><p>foo</p></template></div><!--/lit-part-->`
+    );
+  });
+
+  test('template() directive preserves reflected property and boolean attr semantics', async () => {
+    const {render, templateDirectiveWithReflectedPropertyAndBoolean} =
+      await setup();
+    const result = await render(
+      templateDirectiveWithReflectedPropertyAndBoolean('x')
+    );
+    assert.is(
+      result,
+      `<!--lit-part AEmR7W+R0Ak=--><div><template><input disabled><span class="x"></span></template></div><!--/lit-part-->`
+    );
+  });
+
+  test('template() directive preserves authored marker-like comments', async () => {
+    const {render, templateDirectiveWithMarkerLikeComments} = await setup();
+    const result = await render(templateDirectiveWithMarkerLikeComments('foo'));
+    assert.is(
+      result,
+      `<!--lit-part AEmR7W+R0Ak=--><div><template><!--lit-part--><p>foo</p><!--lit-node 3--></template></div><!--/lit-part-->`
+    );
+  });
+
+  test('template() directive does not serialize event listeners', async () => {
+    const {render, templateDirectiveWithEventListener} = await setup();
+    const result = await render(templateDirectiveWithEventListener());
+    assert.is(
+      result,
+      `<!--lit-part AEmR7W+R0Ak=--><div><template><button >ok</button></template></div><!--/lit-part-->`
+    );
+  });
+
+  test('template() directive rejects non-template values', async () => {
+    const {render, templateDirectiveWithInvalidValue} = await setup();
+    assert.throws(
+      () => render(templateDirectiveWithInvalidValue()),
+      /template\(\) called with a non-TemplateResult value/
+    );
+  });
+
   /* Iterable Expression */
   test('iterable expression with array value', async () => {
     const {render, templateWithIterableExpression} = await setup();

--- a/packages/labs/ssr/src/test/test-files/render-test-module.ts
+++ b/packages/labs/ssr/src/test/test-files/render-test-module.ts
@@ -8,6 +8,7 @@ import {html, mathml, svg, nothing} from 'lit';
 import {repeat} from 'lit/directives/repeat.js';
 import {classMap} from 'lit/directives/class-map.js';
 import {ref, createRef} from 'lit/directives/ref.js';
+import {template} from 'lit/directives/template.js';
 import {LitElement, css, PropertyValues} from 'lit';
 import {property, customElement} from 'lit/decorators.js';
 import type {HTMLElementWithEventMeta} from '@lit-labs/ssr-dom-shim';
@@ -82,6 +83,23 @@ export const elementTemplateWithIDProperty = (x: string) =>
 /* Nested Templates */
 // prettier-ignore
 export const nestedTemplate = html`<div>${html`<p>Hi</p>`}</div>`;
+
+/* Template Directive */
+// prettier-ignore
+export const templateDirectiveWithText = (x: string) =>
+  html`<div>${template(html`<p>${x}</p>`)}</div>`;
+// prettier-ignore
+export const templateDirectiveWithReflectedPropertyAndBoolean = (x: string) =>
+  html`<div>${template(html`<input ?disabled=${true}><span .className=${x}></span>`)}</div>`;
+// prettier-ignore
+export const templateDirectiveWithMarkerLikeComments = (x: string) =>
+  html`<div>${template(html`<!--lit-part--><p>${x}</p><!--lit-node 3-->`)}</div>`;
+// prettier-ignore
+export const templateDirectiveWithEventListener = () =>
+  html`<div>${template(html`<button @click=${() => {}}>ok</button>`)}</div>`;
+// prettier-ignore
+export const templateDirectiveWithInvalidValue = () =>
+  html`<div>${template('not-a-template' as unknown as never)}</div>`;
 
 /* Custom Elements */
 

--- a/packages/lit-html/package.json
+++ b/packages/lit-html/package.json
@@ -260,6 +260,19 @@
       "development": "./development/directives/style-map.js",
       "default": "./directives/style-map.js"
     },
+    "./directives/template.js": {
+      "types": "./development/directives/template.d.ts",
+      "browser": {
+        "development": "./development/directives/template.js",
+        "default": "./directives/template.js"
+      },
+      "node": {
+        "development": "./node/development/directives/template.js",
+        "default": "./node/directives/template.js"
+      },
+      "development": "./development/directives/template.js",
+      "default": "./directives/template.js"
+    },
     "./directives/template-content.js": {
       "types": "./development/directives/template-content.d.ts",
       "browser": {

--- a/packages/lit-html/rollup.config.js
+++ b/packages/lit-html/rollup.config.js
@@ -26,6 +26,7 @@ export const defaultConfig = (options = {}) =>
       'directives/ref',
       'directives/repeat',
       'directives/style-map',
+      'directives/template',
       'directives/template-content',
       'directives/unsafe-html',
       'directives/unsafe-mathml',

--- a/packages/lit-html/src/directives/template.ts
+++ b/packages/lit-html/src/directives/template.ts
@@ -1,0 +1,322 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import {
+  type CompiledTemplateResult,
+  type ChildPart,
+  noChange,
+  nothing,
+  render,
+  type MaybeCompiledTemplateResult,
+  type UncompiledTemplateResult,
+} from '../lit-html.js';
+import {directive, Directive, PartInfo, PartType} from '../directive.js';
+import {isServer} from '../is-server.js';
+import {_$LH} from '../private-ssr-support.js';
+
+const {EventPart, PropertyPart, marker, markerMatch} = _$LH;
+
+const brand = Symbol.for('lit-template-value');
+
+export type TemplateValue = {
+  ['_$litTemplateValue$']: MaybeCompiledTemplateResult;
+  r: typeof brand;
+};
+
+export const isTemplateValue = (value: unknown): value is TemplateValue =>
+  (value as Partial<TemplateValue>)?.r === brand;
+
+export const getTemplateValue = (value: TemplateValue) =>
+  value['_$litTemplateValue$'];
+
+const isUncompiledTemplateResult = (
+  value: unknown
+): value is MaybeCompiledTemplateResult =>
+  typeof (value as {['_$litType$']?: unknown})?.['_$litType$'] === 'number' &&
+  Array.isArray((value as {strings?: unknown}).strings) &&
+  Array.isArray((value as {values?: unknown}).values);
+
+const isCompiledTemplateResult = (
+  value: unknown
+): value is MaybeCompiledTemplateResult =>
+  (value as {['_$litType$']?: {h?: unknown}})?.['_$litType$']?.h !==
+    undefined && Array.isArray((value as {values?: unknown}).values);
+
+const isMaybeCompiledTemplateResult = (
+  value: unknown
+): value is MaybeCompiledTemplateResult =>
+  isUncompiledTemplateResult(value) || isCompiledTemplateResult(value);
+
+const ensureTemplateResult = (value: unknown): MaybeCompiledTemplateResult => {
+  if (!isMaybeCompiledTemplateResult(value)) {
+    throw new Error('template() called with a non-TemplateResult value');
+  }
+  return value;
+};
+
+type TemplatePartRecord =
+  | {
+      type: number;
+      index: number;
+    }
+  | {
+      type: number;
+      index: number;
+      name: string;
+      strings: ReadonlyArray<string>;
+      ctor: typeof EventPart | typeof PropertyPart | Function;
+    };
+
+type TemplateShape = {
+  el: HTMLTemplateElement;
+  parts: ReadonlyArray<TemplatePartRecord>;
+};
+
+const CHILD_TEMPLATE_PART = 2;
+const COMMENT_TEMPLATE_PART = 7;
+
+const getCompiledTemplate = (result: CompiledTemplateResult): TemplateShape => {
+  const template = result['_$litType$'];
+  if (template.el === undefined) {
+    const el = document.createElement('template');
+    el.innerHTML = template.h[0] as unknown as string;
+    template.el = el;
+  }
+  return template as unknown as TemplateShape;
+};
+
+const getTemplateShape = (
+  result: MaybeCompiledTemplateResult,
+  part: ChildPart
+): TemplateShape =>
+  isCompiledTemplateResult(result)
+    ? getCompiledTemplate(result as CompiledTemplateResult)
+    : (
+        part as ChildPart & {
+          _$getTemplate(result: UncompiledTemplateResult): TemplateShape;
+        }
+      )._$getTemplate(result as UncompiledTemplateResult);
+
+const getNodeByIndex = (fragment: DocumentFragment) => {
+  const nodes = new Map<number, Node>();
+  const walker = document.createTreeWalker(
+    fragment,
+    NodeFilter.SHOW_ELEMENT | NodeFilter.SHOW_COMMENT
+  );
+  let nodeIndex = 0;
+  let node: Node | null;
+  while ((node = walker.nextNode()) !== null) {
+    nodes.set(nodeIndex, node);
+    nodeIndex++;
+  }
+  return nodes;
+};
+
+const hasSingleExpression = (strings: ReadonlyArray<string>) =>
+  strings.length === 2 && strings[0] === '' && strings[1] === '';
+
+const supportsClonablePropertyBinding = (
+  sourceElement: Element,
+  name: string,
+  value: unknown
+) => {
+  if (sourceElement.localName.includes('-')) {
+    return false;
+  }
+  if (
+    typeof value === 'function' ||
+    typeof value === 'symbol' ||
+    typeof value === 'bigint' ||
+    (typeof value === 'object' && value !== null)
+  ) {
+    return false;
+  }
+  const probe = sourceElement.cloneNode(false) as Element;
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (probe as any)[name] = value === nothing ? undefined : value;
+    const clone = probe.cloneNode(true) as Element;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return Object.is((clone as any)[name], (probe as any)[name]);
+  } catch {
+    return false;
+  }
+};
+
+const prepareClientTemplateResult = (
+  result: MaybeCompiledTemplateResult,
+  part: ChildPart
+): MaybeCompiledTemplateResult => {
+  const template = getTemplateShape(result, part);
+  const nodes = getNodeByIndex(template.el.content);
+  const values = [...result.values];
+  let valueIndex = 0;
+  let hasRewrites = false;
+
+  for (const templatePart of template.parts) {
+    if ('strings' in templatePart) {
+      const consumed = templatePart.strings.length - 1;
+      if (templatePart.ctor === EventPart) {
+        for (let i = 0; i < consumed; i++) {
+          values[valueIndex + i] = nothing;
+        }
+        hasRewrites = true;
+      } else if (templatePart.ctor === PropertyPart) {
+        const element = nodes.get(templatePart.index);
+        if (
+          !(element instanceof Element) ||
+          !hasSingleExpression(templatePart.strings) ||
+          !supportsClonablePropertyBinding(
+            element,
+            templatePart.name,
+            values[valueIndex]
+          )
+        ) {
+          // Only keep property bindings whose state survives cloneNode(true).
+          throw new Error(
+            `template() only supports clone-stable property bindings on native elements. Unsupported binding: .${templatePart.name} on <${
+              element instanceof Element ? element.localName : 'unknown'
+            }>`
+          );
+        }
+      }
+      valueIndex += consumed;
+    } else {
+      if (templatePart.type === PartType.ELEMENT) {
+        values[valueIndex] = nothing;
+        hasRewrites = true;
+      }
+      valueIndex++;
+    }
+  }
+
+  return hasRewrites ? {...result, values} : result;
+};
+
+const stripRootRenderMarker = (
+  fragment: DocumentFragment,
+  rootPart: ChildPart
+) => {
+  const markerNode = rootPart.startNode;
+  if (markerNode instanceof Comment && markerNode.parentNode === fragment) {
+    markerNode.remove();
+  }
+};
+
+const sanitizeMarkerComments = (
+  fragment: DocumentFragment,
+  template: TemplateShape,
+  rootPart: ChildPart
+) => {
+  // render() always inserts a root marker into the fragment before any content.
+  stripRootRenderMarker(fragment, rootPart);
+  const nodes = getNodeByIndex(fragment);
+  const commentsToRemove: Comment[] = [];
+  for (const templatePart of template.parts) {
+    const node = nodes.get(templatePart.index);
+    if (!(node instanceof Comment) || 'strings' in templatePart) {
+      continue;
+    }
+    if (
+      templatePart.type === CHILD_TEMPLATE_PART &&
+      (node.data === '' || node.data === '?' || node.data === markerMatch)
+    ) {
+      commentsToRemove.push(node);
+    } else if (templatePart.type === COMMENT_TEMPLATE_PART) {
+      // Scrub marker text only on known comment parts, not authored comments.
+      node.data = node.data.split(marker).join('');
+    }
+  }
+  for (const comment of commentsToRemove) {
+    comment.remove();
+  }
+};
+
+class TemplateDirective extends Directive {
+  static directiveName = 'template';
+  private _template?: HTMLTemplateElement;
+
+  constructor(partInfo: PartInfo) {
+    super(partInfo);
+    if (partInfo.type !== PartType.CHILD) {
+      throw new Error('template() can only be used in child bindings');
+    }
+  }
+
+  render(
+    result:
+      | MaybeCompiledTemplateResult
+      | typeof nothing
+      | typeof noChange
+      | undefined
+      | null
+  ) {
+    if (result === nothing || result == null || result === noChange) {
+      return result;
+    }
+    result = ensureTemplateResult(result);
+    if (isServer) {
+      return {
+        ['_$litTemplateValue$']: result,
+        r: brand,
+      } satisfies TemplateValue;
+    }
+    return noChange;
+  }
+
+  override update(
+    part: ChildPart,
+    [result]: [
+      | MaybeCompiledTemplateResult
+      | typeof nothing
+      | typeof noChange
+      | undefined
+      | null,
+    ]
+  ) {
+    if (result === nothing || result == null || result === noChange) {
+      this._template = undefined;
+      return result;
+    }
+    result = ensureTemplateResult(result);
+    result = prepareClientTemplateResult(result, part);
+    if (this._template !== undefined) {
+      return this._template;
+    }
+    const template = document.createElement('template');
+    const rootPart = render(result, template.content, {
+      ...part.options,
+      isConnected: false,
+    }) as ChildPart;
+    sanitizeMarkerComments(
+      template.content,
+      getTemplateShape(result, part),
+      rootPart
+    );
+    this._template = template;
+    return template;
+  }
+}
+
+/**
+ * Renders a `TemplateResult` into an inert `<template>` element.
+ *
+ * The contents are rendered once and then treated as static. Subsequent
+ * updates return the same `<template>` element.
+ *
+ * This directive only creates an inert `HTMLTemplateElement`. Outer template
+ * attributes are intentionally out of scope for this prototype.
+ *
+ * In particular, this directive does not activate declarative shadow DOM,
+ * whose `shadowrootmode` attribute only takes effect when parsed from HTML.
+ */
+export const template = directive(TemplateDirective);
+
+/**
+ * The type of the class that powers this directive. Necessary for naming the
+ * directive's return type.
+ */
+export type {TemplateDirective};

--- a/packages/lit-html/src/test/directives/template_test.ts
+++ b/packages/lit-html/src/test/directives/template_test.ts
@@ -1,0 +1,172 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import {template} from 'lit-html/directives/template.js';
+import {html, noChange, nothing, render} from 'lit-html';
+import {createRef, ref} from 'lit-html/directives/ref.js';
+import {stripExpressionMarkers} from '@lit-labs/testing';
+import {assert} from 'chai';
+
+suite('template', () => {
+  let container: HTMLElement;
+
+  setup(() => {
+    container = document.createElement('div');
+  });
+
+  test('renders a template element', () => {
+    render(html`<div>${template(html`<p>${'aaa'}</p>`)}</div>`, container);
+    assert.equal(
+      stripExpressionMarkers(container.innerHTML),
+      '<div><template><p>aaa</p></template></div>'
+    );
+  });
+
+  test('renders boolean attributes and reflected properties', () => {
+    render(
+      html`<div>${template(html`<input ?disabled=${true}><div .className=${'x'}></div>`)}</div>`,
+      container
+    );
+    assert.equal(
+      stripExpressionMarkers(container.innerHTML),
+      '<div><template><input disabled=""><div class="x"></div></template></div>'
+    );
+  });
+
+  test('preserves authored empty comments', () => {
+    render(
+      html`<div>${template(html`<!----><p>${'aaa'}</p>`)}</div>`,
+      container
+    );
+    const templateEl = container.querySelector('template');
+    assert.instanceOf(templateEl, HTMLTemplateElement);
+    assert.equal(templateEl!.innerHTML, '<!----><p>aaa</p>');
+  });
+
+  test('strips marker text from authored comments', () => {
+    render(html`<div>${template(html`<!-- a=${'A'}-->`)}</div>`, container);
+    const templateEl = container.querySelector('template');
+    assert.instanceOf(templateEl, HTMLTemplateElement);
+    assert.equal(templateEl!.innerHTML, '<!-- a=-->');
+  });
+
+  test('preserves authored marker-like comments', () => {
+    render(
+      html`<div>${template(
+        html`<!--lit-part--><p>${'aaa'}</p><!--lit-node 3-->`
+      )}</div>`,
+      container
+    );
+    const templateEl = container.querySelector('template');
+    assert.instanceOf(templateEl, HTMLTemplateElement);
+    assert.equal(
+      templateEl!.innerHTML,
+      '<!--lit-part--><p>aaa</p><!--lit-node 3-->'
+    );
+  });
+
+  test('does not attach event listeners inside template content', () => {
+    let clicks = 0;
+    render(
+      html`<div>${template(
+        html`<button @click=${() => clicks++}>ok</button>`
+      )}</div>`,
+      container
+    );
+    const templateEl = container.querySelector('template');
+    assert.instanceOf(templateEl, HTMLTemplateElement);
+    const button = templateEl!.content.querySelector('button');
+    assert.instanceOf(button, HTMLButtonElement);
+    button!.click();
+    assert.equal(clicks, 0);
+    assert.equal(templateEl!.innerHTML, '<button>ok</button>');
+  });
+
+  test('renders only once for subsequent updates', () => {
+    const go = (name: string) =>
+      render(html`<div>${template(html`<p>${name}</p>`)}</div>`, container);
+
+    go('first');
+    assert.equal(
+      stripExpressionMarkers(container.innerHTML),
+      '<div><template><p>first</p></template></div>'
+    );
+
+    go('second');
+    assert.equal(
+      stripExpressionMarkers(container.innerHTML),
+      '<div><template><p>first</p></template></div>'
+    );
+  });
+
+  test('re-renders over non-template values', () => {
+    const go = (v: unknown) => render(html`<div>${v}</div>`, container);
+
+    go(template(html`<p>${'aaa'}</p>`));
+    assert.equal(
+      stripExpressionMarkers(container.innerHTML),
+      '<div><template><p>aaa</p></template></div>'
+    );
+
+    go('bbb');
+    assert.equal(stripExpressionMarkers(container.innerHTML), '<div>bbb</div>');
+
+    go(template(html`<p>${'ccc'}</p>`));
+    assert.equal(
+      stripExpressionMarkers(container.innerHTML),
+      '<div><template><p>ccc</p></template></div>'
+    );
+  });
+
+  test('passes through sentinel values', () => {
+    render(html`<div>${template(nothing)}</div>`, container);
+    assert.equal(stripExpressionMarkers(container.innerHTML), '<div></div>');
+
+    render(html`<div>${template(noChange)}</div>`, container);
+    assert.equal(stripExpressionMarkers(container.innerHTML), '<div></div>');
+  });
+
+  test('throws for non-template values', () => {
+    assert.throws(
+      () =>
+        render(
+          html`<div>${template('not-a-template' as unknown as never)}</div>`,
+          container
+        ),
+      'template() called with a non-TemplateResult value'
+    );
+  });
+
+  test('ignores element bindings inside template content', () => {
+    const hits: string[] = [];
+    const spanRef = createRef<HTMLSpanElement>();
+    render(
+      html`<div>${template(
+        html`<button ${ref((el) => hits.push(el?.tagName ?? 'undefined'))}>ok</button><span ${ref(
+          spanRef
+        )}></span>`
+      )}</div>`,
+      container
+    );
+    assert.deepEqual(hits, []);
+    assert.isUndefined(spanRef.value);
+    assert.equal(
+      stripExpressionMarkers(container.innerHTML),
+      '<div><template><button>ok</button><span></span></template></div>'
+    );
+  });
+
+  test('rejects non-clone-stable property bindings', () => {
+    assert.throws(
+      () =>
+        render(
+          html`<div>${template(html`<div .foo=${'bar'}></div>`)}</div>`,
+          container
+        ),
+      'template() only supports clone-stable property bindings on native elements. Unsupported binding: .foo on <div>'
+    );
+  });
+});

--- a/packages/lit-html/src/test/node-imports.ts
+++ b/packages/lit-html/src/test/node-imports.ts
@@ -23,6 +23,7 @@ import 'lit-html/directives/range.js';
 import 'lit-html/directives/ref.js';
 import 'lit-html/directives/repeat.js';
 import 'lit-html/directives/style-map.js';
+import 'lit-html/directives/template.js';
 import 'lit-html/directives/template-content.js';
 import 'lit-html/directives/unsafe-html.js';
 import 'lit-html/directives/unsafe-svg.js';

--- a/packages/lit-html/src/test/polyfill-support/lit-html_html-test.ts
+++ b/packages/lit-html/src/test/polyfill-support/lit-html_html-test.ts
@@ -19,6 +19,7 @@ import '../directives/style-map_test.js';
 import '../directives/live_test.js';
 import '../directives/ref_test.js';
 import '../directives/repeat_test.js';
+import '../directives/template_test.js';
 import '../directives/template-content_test.js';
 import '../directives/unsafe-html_test.js';
 

--- a/packages/lit/package.json
+++ b/packages/lit/package.json
@@ -133,6 +133,10 @@
       "types": "./development/directives/style-map.d.ts",
       "default": "./directives/style-map.js"
     },
+    "./directives/template.js": {
+      "types": "./development/directives/template.d.ts",
+      "default": "./directives/template.js"
+    },
     "./directives/template-content.js": {
       "types": "./development/directives/template-content.d.ts",
       "default": "./directives/template-content.js"

--- a/packages/lit/rollup.config.js
+++ b/packages/lit/rollup.config.js
@@ -60,6 +60,7 @@ export default litProdConfig({
     'directives/ref',
     'directives/repeat',
     'directives/style-map',
+    'directives/template',
     'directives/template-content',
     'directives/unsafe-html',
     'directives/unsafe-mathml',

--- a/packages/lit/src/directives/template.ts
+++ b/packages/lit/src/directives/template.ts
@@ -1,0 +1,7 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+export * from 'lit-html/directives/template.js';

--- a/packages/lit/src/index.all.ts
+++ b/packages/lit/src/index.all.ts
@@ -24,6 +24,7 @@ export * from './directives/range.js';
 export * from './directives/ref.js';
 export * from './directives/repeat.js';
 export * from './directives/style-map.js';
+export * from './directives/template.js';
 export * from './directives/template-content.js';
 export * from './directives/unsafe-html.js';
 export * from './directives/unsafe-svg.js';

--- a/packages/lit/src/test/node-imports.ts
+++ b/packages/lit/src/test/node-imports.ts
@@ -35,6 +35,7 @@ import 'lit/directives/range.js';
 import 'lit/directives/ref.js';
 import 'lit/directives/repeat.js';
 import 'lit/directives/style-map.js';
+import 'lit/directives/template.js';
 import 'lit/directives/template-content.js';
 import 'lit/directives/unsafe-html.js';
 import 'lit/directives/unsafe-svg.js';


### PR DESCRIPTION
https://github.com/lit/lit/issues/5108

what works
- Adds a `template()` directive that renders a `TemplateResult` into an inert `<template>` element
- Covers a narrow supported subset across browser and SSR: child text, boolean attributes, and clone-stable native/reflected property cases

	
out of scope
- Outer <template> attributes, including shadowrootmode, are out of scope. It only creates an inert HTMLTemplateElement and does not attempt to activate Declarative Shadow DOM


unsupported
- this prototype only allows property cases whose meaning survives cloning and/or HTML reflection; expando properties and custom-element own-property state do not