### PR TITLE
[lit-html] Fix removePart() end-marker leak (#5298)

### DIFF
--- a/.changeset/fix-removepart-end-marker-leak.md
+++ b/.changeset/fix-removepart-end-marker-leak.md
@@ -1,0 +1,6 @@
+---
+'lit-html': patch
+'lit': patch
+---
+
+Fix a DOM leak in `removePart()` (from `lit-html/directive-helpers.js`) where the part's end marker comment was left behind. Each call leaked a `<!---->` node; under sustained churn (e.g. `@lit-labs/virtualizer` scrolling, which removes items at one edge and adds at the other) this caused unbounded DOM accumulation and a steady per-operation cost climb. Introduced in #4975 (released in `lit-html@3.3.1`).

--- a/packages/lit-html/src/directive-helpers.ts
+++ b/packages/lit-html/src/directive-helpers.ts
@@ -245,6 +245,11 @@ export const getCommittedValue = (part: ChildPart) => part._$committedValue;
 export const removePart = (part: ChildPart) => {
   part._$clear();
   part._$startNode.remove();
+  // Without this, every removePart call leaves behind a `<!---->` comment
+  // marker (the part's end marker), causing unbounded DOM accumulation
+  // under sustained churn (e.g., virtualizer scrolling that removes items
+  // at one edge and adds at the other).
+  (part._$endNode as (ChildNode & {remove: () => void}) | null)?.remove();
 };
 
 export const clearPart = (part: ChildPart) => {

--- a/packages/lit-html/src/directive-helpers.ts
+++ b/packages/lit-html/src/directive-helpers.ts
@@ -236,9 +236,9 @@ export const getCommittedValue = (part: ChildPart) => part._$committedValue;
  * Removes a ChildPart from the DOM, including any of its content and markers.
  *
  * Note: The only difference between this and clearPart() is that this also
- * removes the part's start node. This means that the ChildPart must own its
- * start node, ie it must be a marker node specifically for this part and not an
- * anchor from surrounding content.
+ * removes the part's start node (and its end marker, if present). This means
+ * that the ChildPart must own its start node, ie it must be a marker node
+ * specifically for this part and not an anchor from surrounding content.
  *
  * @param part The Part to remove
  */
@@ -249,7 +249,7 @@ export const removePart = (part: ChildPart) => {
   // marker (the part's end marker), causing unbounded DOM accumulation
   // under sustained churn (e.g., virtualizer scrolling that removes items
   // at one edge and adds at the other).
-  (part._$endNode as (ChildNode & {remove: () => void}) | null)?.remove();
+  part._$endNode?.remove();
 };
 
 export const clearPart = (part: ChildPart) => {

--- a/packages/lit-html/src/test/directive-helpers_test.ts
+++ b/packages/lit-html/src/test/directive-helpers_test.ts
@@ -267,6 +267,40 @@ suite('directive-helpers', () => {
     assert.strictEqual(container.firstElementChild?.childNodes.length, 0);
   });
 
+  test('removePart removes both the start and end markers of an inserted part', () => {
+    // Regression test: parts created via `insertPart()` own both a start and
+    // an end marker comment. `removePart` must remove both — otherwise every
+    // call leaks a `<!---->` marker, which accumulates under sustained churn
+    // (e.g. virtualizer scrolling that removes items at one edge and adds at
+    // the other).
+    let hostPart: ChildPart | undefined;
+    const captureDirective = directive(
+      class CaptureDirective extends Directive {
+        render() {
+          return undefined;
+        }
+        override update(part: ChildPart) {
+          hostPart = part;
+          return undefined;
+        }
+      }
+    );
+
+    render(html`<div>${captureDirective()}</div>`, container);
+    assert.isDefined(hostPart);
+
+    const div = container.firstElementChild as HTMLDivElement;
+    const childCountBefore = div.childNodes.length;
+
+    // Insert a child part into the host part (this adds two marker comments)
+    // and then immediately remove it. Both markers must be gone.
+    const inserted = insertPart(hostPart!);
+    assert.strictEqual(div.childNodes.length, childCountBefore + 2);
+
+    removePart(inserted);
+    assert.strictEqual(div.childNodes.length, childCountBefore);
+  });
+
   test('insertPart keeps connection state in sync', () => {
     // Directive that tracks/renders connected state
     let connected = false;


### PR DESCRIPTION
## Summary

Fixes #5298.

`removePart()` in `lit-html/directive-helpers.js` only removed the part's start marker, leaving the end marker (`<!---->`) orphaned in the DOM. Parts created via `insertPart()` own two unique marker comments, and both must be removed.

Each call leaked one `<!---->` node. Under sustained churn — notably `@lit-labs/virtualizer` scrolling, which removes items at one edge and adds at the other — the leaked markers accumulated without bound, causing a steady per-operation cost climb (e.g. `node.remove()` grew more expensive as the container filled with orphan comments).

Regression was introduced in #4975 (released in `lit-html@3.3.1`). The pre-regression implementation walked sibling nodes up to (and including) the end marker, correctly removing both.

## Changes

- **`packages/lit-html/src/directive-helpers.ts`** — one-line fix: also call `_$endNode?.remove()` after removing the start marker.
- **`packages/lit-html/src/test/directive-helpers_test.ts`** — regression test (committed separately, before the fix) using `insertPart()` to create a ChildPart with a non-null `_$endNode` and asserting that both markers are removed.
- **`.changeset/fix-removepart-end-marker-leak.md`** — patch changeset for `lit-html` and `lit`.

The existing `'removePart removes the start marker'` test (added alongside #4975) did not catch this because it uses a directive at the end of a `<div>`, where `_$endNode` is `null`. The new test exercises the `_$endNode !== null` path and fails cleanly against the buggy implementation.

## Performance impact

Local tachometer A/B (15 samples, Chromium, local build):

| Benchmark | Before | After | Δ |
|---|---:|---:|---:|
| `lit-html/repeat` update | 595.28 ms | 63.08 ms | −89.4% |
| `lit-html/repeat-full` removeAll | 54.90 ms | 0.23 ms | −99.6% |
| `lit-html/repeat-full` reverse | — | — | −98.8% |
| `lit-html/repeat-full` shuffle | — | — | −98.3% |
| `lit-html/repeat-full` replace | — | — | −97.5% |

All other benchmarks (`lit-html/kitchen-sink`, `lit-html/template-heavy`, `lit-element/list`, `reactive-element/list`) were neutral to slightly faster (−2% to −10%).

## Test plan

- [x] `npm run test --workspace=packages/lit-html` — 7,239 passed, 0 failed (Chromium, Firefox, Webkit)
- [x] Verified the regression test fails against the buggy `removePart()` and passes with the fix
- [x] `npm run test --workspace=packages/lit` — 726 passed, 0 failed
- [x] `npm run test --workspace=packages/labs/virtualizer` — 204 passed, 0 failed
- [x] Full lit-html / lit-element / reactive-element benchmark suite run locally with no regressions